### PR TITLE
Switched check for scalar types from fieldIsScalar to inner.constructor.name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -107,14 +107,13 @@ function buildCypherSelection(initial, selections, variable, schemaType, resolve
 
   if (fieldHasCypherDirective) {
 
-    let fieldIsScalar = fieldType.constructor.name === "GraphQLScalarType"; // FIXME: DRY
     let statement = schemaType.getFields()[fieldName].astNode.directives.find((e) => {
       return e.name.value === 'cypher'
     }).arguments.find((e) => {
       return e.name.value === 'statement'
     }).value.value;
 
-    if (fieldIsScalar) {
+    if (inner.constructor.name === "GraphQLScalarType") {
 
       return buildCypherSelection(initial + `${fieldName}: apoc.cypher.runFirstColumn("${statement}", ${cypherDirectiveArgs(variable, headSelection, schemaType)}, false)${tailSelections.length > 0 ? ',' : ''}`, tailSelections, variable, schemaType, resolveInfo);
     } else {


### PR DESCRIPTION
As mentioned in this https://github.com/neo4j-graphql/neo4j-graphql-js/issues/16#issuecomment-352628643 the ("direct") check for scalar types

    let fieldIsScalar = fieldType.constructor.name === "GraphQLScalarType";

did not work for mandatory fields ("direct" type then is `GraphQLNonNull` and not `GraphQLScalarType`).

Initially used (https://github.com/neo4j-graphql/neo4j-graphql-js/issues/16#issuecomment-352723555)
	
	let fieldIsScalar = fieldType.ofType ? fieldType.ofType.constructor.name === "GraphQLScalarType" : fieldType.constructor.name === "GraphQLScalarType";

which worked but now "discovered" and already existing helper `function innerType (type)` which recurses through `.oftype` down to eventually `.type` (`GraphQLScalarType` in this case). And it is already used here for `let inner = innerType(fieldType)`.

So now completely removed `fieldIsScalar` and instead used

	if (inner.constructor.name === "GraphQLScalarType") { ... }

I did not write any extra test for that as this `if` is so "central" and already used in the other test cases. All tests passed locally.

Long speech for such a "small" change but it is quite "central" in the code flow. And I am completely open to other suggestions if I got something wrong above and it cannot be used like this.

Anyways ... happy holidays :)

