### PR TITLE
prevent queries being cut short

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,7 @@ function buildCypherSelection(initial, selections, variable, schemaType, resolve
   const fieldName = headSelection.name.value;
   if (!schemaType.getFields()[fieldName]){
     // meta field type
-    return buildCypherSelection(tailSelections.length === 0 ? initial.substring(initial.lastIndexOf(','), 1) : initial, tailSelections, variable, schemaType, resolveInfo);
+    return buildCypherSelection(tailSelections.length === 0 ? initial.substring(initial.lastIndexOf(','), 0) : initial, tailSelections, variable, schemaType, resolveInfo);
   }
   const fieldType = schemaType.getFields()[fieldName].type;
 


### PR DESCRIPTION
Was finding my queries to id were getting cut short:
`MATCH (group:Group {}) RETURN group {d: apoc.cypher.runFirstColumn("WITH {this} AS this RETURN ID(this)", {this: group}, false), .name , .description } AS group SKIP 0`

...only when called with `apollo-client` and not with graphiql. This change seems to fix the problem...