### PR TITLE
Allow nested fragments

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -269,7 +269,11 @@ export function extractSelections(selections, fragments) {
   // extract any fragment selection sets into a single array of selections
   return selections.reduce((acc, cur) => {
     if (cur.kind === 'FragmentSpread') {
-      return [...acc, ...fragments[cur.name.value].selectionSet.selections];
+      const recursivelyExtractedSelections = extractSelections(
+        fragments[cur.name.value].selectionSet.selections,
+        fragments,
+      );
+      return [...acc, ...recursivelyExtractedSelections];
     } else {
       return [...acc, cur];
     }


### PR DESCRIPTION
Example query:

```gql
query items {
  items {
    ...Foo
  }
}

fragment Foo on Item {
  name
  ...Bar
}

fragment Bar on Item {
  description
}
```

Currently, neo4j-graphql-js returns only part of the desired data:

```json
"items": [
  {
    "name": "My name",
    "description": null
  }
]
```

Effectively ignoring the nested fragment. This simple change allows it to check fragments for nested fragments and return that data as well.