### PR TITLE
Parameterise queries

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ src
 test
 .DS_Store
 .idea
+scripts

--- a/package-lock.json
+++ b/package-lock.json
@@ -360,7 +360,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
       "dev": true
     },
     "accepts": {
@@ -1544,7 +1544,7 @@
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "resolved": "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
@@ -1553,7 +1553,7 @@
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "resolved": "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
@@ -1621,7 +1621,7 @@
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "resolved": "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
@@ -1641,7 +1641,7 @@
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "resolved": "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
@@ -1749,7 +1749,7 @@
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "resolved": "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
@@ -1758,7 +1758,7 @@
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "resolved": "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
@@ -3015,7 +3015,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {
@@ -4560,7 +4560,7 @@
     },
     "is-number": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "resolved": "https://neo.jfrog.io/neo/api/npm/npm/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
@@ -4720,7 +4720,7 @@
     },
     "isobject": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "resolved": "https://neo.jfrog.io/neo/api/npm/npm/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
       "requires": {
@@ -7924,7 +7924,7 @@
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.18.0",
@@ -8755,7 +8755,7 @@
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "integrity": "sha1-/jZfX3XsntTlaCXgu3bSSrdK+Ds=",
       "dev": true,
       "requires": {
         "nopt": "~1.0.10"

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,31 @@
 import filter from 'lodash/filter';
 import {
-  isMutation,
-  isAddRelationshipMutation,
-  typeIdentifiers,
-  lowFirstLetter,
-  getFilterParams,
-  innerFilterParams,
+  computeOrderBy,
   extractQueryResult,
   extractSelections,
-  computeOrderBy
+  getFilterParams,
+  innerFilterParams,
+  isAddMutation,
+  isCreateMutation,
+  isMutation,
+  lowFirstLetter,
+  typeIdentifiers
 } from './utils';
 import { buildCypherSelection } from './selections';
-import { addIdFieldToSchema, addOrderByToSchema, addMutationsToSchema } from './augmentSchema';
+import {
+  addIdFieldToSchema,
+  addOrderByToSchema,
+  addMutationsToSchema
+} from './augmentSchema';
 import { checkRequestError } from './auth';
 
-export async function neo4jgraphql(object, params, context, resolveInfo, debug = true) {
+export async function neo4jgraphql(
+  object,
+  params,
+  context,
+  resolveInfo,
+  debug = true
+) {
   // throw error if context.req.error exists
   if (checkRequestError(context)) {
     throw new Error(checkRequestError(context));
@@ -23,16 +34,8 @@ export async function neo4jgraphql(object, params, context, resolveInfo, debug =
   let query;
   let cypherParams;
 
-  if (isMutation(resolveInfo)) {
-    query = cypherMutation(params, context, resolveInfo);
-    if (isAddRelationshipMutation(resolveInfo)) {
-      //params = fixParamsForAddRelationshipMutation(params, resolveInfo);
-    } else {
-      cypherParams = { params };
-    }
-  } else {
-    [query, cypherParams] = cypherQuery(params, context, resolveInfo);
-  }
+  const cypherFunction = isMutation(resolveInfo) ? cypherMutation : cypherQuery;
+  [query, cypherParams] = cypherFunction(params, context, resolveInfo);
 
   if (debug) {
     console.log(query);
@@ -44,14 +47,27 @@ export async function neo4jgraphql(object, params, context, resolveInfo, debug =
   return extractQueryResult(result, resolveInfo.returnType);
 }
 
-export function cypherQuery({ first = -1, offset = 0, _id, orderBy, ...otherParams }, context, resolveInfo) {
+const getOuterSkipLimit = first =>
+  `SKIP $offset${first > -1 ? ' LIMIT $first' : ''}`;
+
+export function cypherQuery(
+  { first = -1, offset = 0, _id, orderBy, ...otherParams },
+  context,
+  resolveInfo
+) {
   const { typeName, variableName } = typeIdentifiers(resolveInfo.returnType);
   const schemaType = resolveInfo.schema.getType(typeName);
 
-  const filteredFieldNodes = filter(resolveInfo.fieldNodes, n => n.name.value === resolveInfo.fieldName);
+  const filteredFieldNodes = filter(
+    resolveInfo.fieldNodes,
+    n => n.name.value === resolveInfo.fieldName
+  );
 
   // FIXME: how to handle multiple fieldNode matches
-  const selections = extractSelections(filteredFieldNodes[0].selectionSet.selections, resolveInfo.fragments);
+  const selections = extractSelections(
+    filteredFieldNodes[0].selectionSet.selections,
+    resolveInfo.fragments
+  );
 
   const [nullParams, nonNullParams] = Object.entries({
     ...{ offset, first },
@@ -69,7 +85,7 @@ export function cypherQuery({ first = -1, offset = 0, _id, orderBy, ...otherPara
   );
   const argString = innerFilterParams(getFilterParams(nonNullParams));
 
-  const outerSkipLimit = `SKIP $offset${first > -1 ? ' LIMIT $first' : ''}`;
+  const outerSkipLimit = getOuterSkipLimit(first);
   const orderByValue = computeOrderBy(resolveInfo, selections);
 
   let query;
@@ -78,9 +94,9 @@ export function cypherQuery({ first = -1, offset = 0, _id, orderBy, ...otherPara
   const queryTypeCypherDirective = resolveInfo.schema
     .getQueryType()
     .getFields()
-    [resolveInfo.fieldName].astNode.directives.filter(x => {
+    [resolveInfo.fieldName].astNode.directives.find(x => {
       return x.name.value === 'cypher';
-    })[0];
+    });
 
   const [subQuery, subParams] = buildCypherSelection({
     initial: '',
@@ -93,9 +109,9 @@ export function cypherQuery({ first = -1, offset = 0, _id, orderBy, ...otherPara
 
   if (queryTypeCypherDirective) {
     // QueryType with a @cypher directive
-    const cypherQueryArg = queryTypeCypherDirective.arguments.filter(x => {
+    const cypherQueryArg = queryTypeCypherDirective.arguments.find(x => {
       return x.name.value === 'statement';
-    })[0];
+    });
 
     query = `WITH apoc.cypher.runFirstColumn("${
       cypherQueryArg.value.value
@@ -105,8 +121,11 @@ export function cypherQuery({ first = -1, offset = 0, _id, orderBy, ...otherPara
     // No @cypher directive on QueryType
 
     // FIXME: support IN for multiple values -> WHERE
-    const idWherePredicate = typeof _id !== 'undefined' ? `ID(${variableName})=${_id}` : '';
-    const nullFieldPredicates = Object.keys(nullParams).map(key => `${variableName}.${key} IS NULL`);
+    const idWherePredicate =
+      typeof _id !== 'undefined' ? `ID(${variableName})=${_id}` : '';
+    const nullFieldPredicates = Object.keys(nullParams).map(
+      key => `${variableName}.${key} IS NULL`
+    );
     const predicateClauses = [idWherePredicate, ...nullFieldPredicates]
       .filter(predicate => !!predicate)
       .join(' AND ');
@@ -131,46 +150,67 @@ export function cypherMutation(
   const { typeName, variableName } = typeIdentifiers(resolveInfo.returnType);
   const schemaType = resolveInfo.schema.getType(typeName);
 
-  const filteredFieldNodes = filter(resolveInfo.fieldNodes, n => n.name.value === resolveInfo.fieldName);
+  const filteredFieldNodes = filter(
+    resolveInfo.fieldNodes,
+    n => n.name.value === resolveInfo.fieldName
+  );
 
   // FIXME: how to handle multiple fieldNode matches
-  let selections = extractSelections(filteredFieldNodes[0].selectionSet.selections, resolveInfo.fragments);
+  let selections = extractSelections(
+    filteredFieldNodes[0].selectionSet.selections,
+    resolveInfo.fragments
+  );
 
   if (selections.length === 0) {
     // FIXME: why aren't the selections found in the filteredFieldNode?
-    selections = extractSelections(resolveInfo.operation.selectionSet.selections, resolveInfo.fragments);
+    selections = extractSelections(
+      resolveInfo.operation.selectionSet.selections,
+      resolveInfo.fragments
+    );
   }
 
-  // FIXME: support IN for multiple values -> WHERE
-  const argString = innerFilterParams(getFilterParams(otherParams));
-
-  const idWherePredicate = typeof _id !== 'undefined' ? `WHERE ID(${variableName})=${_id} ` : '';
-  const outerSkipLimit = `SKIP ${offset}${first > -1 ? ' LIMIT ' + first : ''}`;
+  const outerSkipLimit = getOuterSkipLimit(first);
   const orderByValue = computeOrderBy(resolveInfo, selections);
 
   let query;
   const mutationTypeCypherDirective = resolveInfo.schema
     .getMutationType()
     .getFields()
-    [resolveInfo.fieldName].astNode.directives.filter(x => {
+    [resolveInfo.fieldName].astNode.directives.find(x => {
       return x.name.value === 'cypher';
-    })[0];
+    });
+
+  let params =
+    isCreateMutation(resolveInfo) && !mutationTypeCypherDirective
+      ? { params: otherParams, ...{ first, offset } }
+      : { ...otherParams, ...{ first, offset } };
 
   if (mutationTypeCypherDirective) {
-    const cypherQueryArg = mutationTypeCypherDirective.arguments.filter(x => {
-      return x.name.value === 'statement';
-    })[0];
+    // FIXME: support IN for multiple values -> WHERE
+    const argString = innerFilterParams(
+      getFilterParams(params.params || params)
+    );
 
-    query = `CALL apoc.cypher.doIt("${cypherQueryArg.value.value}", ${argString}) YIELD value
-    WITH apoc.map.values(value, [keys(value)[0]])[0] AS ${variableName}
-    RETURN ${variableName} {${buildCypherSelection({
+    const cypherQueryArg = mutationTypeCypherDirective.arguments.find(x => {
+      return x.name.value === 'statement';
+    });
+
+    const [subQuery, subParams] = buildCypherSelection({
       initial: '',
       selections,
       variableName,
       schemaType,
-      resolveInfo
-    })}} AS ${variableName}${orderByValue} ${outerSkipLimit}`;
-  } else if (resolveInfo.fieldName.startsWith('Create') || resolveInfo.fieldName.startsWith('create')) {
+      resolveInfo,
+      paramIndex: 1
+    });
+    params = { ...params, ...subParams };
+
+    query = `CALL apoc.cypher.doIt("${
+      cypherQueryArg.value.value
+    }", ${argString}) YIELD value
+    WITH apoc.map.values(value, [keys(value)[0]])[0] AS ${variableName}
+    RETURN ${variableName} {${subQuery}} AS ${variableName}${orderByValue} ${outerSkipLimit}`;
+  } else if (isCreateMutation(resolveInfo)) {
     // CREATE node
     // TODO: handle for create relationship
     // TODO: update / delete
@@ -178,44 +218,50 @@ export function cypherMutation(
     query = `CREATE (${variableName}:${typeName}) `;
     query += `SET ${variableName} = $params `;
     //query += `RETURN ${variable}`;
-    query +=
-      `RETURN ${variableName} {` +
-      buildCypherSelection({
-        initial: ``,
-        selections,
-        variableName,
-        schemaType,
-        resolveInfo
-      });
-    query += `} AS ${variableName}`;
-  } else if (resolveInfo.fieldName.startsWith('Add') || resolveInfo.fieldName.startsWith('add')) {
+
+    const [subQuery, subParams] = buildCypherSelection({
+      initial: ``,
+      selections,
+      variableName,
+      schemaType,
+      resolveInfo,
+      paramIndex: 1
+    });
+    params = { ...params, ...subParams };
+
+    query += `RETURN ${variableName} {${subQuery}} AS ${variableName}`;
+  } else if (isAddMutation(resolveInfo)) {
     let mutationMeta, relationshipNameArg, fromTypeArg, toTypeArg;
 
     try {
       mutationMeta = resolveInfo.schema
         .getMutationType()
         .getFields()
-        [resolveInfo.fieldName].astNode.directives.filter(x => {
+        [resolveInfo.fieldName].astNode.directives.find(x => {
           return x.name.value === 'MutationMeta';
-        })[0];
+        });
     } catch (e) {
-      throw new Error('Missing required MutationMeta directive on add relationship directive');
+      throw new Error(
+        'Missing required MutationMeta directive on add relationship directive'
+      );
     }
 
     try {
-      relationshipNameArg = mutationMeta.arguments.filter(x => {
+      relationshipNameArg = mutationMeta.arguments.find(x => {
         return x.name.value === 'relationship';
-      })[0];
+      });
 
-      fromTypeArg = mutationMeta.arguments.filter(x => {
+      fromTypeArg = mutationMeta.arguments.find(x => {
         return x.name.value === 'from';
-      })[0];
+      });
 
-      toTypeArg = mutationMeta.arguments.filter(x => {
+      toTypeArg = mutationMeta.arguments.find(x => {
         return x.name.value === 'to';
-      })[0];
+      });
     } catch (e) {
-      throw new Error('Missing required argument in MutationMeta directive (relationship, from, or to)');
+      throw new Error(
+        'Missing required argument in MutationMeta directive (relationship, from, or to)'
+      );
     }
     //TODO: need to handle one-to-one and one-to-many
 
@@ -227,33 +273,41 @@ export function cypherMutation(
       fromParam = resolveInfo.schema
         .getMutationType()
         .getFields()
-        [resolveInfo.fieldName].astNode.arguments[0].name.value.substr(fromVar.length),
+        [resolveInfo.fieldName].astNode.arguments[0].name.value.substr(
+          fromVar.length
+        ),
       toParam = resolveInfo.schema
         .getMutationType()
         .getFields()
-        [resolveInfo.fieldName].astNode.arguments[1].name.value.substr(toVar.length);
+        [resolveInfo.fieldName].astNode.arguments[1].name.value.substr(
+          toVar.length
+        );
 
-    let query = `MATCH (${fromVar}:${fromType} {${fromParam}: $${
-      resolveInfo.schema.getMutationType().getFields()[resolveInfo.fieldName].astNode.arguments[0].name.value
-    }})
-       MATCH (${toVar}:${toType} {${toParam}: $${
-      resolveInfo.schema.getMutationType().getFields()[resolveInfo.fieldName].astNode.arguments[1].name.value
-    }})
-      CREATE (${fromVar})-[:${relationshipName}]->(${toVar})
-      RETURN ${fromVar} {${buildCypherSelection({
+    const [subQuery, subParams] = buildCypherSelection({
       initial: '',
       selections,
       variableName,
       schemaType,
-      resolveInfo
-    })}} AS ${fromVar};`;
+      resolveInfo,
+      paramIndex: 1
+    });
+    params = { ...params, ...subParams };
 
-    return query;
+    query = `MATCH (${fromVar}:${fromType} {${fromParam}: $${
+      resolveInfo.schema.getMutationType().getFields()[resolveInfo.fieldName]
+        .astNode.arguments[0].name.value
+    }})
+       MATCH (${toVar}:${toType} {${toParam}: $${
+      resolveInfo.schema.getMutationType().getFields()[resolveInfo.fieldName]
+        .astNode.arguments[1].name.value
+    }})
+      CREATE (${fromVar})-[:${relationshipName}]->(${toVar})
+      RETURN ${fromVar} {${subQuery}} AS ${fromVar};`;
   } else {
     // throw error - don't know how to handle this type of mutation
     throw new Error('Mutation does not follow naming convention.');
   }
-  return query;
+  return [query, params];
 }
 
 export function augmentSchema(schema) {

--- a/src/selections.js
+++ b/src/selections.js
@@ -17,14 +17,14 @@ export function buildCypherSelection({
   variableName,
   schemaType,
   resolveInfo,
-  paramIndex
+  paramIndex = 1
 }) {
   if (!selections.length) {
     return [initial, {}];
   }
 
   const filterParams = getFilterParams(
-    filtersFromSelections(selections),
+    filtersFromSelections(selections, resolveInfo.variableValues),
     paramIndex
   );
   const shallowFilterParams = Object.entries(filterParams).reduce(

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,19 @@
+function parseArg(arg, variableValues) {
+  switch (arg.value.kind) {
+    case 'IntValue':
+      return parseInt(arg.value.value);
+      break;
+    case 'FloatValue':
+      return parseFloat(arg.value.value);
+      break;
+    case 'Variable':
+      return variableValues[arg.name.value];
+      break;
+    default:
+      return arg.value.value;
+  }
+}
+
 export function parseArgs(args, variableValues) {
   // get args from selection.arguments object
   // or from resolveInfo.variableValues if arg is a variable
@@ -12,19 +28,7 @@ export function parseArgs(args, variableValues) {
   }
 
   return args.reduce((acc, arg) => {
-    switch (arg.value.kind) {
-      case 'IntValue':
-        acc[arg.name.value] = parseInt(arg.value.value);
-        break;
-      case 'FloatValue':
-        acc[arg.name.value] = parseFloat(arg.value.value);
-        break;
-      case 'Variable':
-        acc[arg.name.value] = variableValues[arg.name.value];
-        break;
-      default:
-        acc[arg.name.value] = arg.value.value;
-    }
+    acc[arg.name.value] = parseArg(arg, variableValues);
 
     return acc;
   }, {});
@@ -43,13 +47,26 @@ function getDefaultArguments(fieldName, schemaType) {
   }
 }
 
-export function cypherDirectiveArgs(variable, headSelection, schemaType, resolveInfo) {
+export function cypherDirectiveArgs(
+  variable,
+  headSelection,
+  schemaType,
+  resolveInfo
+) {
   const defaultArgs = getDefaultArguments(headSelection.name.value, schemaType);
-  const queryArgs = parseArgs(headSelection.arguments, resolveInfo.variableValues);
+  const queryArgs = parseArgs(
+    headSelection.arguments,
+    resolveInfo.variableValues
+  );
 
-  let args = JSON.stringify(Object.assign(defaultArgs, queryArgs)).replace(/\"([^(\")"]+)\":/g, ' $1: ');
+  let args = JSON.stringify(Object.assign(defaultArgs, queryArgs)).replace(
+    /\"([^(\")"]+)\":/g,
+    ' $1: '
+  );
 
-  return args === '{}' ? `{this: ${variable}${args.substring(1)}` : `{this: ${variable},${args.substring(1)}`;
+  return args === '{}'
+    ? `{this: ${variable}${args.substring(1)}`
+    : `{this: ${variable},${args.substring(1)}`;
 }
 
 export function isMutation(resolveInfo) {
@@ -59,7 +76,8 @@ export function isMutation(resolveInfo) {
 export function isAddRelationshipMutation(resolveInfo) {
   return (
     resolveInfo.operation.operation === 'mutation' &&
-    (resolveInfo.fieldName.startsWith('Add') || resolveInfo.fieldName.startsWith('add')) &&
+    (resolveInfo.fieldName.startsWith('Add') ||
+      resolveInfo.fieldName.startsWith('add')) &&
     resolveInfo.schema
       .getMutationType()
       .getFields()
@@ -78,7 +96,10 @@ export function typeIdentifiers(returnType) {
 }
 
 export function isGraphqlScalarType(type) {
-  return type.constructor.name === 'GraphQLScalarType' || type.constructor.name === 'GraphQLEnumType';
+  return (
+    type.constructor.name === 'GraphQLScalarType' ||
+    type.constructor.name === 'GraphQLEnumType'
+  );
 }
 
 export function isArrayType(type) {
@@ -97,7 +118,9 @@ export function innerType(type) {
 // TODO: refactor to handle Query/Mutation type schema directives
 const directiveWithArgs = (directiveName, args) => (schemaType, fieldName) => {
   function fieldDirective(schemaType, fieldName, directiveName) {
-    return schemaType.getFields()[fieldName].astNode.directives.find(e => e.name.value === directiveName);
+    return schemaType
+      .getFields()
+      [fieldName].astNode.directives.find(e => e.name.value === directiveName);
   }
 
   function directiveArgument(directive, name) {
@@ -118,12 +141,24 @@ const directiveWithArgs = (directiveName, args) => (schemaType, fieldName) => {
 };
 
 export const cypherDirective = directiveWithArgs('cypher', ['statement']);
-export const relationDirective = directiveWithArgs('relation', ['name', 'direction']);
+export const relationDirective = directiveWithArgs('relation', [
+  'name',
+  'direction'
+]);
 
-export function filtersFromSelections(selections) {
-  if (selections && selections.length && selections[0].arguments && selections[0].arguments.length) {
+export function filtersFromSelections(selections, variableValues) {
+  if (
+    selections &&
+    selections.length &&
+    selections[0].arguments &&
+    selections[0].arguments.length
+  ) {
     return selections[0].arguments.reduce((result, x) => {
-      result[x.name.value] = x.value.value;
+      (result[x.name.value] = argumentValue(
+        selections[0],
+        x.name.value,
+        variableValues
+      )) || x.value.value;
       return result;
     }, {});
   }
@@ -147,7 +182,10 @@ export function innerFilterParams(filters) {
     ? `{${Object.entries(filters)
         .filter(([key]) => !['first', 'offset', 'orderBy'].includes(key))
         .map(
-          ([key, value]) => `${key}:$${typeof value.index === 'undefined' ? key : `${value.index}-${key}`}`
+          ([key, value]) =>
+            `${key}:$${
+              typeof value.index === 'undefined' ? key : `${value.index}-${key}`
+            }`
         )
         .join(',')}}`
     : '';
@@ -172,10 +210,8 @@ function argumentValue(selection, name, variableValues) {
   let arg = selection.arguments.find(a => a.name.value === name);
   if (!arg) {
     return null;
-  } else if (!arg.value.value && name in variableValues && arg.value.kind === 'Variable') {
-    return variableValues[name];
   } else {
-    return arg.value.value;
+    return parseArg(arg, variableValues);
   }
 }
 
@@ -213,7 +249,9 @@ export const computeOrderBy = (resolveInfo, selection) => {
     const order = orderByVar.substring(splitIndex + 1);
     const orderBy = orderByVar.substring(0, splitIndex);
     const { variableName } = typeIdentifiers(resolveInfo.returnType);
-    return ` ORDER BY ${variableName}.${orderBy} ${order === 'asc' ? 'ASC' : 'DESC'} `;
+    return ` ORDER BY ${variableName}.${orderBy} ${
+      order === 'asc' ? 'ASC' : 'DESC'
+    } `;
   }
 };
 
@@ -240,7 +278,9 @@ export function fixParamsForAddRelationshipMutation(params, resolveInfo) {
         return x.name.value === 'MutationMeta';
       })[0];
   } catch (e) {
-    throw new Error('Missing required MutationMeta directive on add relationship directive');
+    throw new Error(
+      'Missing required MutationMeta directive on add relationship directive'
+    );
   }
 
   try {
@@ -252,7 +292,9 @@ export function fixParamsForAddRelationshipMutation(params, resolveInfo) {
       return x.name.value === 'to';
     })[0];
   } catch (e) {
-    throw new Error('Missing required argument in MutationMeta directive (relationship, from, or to)');
+    throw new Error(
+      'Missing required argument in MutationMeta directive (relationship, from, or to)'
+    );
   }
   //TODO: need to handle one-to-one and one-to-many
 
@@ -263,28 +305,38 @@ export function fixParamsForAddRelationshipMutation(params, resolveInfo) {
     fromParam = resolveInfo.schema
       .getMutationType()
       .getFields()
-      [resolveInfo.fieldName].astNode.arguments[0].name.value.substr(fromVar.length),
+      [resolveInfo.fieldName].astNode.arguments[0].name.value.substr(
+        fromVar.length
+      ),
     toParam = resolveInfo.schema
       .getMutationType()
       .getFields()
-      [resolveInfo.fieldName].astNode.arguments[1].name.value.substr(toVar.length);
+      [resolveInfo.fieldName].astNode.arguments[1].name.value.substr(
+        toVar.length
+      );
 
   params[toParam] =
     params[
-      resolveInfo.schema.getMutationType().getFields()[resolveInfo.fieldName].astNode.arguments[1].name.value
+      resolveInfo.schema.getMutationType().getFields()[
+        resolveInfo.fieldName
+      ].astNode.arguments[1].name.value
     ];
 
   params[fromParam] =
     params[
-      resolveInfo.schema.getMutationType().getFields()[resolveInfo.fieldName].astNode.arguments[0].name.value
+      resolveInfo.schema.getMutationType().getFields()[
+        resolveInfo.fieldName
+      ].astNode.arguments[0].name.value
     ];
 
   delete params[
-    resolveInfo.schema.getMutationType().getFields()[resolveInfo.fieldName].astNode.arguments[1].name.value
+    resolveInfo.schema.getMutationType().getFields()[resolveInfo.fieldName]
+      .astNode.arguments[1].name.value
   ];
 
   delete params[
-    resolveInfo.schema.getMutationType().getFields()[resolveInfo.fieldName].astNode.arguments[0].name.value
+    resolveInfo.schema.getMutationType().getFields()[resolveInfo.fieldName]
+      .astNode.arguments[0].name.value
   ];
 
   return params;

--- a/test/cypherTest.js
+++ b/test/cypherTest.js
@@ -1,5 +1,8 @@
 import test from 'ava';
-import { cypherTestRunner, augmentedSchemaCypherTestRunner } from './helpers/cypherTestHelpers';
+import {
+  cypherTestRunner,
+  augmentedSchemaCypherTestRunner
+} from './helpers/cypherTestHelpers';
 
 test('simple Cypher query', t => {
   const graphQLQuery = `{
@@ -11,7 +14,11 @@ test('simple Cypher query', t => {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -29,7 +36,11 @@ test('Simple skip limit', t => {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      first: 1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -51,7 +62,12 @@ test('Cypher projection skip limit', t => {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      '1-first': 3,
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -63,11 +79,16 @@ test('Handle Query with name not aligning to type', t => {
   }
 }
   `,
-    expectedCypherQuery = 'MATCH (movie:Movie {year:2010}) RETURN movie { .title } AS movie SKIP $offset';
+    expectedCypherQuery =
+      'MATCH (movie:Movie {year:$year}) RETURN movie { .title } AS movie SKIP $offset';
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      year: 2010,
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -78,11 +99,15 @@ test('Query without arguments, non-null type', t => {
     movieId
   }
 }`,
-    expectedCypherQuery = 'MATCH (movie:Movie {}) RETURN movie { .movieId } AS movie SKIP $offset';
+    expectedCypherQuery =
+      'MATCH (movie:Movie {}) RETURN movie { .movieId } AS movie SKIP $offset';
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -94,11 +119,16 @@ test('Query single object', t => {
       title
     }
   }`,
-    expectedCypherQuery = 'MATCH (movie:Movie {movieId:"18"}) RETURN movie { .title } AS movie SKIP $offset';
+    expectedCypherQuery =
+      'MATCH (movie:Movie {movieId:$movieId}) RETURN movie { .title } AS movie SKIP $offset';
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      movieId: '18',
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -115,11 +145,15 @@ test('Query single object relation', t => {
     }
   `,
     expectedCypherQuery =
-      'MATCH (movie:Movie {movieId:"3100"}) RETURN movie { .title ,filmedIn: head([(movie)-[:FILMED_IN]->(movie_filmedIn:State) | movie_filmedIn { .name }]) } AS movie SKIP $offset';
+      'MATCH (movie:Movie {movieId:$movieId}) RETURN movie { .title ,filmedIn: head([(movie)-[:FILMED_IN]->(movie_filmedIn:State) | movie_filmedIn { .name }]) } AS movie SKIP $offset';
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      movieId: '3100',
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -138,11 +172,15 @@ test('Query single object and array of objects relations', t => {
       }
     }`,
     expectedCypherQuery =
-      'MATCH (movie:Movie {movieId:"3100"}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor) | movie_actors { .name }] ,filmedIn: head([(movie)-[:FILMED_IN]->(movie_filmedIn:State) | movie_filmedIn { .name }]) } AS movie SKIP $offset';
+      'MATCH (movie:Movie {movieId:$movieId}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor) | movie_actors { .name }] ,filmedIn: head([(movie)-[:FILMED_IN]->(movie_filmedIn:State) | movie_filmedIn { .name }]) } AS movie SKIP $offset';
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      movieId: '3100',
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -178,7 +216,9 @@ test('Deeply nested object query', t => {
     cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
       title: 'River Runs Through It, A',
       '1-name': 'Tom Hanks',
-      '2-first': '3'
+      '2-first': 3,
+      first: -1,
+      offset: 0
     }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
@@ -196,7 +236,11 @@ test('Handle meta field at beginning of selection set', t => {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -214,7 +258,11 @@ test('Handle meta field at end of selection set', t => {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -233,7 +281,11 @@ test('Handle meta field in middle of selection set', t => {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -252,7 +304,11 @@ test('Handle @cypher directive without any params for sub-query', t => {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -268,7 +324,11 @@ test('Pass @cypher directive default params to sub-query', t => {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      title: 'River Runs Through It, A'
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -284,7 +344,12 @@ test('Pass @cypher directive params to sub-query', t => {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      title: 'River Runs Through It, A',
+      '1-scale': 10
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -301,7 +366,10 @@ test('Query for Neo4js internal _id', t => {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -318,7 +386,11 @@ test('Query for Neo4js internal _id and another param before _id', t => {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -331,11 +403,15 @@ test('Query for Neo4js internal _id and another param after _id', t => {
     }
 
   }`,
-    expectedCypherQuery = `MATCH (movie:Movie {year:2010}) WHERE ID(movie)=0 RETURN movie { .title , .year } AS movie SKIP $offset`;
+    expectedCypherQuery = `MATCH (movie:Movie {year:$year}) WHERE ID(movie)=0 RETURN movie { .title , .year } AS movie SKIP $offset`;
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      year: 2010
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -352,7 +428,10 @@ test('Query for Neo4js internal _id by dedicated Query MovieBy_Id(_id: Int!)', t
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -368,7 +447,10 @@ test(`Query for null value translates to 'IS NULL' WHERE clause`, t => {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -380,11 +462,15 @@ test(`Query for null value combined with internal ID and another param`, t => {
         year
       }
     }`,
-    expectedCypherQuery = `MATCH (movie:Movie {year:2010}) WHERE ID(movie)=0 AND movie.poster IS NULL RETURN movie { .title , .year } AS movie SKIP $offset`;
+    expectedCypherQuery = `MATCH (movie:Movie {year:$year}) WHERE ID(movie)=0 AND movie.poster IS NULL RETURN movie { .title , .year } AS movie SKIP $offset`;
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      year: 2010,
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -403,11 +489,17 @@ test('Cypher subquery filters', t => {
       }
     }`,
     expectedCypherQuery =
-      'MATCH (movie:Movie {title:$title}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor{name: "Tom Hanks"}) | movie_actors { .name }] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title }][..3] } AS movie SKIP $offset';
+      'MATCH (movie:Movie {title:$title}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor{name:$1-name}) | movie_actors { .name }] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title }][..3] } AS movie SKIP $offset';
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0,
+      '1-name': 'Tom Hanks',
+      '3-first': 3
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -426,11 +518,18 @@ test('Cypher subquery filters with paging', t => {
       }
     }`,
     expectedCypherQuery =
-      'MATCH (movie:Movie {title:$title}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor{name: "Tom Hanks"}) | movie_actors { .name }][..3] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title }][..3] } AS movie SKIP $offset';
+      'MATCH (movie:Movie {title:$title}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor{name:$1-name}) | movie_actors { .name }][..3] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title }][..3] } AS movie SKIP $offset';
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0,
+      '1-first': 3,
+      '1-name': 'Tom Hanks',
+      '3-first': 3
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -446,12 +545,17 @@ test('Handle @cypher directive on Query Type', t => {
   }
 }
   `,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {substring:"Action"}, True) AS x UNWIND x AS genre
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {substring:$substring}, True) AS x UNWIND x AS genre
     RETURN genre { .name ,movies: [(genre)<-[:IN_GENRE]-(genre_movies:Movie{}) | genre_movies { .title }][..3] } AS genre SKIP $offset`;
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      substring: 'Action',
+      first: -1,
+      offset: 0,
+      '1-first': 3
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -524,7 +628,12 @@ test.cb('Add relationship mutation with GraphQL variables', t => {
       RETURN movie {_id: ID(movie), .title ,genres: [(movie)-[:IN_GENRE]->(movie_genres:Genre) | movie_genres { .name }] } AS movie;`;
 
   t.plan(1);
-  return cypherTestRunner(t, graphQLQuery, { movieParam: '123' }, expectedCypherQuery);
+  return cypherTestRunner(
+    t,
+    graphQLQuery,
+    { movieParam: '123' },
+    expectedCypherQuery
+  );
 });
 
 test('Handle GraphQL variables in nested selection - first/offset', t => {
@@ -538,12 +647,30 @@ test('Handle GraphQL variables in nested selection - first/offset', t => {
     }
   }
 }`,
-    expectedCypherQuery = `MATCH (movie:Movie {year:2016}) RETURN movie { .title , .year ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title }][..3] } AS movie SKIP $offset`;
+    expectedCypherQuery = `MATCH (movie:Movie {year:$year}) RETURN movie { .title , .year ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title }][..3] } AS movie SKIP $offset`;
 
   t.plan(3);
 
-  return Promise.all([cypherTestRunner(t, graphQLQuery, { year: 2016, first: 3 }, expectedCypherQuery)]);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, { year: 2016, first: 3 }, expectedCypherQuery);
+  return Promise.all([
+    cypherTestRunner(
+      t,
+      graphQLQuery,
+      { year: 2016, first: 3 },
+      expectedCypherQuery,
+      {
+        '1-first': 3,
+        year: 2016,
+        first: -1,
+        offset: 0
+      }
+    ),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      { year: 2016, first: 3 },
+      expectedCypherQuery
+    )
+  ]);
 });
 
 test('Handle GraphQL variables in nest selection - @cypher param (not first/offset)', t => {
@@ -559,13 +686,30 @@ test('Handle GraphQL variables in nest selection - @cypher param (not first/offs
 
   }
 }`,
-    expectedCypherQuery = `MATCH (movie:Movie {year:2016}) RETURN movie { .title , .year ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title ,scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie_similar, scale: 5}, false)}][..3] } AS movie SKIP $offset`;
+    expectedCypherQuery = `MATCH (movie:Movie {year:$year}) RETURN movie { .title , .year ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title ,scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie_similar, scale: 5}, false)}][..3] } AS movie SKIP $offset`;
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, { year: 2016, first: 3, scale: 5 }, expectedCypherQuery)
+    cypherTestRunner(
+      t,
+      graphQLQuery,
+      { year: 2016, first: 3, scale: 5 },
+      expectedCypherQuery,
+      {
+        year: 2016,
+        first: -1,
+        offset: 0,
+        '1-first': 3,
+        '2-scale': 5
+      }
+    ),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      { year: 2016, first: 3, scale: 5 },
+      expectedCypherQuery
+    )
   ]);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, { year: 2016, first: 3, scale: 5 }, expectedCypherQuery);
 });
 
 test('Return internal node id for _id field', t => {
@@ -581,12 +725,16 @@ test('Return internal node id for _id field', t => {
   }
 }
 `,
-    expectedCypherQuery = `MATCH (movie:Movie {year:2016}) RETURN movie {_id: ID(movie), .title , .year ,genres: [(movie)-[:IN_GENRE]->(movie_genres:Genre) | movie_genres {_id: ID(movie_genres), .name }] } AS movie SKIP $offset`;
+    expectedCypherQuery = `MATCH (movie:Movie {year:$year}) RETURN movie {_id: ID(movie), .title , .year ,genres: [(movie)-[:IN_GENRE]->(movie_genres:Genre) | movie_genres {_id: ID(movie_genres), .name }] } AS movie SKIP $offset`;
 
   t.plan(3);
 
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      year: 2016,
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -603,7 +751,10 @@ test('Treat enum as a scalar', t => {
   t.plan(3);
 
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -627,7 +778,11 @@ query getMovie {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });
@@ -656,7 +811,11 @@ query getMovie {
 
   t.plan(3);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });

--- a/test/cypherTest.js
+++ b/test/cypherTest.js
@@ -12,9 +12,11 @@ test('simple Cypher query', t => {
   }`,
     expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Simple skip limit', t => {
@@ -28,9 +30,11 @@ test('Simple skip limit', t => {
     expectedCypherQuery =
       'MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title , .year } AS movie SKIP 0 LIMIT 1';
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Cypher projection skip limit', t => {
@@ -48,9 +52,11 @@ test('Cypher projection skip limit', t => {
     expectedCypherQuery =
       'MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor) | movie_actors { .name }] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title }][..3] } AS movie SKIP 0';
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Handle Query with name not aligning to type', t => {
@@ -63,9 +69,11 @@ test('Handle Query with name not aligning to type', t => {
     expectedCypherQuery =
       'MATCH (movie:Movie {year:2010}) RETURN movie { .title } AS movie SKIP 0';
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Query without arguments, non-null type', t => {
@@ -77,9 +85,11 @@ test('Query without arguments, non-null type', t => {
     expectedCypherQuery =
       'MATCH (movie:Movie {}) RETURN movie { .movieId } AS movie SKIP 0';
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Query single object', t => {
@@ -92,9 +102,11 @@ test('Query single object', t => {
     expectedCypherQuery =
       'MATCH (movie:Movie {movieId:"18"}) RETURN movie { .title } AS movie SKIP 0';
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Query single object relation', t => {
@@ -111,9 +123,11 @@ test('Query single object relation', t => {
     expectedCypherQuery =
       'MATCH (movie:Movie {movieId:"3100"}) RETURN movie { .title ,filmedIn: head([(movie)-[:FILMED_IN]->(movie_filmedIn:State) | movie_filmedIn { .name }]) } AS movie SKIP 0';
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Query single object and array of objects relations', t => {
@@ -132,9 +146,11 @@ test('Query single object and array of objects relations', t => {
     expectedCypherQuery =
       'MATCH (movie:Movie {movieId:"3100"}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor) | movie_actors { .name }] ,filmedIn: head([(movie)-[:FILMED_IN]->(movie_filmedIn:State) | movie_filmedIn { .name }]) } AS movie SKIP 0';
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Deeply nested object query', t => {
@@ -146,7 +162,7 @@ test('Deeply nested object query', t => {
       name
       movies {
         title
-        actors {
+        actors(name: "Tom Hanks") {
           name
           movies {
             title
@@ -161,11 +177,17 @@ test('Deeply nested object query', t => {
     }
   }
 }`,
-    expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor) | movie_actors { .name ,movies: [(movie_actors)-[:ACTED_IN]->(movie_actors_movies:Movie) | movie_actors_movies { .title ,actors: [(movie_actors_movies)<-[:ACTED_IN]-(movie_actors_movies_actors:Actor) | movie_actors_movies_actors { .name ,movies: [(movie_actors_movies_actors)-[:ACTED_IN]->(movie_actors_movies_actors_movies:Movie) | movie_actors_movies_actors_movies { .title , .year ,similar: [ movie_actors_movies_actors_movies_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie_actors_movies_actors_movies, first: 3, offset: 0}, true) | movie_actors_movies_actors_movies_similar { .title , .year }][..3] }] }] }] }] } AS movie SKIP 0`;
+    expectedCypherQuery = `MATCH (movie:Movie {title:$title}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor) | movie_actors { .name ,movies: [(movie_actors)-[:ACTED_IN]->(movie_actors_movies:Movie) | movie_actors_movies { .title ,actors: [(movie_actors_movies)<-[:ACTED_IN]-(movie_actors_movies_actors:Actor{name:$1-name}) | movie_actors_movies_actors { .name ,movies: [(movie_actors_movies_actors)-[:ACTED_IN]->(movie_actors_movies_actors_movies:Movie) | movie_actors_movies_actors_movies { .title , .year ,similar: [ movie_actors_movies_actors_movies_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie_actors_movies_actors_movies, first: 3, offset: 0}, true) | movie_actors_movies_actors_movies_similar { .title , .year }][..3] }] }] }] }] } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      title: 'River Runs Through It, A',
+      '1-name': 'Tom Hanks',
+      '2-first': '3'
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Handle meta field at beginning of selection set', t => {
@@ -178,9 +200,11 @@ test('Handle meta field at beginning of selection set', t => {
   }`,
     expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Handle meta field at end of selection set', t => {
@@ -194,9 +218,11 @@ test('Handle meta field at end of selection set', t => {
   `,
     expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Handle meta field in middle of selection set', t => {
@@ -211,9 +237,11 @@ test('Handle meta field in middle of selection set', t => {
   `,
     expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title , .year } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Handle @cypher directive without any params for sub-query', t => {
@@ -228,9 +256,11 @@ test('Handle @cypher directive without any params for sub-query', t => {
   }`,
     expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie {mostSimilar: head([ movie_mostSimilar IN apoc.cypher.runFirstColumn("WITH {this} AS this RETURN this", {this: movie}, true) | movie_mostSimilar { .title , .year }]) } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Pass @cypher directive default params to sub-query', t => {
@@ -242,9 +272,11 @@ test('Pass @cypher directive default params to sub-query', t => {
   }`,
     expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie {scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie, scale: 3}, false)} AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Pass @cypher directive params to sub-query', t => {
@@ -256,9 +288,11 @@ test('Pass @cypher directive params to sub-query', t => {
   }`,
     expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie {scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie, scale: 10}, false)} AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Query for Neo4js internal _id', t => {
@@ -271,9 +305,11 @@ test('Query for Neo4js internal _id', t => {
   }`,
     expectedCypherQuery = `MATCH (movie:Movie {}) WHERE ID(movie)=0 RETURN movie { .title , .year } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Query for Neo4js internal _id and another param before _id', t => {
@@ -286,9 +322,11 @@ test('Query for Neo4js internal _id and another param before _id', t => {
   }`,
     expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) WHERE ID(movie)=0 RETURN movie { .title , .year } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Query for Neo4js internal _id and another param after _id', t => {
@@ -301,9 +339,11 @@ test('Query for Neo4js internal _id and another param after _id', t => {
   }`,
     expectedCypherQuery = `MATCH (movie:Movie {year:2010}) WHERE ID(movie)=0 RETURN movie { .title , .year } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Query for Neo4js internal _id by dedicated Query MovieBy_Id(_id: Int!)', t => {
@@ -316,9 +356,11 @@ test('Query for Neo4js internal _id by dedicated Query MovieBy_Id(_id: Int!)', t
   }`,
     expectedCypherQuery = `MATCH (movie:Movie {}) WHERE ID(movie)=0 RETURN movie { .title , .year } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test(`Query for null value translates to 'IS NULL' WHERE clause`, t => {
@@ -330,9 +372,11 @@ test(`Query for null value translates to 'IS NULL' WHERE clause`, t => {
   }`,
     expectedCypherQuery = `MATCH (movie:Movie {}) WHERE movie.poster IS NULL RETURN movie { .title , .year } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test(`Query for null value combined with internal ID and another param`, t => {
@@ -344,9 +388,11 @@ test(`Query for null value combined with internal ID and another param`, t => {
     }`,
     expectedCypherQuery = `MATCH (movie:Movie {year:2010}) WHERE ID(movie)=0 AND movie.poster IS NULL RETURN movie { .title , .year } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Cypher subquery filters', t => {
@@ -365,9 +411,11 @@ test('Cypher subquery filters', t => {
     expectedCypherQuery =
       'MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor{name: "Tom Hanks"}) | movie_actors { .name }] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title }][..3] } AS movie SKIP 0';
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Cypher subquery filters with paging', t => {
@@ -386,9 +434,11 @@ test('Cypher subquery filters with paging', t => {
     expectedCypherQuery =
       'MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor{name: "Tom Hanks"}) | movie_actors { .name }][..3] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title }][..3] } AS movie SKIP 0';
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Handle @cypher directive on Query Type', t => {
@@ -405,9 +455,11 @@ test('Handle @cypher directive on Query Type', t => {
     expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {substring:"Action"}, True) AS x UNWIND x AS genre
     RETURN genre { .name ,movies: [(genre)<-[:IN_GENRE]-(genre_movies:Movie{}) | genre_movies { .title }][..3] } AS genre SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test.cb('Handle @cypher directive on Mutation type', t => {
@@ -421,7 +473,7 @@ test.cb('Handle @cypher directive on Mutation type', t => {
     RETURN genre { .name } AS genre SKIP 0`;
 
   t.plan(1);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  return cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {});
 });
 
 test.cb('Create node mutation', t => {
@@ -438,7 +490,7 @@ test.cb('Create node mutation', t => {
 
   t.plan(1);
   // FIXME: Cypher params are not tested here
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  return cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {});
 });
 
 test.cb('Add relationship mutation', t => {
@@ -458,7 +510,7 @@ test.cb('Add relationship mutation', t => {
       RETURN movie {_id: ID(movie), .title ,genres: [(movie)-[:IN_GENRE]->(movie_genres:Genre) | movie_genres { .name }] } AS movie;`;
 
   t.plan(1);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {});
 });
 
 test.cb('Add relationship mutation with GraphQL variables', t => {
@@ -478,7 +530,12 @@ test.cb('Add relationship mutation with GraphQL variables', t => {
       RETURN movie {_id: ID(movie), .title ,genres: [(movie)-[:IN_GENRE]->(movie_genres:Genre) | movie_genres { .name }] } AS movie;`;
 
   t.plan(1);
-  cypherTestRunner(t, graphQLQuery, { movieParam: '123' }, expectedCypherQuery);
+  return cypherTestRunner(
+    t,
+    graphQLQuery,
+    { movieParam: '123' },
+    expectedCypherQuery
+  );
 });
 
 test('Handle GraphQL variables in nested selection - first/offset', t => {
@@ -494,15 +551,16 @@ test('Handle GraphQL variables in nested selection - first/offset', t => {
 }`,
     expectedCypherQuery = `MATCH (movie:Movie {year:2016}) RETURN movie { .title , .year ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title }][..3] } AS movie SKIP 0`;
 
-  t.plan(2);
+  t.plan(3);
 
-  cypherTestRunner(
-    t,
-    graphQLQuery,
-    { year: 2016, first: 3 },
-    expectedCypherQuery
-  );
-
+  return Promise.all([
+    cypherTestRunner(
+      t,
+      graphQLQuery,
+      { year: 2016, first: 3 },
+      expectedCypherQuery
+    )
+  ]);
   augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
@@ -526,14 +584,15 @@ test('Handle GraphQL variables in nest selection - @cypher param (not first/offs
 }`,
     expectedCypherQuery = `MATCH (movie:Movie {year:2016}) RETURN movie { .title , .year ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, first: 3, offset: 0}, true) | movie_similar { .title ,scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie_similar, scale: 5}, false)}][..3] } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(
-    t,
-    graphQLQuery,
-    { year: 2016, first: 3, scale: 5 },
-    expectedCypherQuery
-  );
-
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(
+      t,
+      graphQLQuery,
+      { year: 2016, first: 3, scale: 5 },
+      expectedCypherQuery
+    )
+  ]);
   augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
@@ -557,10 +616,12 @@ test('Return internal node id for _id field', t => {
 `,
     expectedCypherQuery = `MATCH (movie:Movie {year:2016}) RETURN movie {_id: ID(movie), .title , .year ,genres: [(movie)-[:IN_GENRE]->(movie_genres:Genre) | movie_genres {_id: ID(movie_genres), .name }] } AS movie SKIP 0`;
 
-  t.plan(2);
+  t.plan(3);
 
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Treat enum as a scalar', t => {
@@ -572,10 +633,12 @@ test('Treat enum as a scalar', t => {
   }`,
     expectedCypherQuery = `MATCH (book:Book {}) RETURN book { .genre } AS book SKIP 0`;
 
-  t.plan(2);
+  t.plan(3);
 
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Handle query fragment', t => {
@@ -595,9 +658,11 @@ query getMovie {
 }`,
     expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor) | movie_actors { .name }] , .year } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 test('Handle multiple query fragments', t => {
@@ -622,13 +687,15 @@ query getMovie {
   `,
     expectedCypherQuery = `MATCH (movie:Movie {title:"River Runs Through It, A"}) RETURN movie { .title ,actors: [(movie)<-[:ACTED_IN]-(movie_actors:Actor) | movie_actors { .name }] , .year } AS movie SKIP 0`;
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
-  augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery);
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {}),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
 });
 
 // // test augmented schema:
-// test.cb('Add relationship mutation on augmented schema', t => {
+// test.cb('Add relationship mutation on augmented schema',t => {
 //   const graphQLQuery = `
 //     mutation {
 //   AddMovieGenre(movieId: "123", name: "Boring") {

--- a/test/helpers/cypherTestHelpers.js
+++ b/test/helpers/cypherTestHelpers.js
@@ -7,13 +7,12 @@ export function cypherTestRunner(
   t,
   graphqlQuery,
   graphqlParams,
-  expectedCypherQuery
+  expectedCypherQuery,
+  expectedCypherParams
 ) {
   const testMovieSchema =
     testSchema +
     `
-
-
 type Mutation {
     CreateGenre(name: String): Genre @cypher(statement: "CREATE (g:Genre) SET g.name = $name RETURN g")
     CreateMovie(movieId: ID!, title: String, year: Int, plot: String, poster: String, imdbRating: Float): Movie
@@ -21,49 +20,56 @@ type Mutation {
 }
 `;
 
-  //t.plan(2);
-
   const resolvers = {
     Query: {
       Movie(object, params, ctx, resolveInfo) {
-        let query = cypherQuery(params, ctx, resolveInfo);
+        const [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
       },
       MoviesByYear(object, params, ctx, resolveInfo) {
-        let query = cypherQuery(params, ctx, resolveInfo);
+        const [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
       },
       MovieById(object, params, ctx, resolveInfo) {
-        let query = cypherQuery(params, ctx, resolveInfo);
+        const [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
       },
       MovieBy_Id(object, params, ctx, resolveInfo) {
-        let query = cypherQuery(params, ctx, resolveInfo);
+        const [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
       },
       GenresBySubstring(object, params, ctx, resolveInfo) {
-        let query = cypherQuery(params, ctx, resolveInfo);
+        const [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
       },
       Books(object, params, ctx, resolveInfo) {
-        let query = cypherQuery(params, ctx, resolveInfo);
+        const [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
       }
     },
     Mutation: {
       CreateGenre(object, params, ctx, resolveInfo) {
-        let query = cypherMutation(params, ctx, resolveInfo);
+        const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
         t.end();
       },
       CreateMovie(object, params, ctx, resolveInfo) {
-        let query = cypherMutation(params, ctx, resolveInfo);
+        const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
         t.end();
       },
       AddMovieGenre(object, params, ctx, resolveInfo) {
-        let query = cypherMutation(params, ctx, resolveInfo);
+        const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
         t.end();
       }
     }
@@ -78,11 +84,7 @@ type Mutation {
   });
 
   // query the test schema with the test query, assertion is in the resolver
-  return graphql(schema, graphqlQuery, null, null, graphqlParams).then(function(
-    data
-  ) {
-    // no data is actually resolved, we're just comparing the generated Cypher queries
-  });
+  return graphql(schema, graphqlQuery, null, null, graphqlParams);
 }
 
 export function augmentedSchemaCypherTestRunner(
@@ -95,28 +97,34 @@ export function augmentedSchemaCypherTestRunner(
   const resolvers = {
     Query: {
       Movie(object, params, ctx, resolveInfo) {
-        let query = cypherQuery(params, ctx, resolveInfo);
+        let [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
       },
       MoviesByYear(object, params, ctx, resolveInfo) {
-        let query = cypherQuery(params, ctx, resolveInfo);
+        let [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
       },
       MovieById(object, params, ctx, resolveInfo) {
-        let query = cypherQuery(params, ctx, resolveInfo);
+        let [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
       },
       MovieBy_Id(object, params, ctx, resolveInfo) {
-        let query = cypherQuery(params, ctx, resolveInfo);
+        let [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
       },
       GenresBySubstring(object, params, ctx, resolveInfo) {
-        let query = cypherQuery(params, ctx, resolveInfo);
+        let [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
       },
       Books(object, params, ctx, resolveInfo) {
-        let query = cypherQuery(params, ctx, resolveInfo);
+        let [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
       }
     }
   };
@@ -131,11 +139,7 @@ export function augmentedSchemaCypherTestRunner(
 
   const augmentedSchema = augmentSchema(schema);
 
-  return graphql(augmentedSchema, graphqlQuery, null, null, graphqlParams).then(
-    d => {
-      // no data actually resolved, just need to generate the Cypher query
-    }
-  );
+  return graphql(augmentedSchema, graphqlQuery, null, null, graphqlParams);
 }
 
 export function augmentedSchema() {


### PR DESCRIPTION
Use parameters at all level of read and mutation queries.

Parameters are added with no prefix for top level parameters, and then an index prefix for all nested parameters.
This index is a monotonically increasing integer, which is incremented when a query selection has any additional parameters to add.

Fixes https://github.com/neo4j-graphql/neo4j-graphql-js/issues/72.