### PR TITLE
Ensure the driver session is closed after a query is completed/errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,13 @@ export async function neo4jgraphql(
   }
 
   const session = context.driver.session();
-  const result = await session.run(query, cypherParams);
+  let result;
+
+  try {
+    result = await session.run(query, cypherParams);
+  } finally {
+    session.close();
+  }
   return extractQueryResult(result, resolveInfo.returnType);
 }
 


### PR DESCRIPTION
We're still experiencing performance issues with this library and noticed this doesn\'t happen, whereas we explicitly close any connections in our applications.