### PR TITLE
Allow for qerying by Neo4j's internal id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,8 +72,15 @@ export function cypherQuery(params, context, resolveInfo) {
 
   // FIXME: how to handle multiple fieldNode matches
   let selections = filteredFieldNodes[0].selectionSet.selections;
+
+  let wherePredicate = ``;
+  if (_.has(params, '_id')) {
+    wherePredicate = `WHERE ID(${variable})=${params._id} `;
+    delete params._id;
+  }
+
   let argString = JSON.stringify(params).replace(/\"([^(\")"]+)\":/g,"$1:"); // FIXME: support IN for multiple values -> WHERE
-  let query = `MATCH (${variable}:${type} ${argString}) `;
+  let query = `MATCH (${variable}:${type} ${argString}) ${wherePredicate}`;
 
   query = query +  `RETURN ${variable} {` + buildCypherSelection(``, selections, variable, schemaType, resolveInfo);// ${variable} { ${selection} } as ${variable}`;
 

--- a/test/cypherTest.js
+++ b/test/cypherTest.js
@@ -211,3 +211,52 @@ test('Pass @cypher directive params to sub-query', t=> {
     expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie {scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie, scale: 10}, false)} AS movie SKIP 0`;
   cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
 });
+
+test('Query for Neo4js internal _id', t=> {
+  const graphQLQuery = `{
+    Movie(_id: 0) {
+      title
+      year
+    }
+  
+  }`,
+    expectedCypherQuery = `MATCH (movie:Movie {}) WHERE ID(movie)=0 RETURN movie { .title , .year } AS movie SKIP 0`;
+  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+});
+
+test('Query for Neo4js internal _id and another param before _id', t=> {
+  const graphQLQuery = `{
+    Movie(title: "River Runs Through It, A", _id: 0) {
+      title
+      year
+    }
+  
+  }`,
+    expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) WHERE ID(movie)=0 RETURN movie { .title , .year } AS movie SKIP 0`;
+  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+});
+
+test('Query for Neo4js internal _id and another param after _id', t=> {
+  const graphQLQuery = `{
+    Movie(_id: 0, year: 2010) {
+      title
+      year
+    }
+  
+  }`,
+    expectedCypherQuery = `MATCH (movie:Movie {year:2010}) WHERE ID(movie)=0 RETURN movie { .title , .year } AS movie SKIP 0`;
+  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+});
+
+test('Query for Neo4js internal _id by dedicated Query MovieBy_Id(_id: Int!)', t=> {
+  const graphQLQuery = `{
+    MovieBy_Id(_id: 0) {
+      title
+      year
+    }
+  
+  }`,
+    expectedCypherQuery = `MATCH (movie:Movie {}) WHERE ID(movie)=0 RETURN movie { .title , .year } AS movie SKIP 0`;
+  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+});
+

--- a/test/helpers/cypherTestHelpers.js
+++ b/test/helpers/cypherTestHelpers.js
@@ -43,11 +43,11 @@ type User implements Person {
 	name: String
 }
 
-
 type Query {
-  Movie(id: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float, first: Int, offset: Int): [Movie]
+  Movie(_id: Int, id: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float, first: Int, offset: Int): [Movie]
   MoviesByYear(year: Int): [Movie]
   MovieById(movieId: ID!): Movie
+  MovieBy_Id(_id: Int!): Movie
 }
 `;
 
@@ -63,8 +63,12 @@ type Query {
       MoviesByYear(object, params, ctx, resolveInfo){
         let query = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
-    },
+      },
       MovieById(object, params, ctx, resolveInfo) {
+        let query = cypherQuery(params, ctx, resolveInfo);
+        t.is(query, expectedCypherQuery);
+      },
+      MovieBy_Id(object, params, ctx, resolveInfo) {
         let query = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
       }


### PR DESCRIPTION
Up front: This is probably not the most "beautiful" solution, but it (for now) does the trick:

**Allow for querying by Neo4j's `internal id` by calling Cypher's `ID()` function if the `key` `_id` is present in `params`.** 

It does not require a Cypher directive in the `Query` definition as mentioned in #22 , but only listens to `_id` and fixes #23 .

It does not "swallow" other params and thus can be combined with other params which still are translated to a node `properties` based pattern `MATCH` (e.g. in `MATCH (n {name: 'Alice', ...})` ). It just adds/appends a `WHERE` predicate after it in the generated Cypher query if `_id` is present in `params`. Otherwise it is an empty string.

Also added test cases which required to change the `testMovieSchema` to accommodate for these. All tests passed locally.

If there are other ways (e.g. being able to call `ID()` in the "shorthand" `WHERE` notation as e.g. in `MATCH (n {name: 'Alice'})`) I am grateful for other suggestions.
