### PR TITLE
Allow fragments within relations

### DIFF
--- a/src/selections.js
+++ b/src/selections.js
@@ -8,6 +8,7 @@ import {
   innerType,
   isArrayType,
   isGraphqlScalarType,
+  extractSelections,
   relationDirective
 } from './utils';
 
@@ -105,9 +106,14 @@ export function buildCypherSelection({
   const nestedVariable = variableName + '_' + fieldName;
   const skipLimit = computeSkipLimit(headSelection, resolveInfo.variableValues);
 
+  const subSelections = extractSelections(
+    headSelection.selectionSet.selections,
+    resolveInfo.fragments
+  );
+
   const subSelection = recurse({
     initial: '',
-    selections: headSelection.selectionSet.selections,
+    selections: subSelections,
     variableName: nestedVariable,
     schemaType: innerSchemaType,
     resolveInfo


### PR DESCRIPTION
Similar to https://github.com/neo4j-graphql/neo4j-graphql-js/pull/78, allow fragments within relations by extracting selections before trying to parse. See new tests for examples.