### PR TITLE
Fix node 8 install issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "ava test/cypherTest.js test/augmentSchemaTest.js --verbose"
   },
   "engines": {
-    "node": "> 8"
+    "node": ">=8"
   },
   "author": "William Lyon",
   "license": "Apache-2.0",


### PR DESCRIPTION
After release of version 1.22.0 this package cant be installed in node 8 LTS due to the engines property set in package.json. This PR reverts it back and enables node 8 installs. please merge and release this ASAP. 