### PR TITLE
Handle cypher directive without any params

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "nodemon ./example/graphql-tools/movies.js --exec babel-node -e js",
     "build": "babel src --presets babel-preset-env --out-dir dist",
     "prepublish": "npm run build",
+    "pretest": "npm run build",
     "test": "ava test/*.js"
   },
   "author": "William Lyon",

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,8 +43,8 @@ export function cypherDirectiveArgs(variable, headSelection, schemaType) {
   const queryArgs = parseArgs(headSelection.arguments);
   console.log(queryArgs);
 
-  let args = JSON.stringify(Object.assign(defaultArgs, queryArgs)).replace(/\"([^(\")"]+)\":/g,"$1:");
+  let args = JSON.stringify(Object.assign(defaultArgs, queryArgs)).replace(/\"([^(\")"]+)\":/g," $1: ");
 
-  return `{this: ${variable},` + args.substring(1);
+  return args === "{}" ? `{this: ${variable}${args.substring(1)}` : `{this: ${variable},${args.substring(1)}`
 
 }

--- a/test/cypherTest.js
+++ b/test/cypherTest.js
@@ -40,7 +40,7 @@ test('Cypher projection skip limit', t=> {
       }
     }
   }`,
-    expectedCypherQuery = 'MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor) | movie_actors { .name }] ,similar: [ x IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie,first:3,offset:0}, true) | x { .title }][..3] } AS movie SKIP 0';
+    expectedCypherQuery = 'MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor) | movie_actors { .name }] ,similar: [ x IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | x { .title }][..3] } AS movie SKIP 0';
   cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
 
 });
@@ -133,7 +133,7 @@ test('Deeply nested object query', t=> {
     }
   }
 }`,
-    expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor) | movie_actors { .name ,movies: [(movie_actors)-[:ACTED_IN]->(movie_actors_movies:Movie) | movie_actors_movies { .title ,actors: [(movie_actors_movies)<-[:ACTED_IN]-(movie_actors_movies_actors:Actor) | movie_actors_movies_actors { .name ,movies: [(movie_actors_movies_actors)-[:ACTED_IN]->(movie_actors_movies_actors_movies:Movie) | movie_actors_movies_actors_movies { .title , .year ,similar: [ x IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie_actors_movies_actors_movies,first:3,offset:0}, true) | x { .title , .year }][..3] }] }] }] }] } AS movie SKIP 0`;
+    expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor) | movie_actors { .name ,movies: [(movie_actors)-[:ACTED_IN]->(movie_actors_movies:Movie) | movie_actors_movies { .title ,actors: [(movie_actors_movies)<-[:ACTED_IN]-(movie_actors_movies_actors:Actor) | movie_actors_movies_actors { .name ,movies: [(movie_actors_movies_actors)-[:ACTED_IN]->(movie_actors_movies_actors_movies:Movie) | movie_actors_movies_actors_movies { .title , .year ,similar: [ x IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie_actors_movies_actors_movies, first: 3, offset: 0}, true) | x { .title , .year }][..3] }] }] }] }] } AS movie SKIP 0`;
   cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
 });
 
@@ -176,6 +176,20 @@ test('Handle meta field in middle of selection set', t=> {
   cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
 });
 
+test('Handle @cypher directive without any params for sub-query', t=> {
+  const graphQLQuery = `{
+    Movie(title: "River Runs Through It, A") {
+      mostSimilar {
+        title
+        year
+      }
+    }
+  
+  }`,
+    expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie {mostSimilar: head([ x IN apoc.cypher.runFirstColumn("WITH {this} AS this RETURN this", {this: movie}, true) | x { .title , .year }]) } AS movie SKIP 0`;
+  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+});
+
 test('Pass @cypher directive default params to sub-query', t=> {
   const graphQLQuery = `{
     Movie(title: "River Runs Through It, A") {
@@ -183,7 +197,7 @@ test('Pass @cypher directive default params to sub-query', t=> {
     }
   
   }`,
-    expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie {scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie,scale:3}, false)} AS movie SKIP 0`;
+    expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie {scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie, scale: 3}, false)} AS movie SKIP 0`;
   cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
 });
 
@@ -194,6 +208,6 @@ test('Pass @cypher directive params to sub-query', t=> {
     }
   
   }`,
-    expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie {scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie,scale:10}, false)} AS movie SKIP 0`;
+    expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie {scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie, scale: 10}, false)} AS movie SKIP 0`;
   cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
 });


### PR DESCRIPTION
1. Before in `utils` the `cypherDirectiveArgs` function's 
```
`return `{this: ${variable},` + args.substring(1);
```
always put a comma even if there were no arguments following. This resulted in a cypher query e.g. like
```
"... apoc.cypher.runFirstColumn("WITH {this} AS this RETURN this", {this: movie**,}**, true) ...
# Neo4jError: Invalid input '}': expected whitespace or ...
```
So changed to:
```
return args === "{}" ? `{this: ${variable}${args.substring(1)}` : `{this: ${variable},${args.substring(1)}`
```

This is also relevant when using a `cypher schema directive` to query for Neo4j's internal node `id`, like e.g. `@cypher(statement: "WITH {this} AS this RETURN ID(this)")`.

2. Improved whitespaces in the generated queries by `" $1: "` in args `replace` statement. This is why I needed to update some of `expectedCypherQuery` in existing test cases as well.

3. Also added a new test case `Handle @cypher directive without any params for sub-query` for cases as described in 1.

4. Finally added `"pretest": "npm run build"` in package scripts to have the latest build for testing.