### PR TITLE
Updates to augmentSchema

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,7 @@ import {
 import { buildCypherSelection } from './selections';
 import {
   extractAstNodesFromSchema,
-  augmentTypeDefs,
-  createOperationMap,
+  extractResolvers,
   makeAugmentedSchema
 } from './augmentSchema';
 import { checkRequestError } from './auth';
@@ -441,9 +440,8 @@ RETURN ${fromVar} {${subQuery}} AS ${fromVar};`;
 }
 
 export const augmentSchema = (schema) => {
-  const typeMap = extractAstNodesFromSchema(schema);
-  const mutationMap = createOperationMap(typeMap.Mutation);
-  const queryMap = createOperationMap(typeMap.Query);
-  const augmentedTypeMap = augmentTypeDefs(typeMap);
-  return makeAugmentedSchema(schema, augmentedTypeMap, queryMap, mutationMap);
+  let typeMap = extractAstNodesFromSchema(schema);
+  let queryResolvers = extractResolvers(schema.getQueryType());
+  let mutationResolvers = extractResolvers(schema.getMutationType());
+  return makeAugmentedSchema(typeMap, queryResolvers, mutationResolvers);
 }

--- a/test/augmentSchemaTest.js
+++ b/test/augmentSchemaTest.js
@@ -5,7 +5,21 @@ import { printSchema } from 'graphql';
 test.cb('Test augmented schema', t => {
   let schema = augmentedSchema();
 
-  let expectedSchema = `enum _GenreOrdering {
+  let expectedSchema = `enum _ActorOrdering {
+  id_asc
+  id_desc
+  name_asc
+  name_desc
+  _id_asc
+  _id_desc
+}
+
+enum _BookOrdering {
+  _id_asc
+  _id_desc
+}
+
+enum _GenreOrdering {
   name_desc
   name_asc
 }
@@ -15,16 +29,32 @@ enum _MovieOrdering {
   title_asc
 }
 
+enum _StateOrdering {
+  name_asc
+  name_desc
+  _id_asc
+  _id_desc
+}
+
+enum _UserOrdering {
+  id_asc
+  id_desc
+  name_asc
+  name_desc
+  _id_asc
+  _id_desc
+}
+
 type Actor implements Person {
   id: ID!
   name: String
-  movies: [Movie]
-  _id: ID
+  movies(first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
+  _id: Int
 }
 
 type Book {
   genre: BookGenre
-  _id: ID
+  _id: Int
 }
 
 enum BookGenre {
@@ -34,9 +64,9 @@ enum BookGenre {
 }
 
 type Genre {
-  _id: ID
+  _id: Int
   name: String
-  movies(first: Int = 3, offset: Int = 0): [Movie]
+  movies(first: Int = 3, offset: Int = 0, orderBy: _MovieOrdering): [Movie]
   highestRatedMovie: Movie
 }
 
@@ -48,42 +78,39 @@ type Movie {
   plot: String
   poster: String
   imdbRating: Float
-  genres: [Genre]
-  similar(first: Int = 3, offset: Int = 0): [Movie]
+  genres(first: Int, offset: Int, orderBy: _GenreOrdering): [Genre]
+  similar(first: Int = 3, offset: Int = 0, orderBy: _MovieOrdering): [Movie]
   mostSimilar: Movie
   degree: Int
-  actors(first: Int = 3, offset: Int = 0, name: String): [Actor]
+  actors(first: Int = 3, offset: Int = 0, name: String, orderBy: _ActorOrdering): [Actor]
   avgStars: Float
   filmedIn: State
   scaleRating(scale: Int = 3): Float
   scaleRatingFloat(scale: Float = 1.5): Float
-  actorMovies: [Movie]
+  actorMovies(first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
 }
 
 type Mutation {
-  CreateMovie(movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float, degree: Int, avgStars: Float, scaleRating: Float, scaleRatingFloat: Float): Movie
-  UpdateMovie(movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float, degree: Int, avgStars: Float, scaleRating: Float, scaleRatingFloat: Float): Movie
+  CreateMovie(movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float, avgStars: Float): Movie
+  UpdateMovie(movieId: ID!, title: String, year: Int, plot: String, poster: String, imdbRating: Float, avgStars: Float): Movie
   DeleteMovie(movieId: ID!): Movie
-  AddMovieGenre(moviemovieId: ID!, genrename: String!): Movie
-  RemoveMovieGenre(moviemovieId: ID!, genrename: String!): Movie
-  AddMovieState(moviemovieId: ID!, statename: String!): Movie
-  RemoveMovieState(moviemovieId: ID!, statename: String!): Movie
+  AddMovieGenres(moviemovieId: ID!, genrename: String!): Movie
+  RemoveMovieGenres(moviemovieId: ID!, genrename: String!): Movie
+  AddMovieFilmedIn(moviemovieId: ID!, statename: String!): Movie
+  RemoveMovieFilmedIn(moviemovieId: ID!, statename: String!): Movie
   CreateGenre(name: String): Genre
-  UpdateGenre(name: String): Genre
-  DeleteGenre(name: String): Genre
+  DeleteGenre(name: String!): Genre
   CreateActor(id: ID, name: String): Actor
-  UpdateActor(id: ID, name: String): Actor
+  UpdateActor(id: ID!, name: String): Actor
   DeleteActor(id: ID!): Actor
-  AddActorMovie(actorid: ID!, moviemovieId: ID!): Actor
-  RemoveActorMovie(actorid: ID!, moviemovieId: ID!): Actor
+  AddActorMovies(actorid: ID!, moviemovieId: ID!): Actor
+  RemoveActorMovies(actorid: ID!, moviemovieId: ID!): Actor
   CreateState(name: String): State
-  UpdateState(name: String): State
-  DeleteState(name: String): State
+  DeleteState(name: String!): State
   CreateBook(genre: BookGenre): Book
-  UpdateBook(genre: BookGenre): Book
-  DeleteBook(genre: BookGenre): Book
+  DeleteBook(genre: BookGenre!): Book
   CreateUser(id: ID, name: String): User
-  UpdateUser(id: ID, name: String): User
+  UpdateUser(id: ID!, name: String): User
   DeleteUser(id: ID!): User
 }
 
@@ -94,22 +121,27 @@ interface Person {
 
 type Query {
   Movie(_id: Int, movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float, first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
-  MoviesByYear(year: Int): [Movie]
+  MoviesByYear(year: Int, first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
   MovieById(movieId: ID!): Movie
   MovieBy_Id(_id: Int!): Movie
-  GenresBySubstring(substring: String): [Genre]
-  Books: [Book]
+  GenresBySubstring(substring: String, first: Int, offset: Int, orderBy: _GenreOrdering): [Genre]
+  Books(first: Int, offset: Int, orderBy: _BookOrdering): [Book]
+  Genre(_id: Int, name: String, first: Int, offset: Int, orderBy: _GenreOrdering): [Genre]
+  Actor(id: ID, name: String, _id: Int, first: Int, offset: Int, orderBy: _ActorOrdering): [Actor]
+  State(name: String, _id: Int, first: Int, offset: Int, orderBy: _StateOrdering): [State]
+  Book(genre: BookGenre, _id: Int, first: Int, offset: Int, orderBy: _BookOrdering): [Book]
+  User(id: ID, name: String, _id: Int, first: Int, offset: Int, orderBy: _UserOrdering): [User]
 }
 
 type State {
   name: String
-  _id: ID
+  _id: Int
 }
 
 type User implements Person {
   id: ID!
   name: String
-  _id: ID
+  _id: Int
 }
 `;
 


### PR DESCRIPTION
For every generated creation mutation, the first ID type
argument (if any exists) will not be required. (relating to #70)

For every list field and list query, the first, offset, and orderBy arguments are added, if not provided. Any that you provide will not be overwritten, maintaining any default values you may set. The _[Type]Ordering enum types are generated, if not provided. (#86, #87)

Computed fields are no longer included in generated mutations. (#90)

Relation mutation names are now generated by adding the capitalized name of the
relation field after the name of the type. (#92) For example:

```
type Movie {
  genres: [Genre] @relation(name: "IN_GENRE", direction: "OUT")
}
```

Add[Type][Field] -> AddMovieGenres

Other changes:

The primary key field used for node selection in the update mutation is now
always listed as the first argument, and is required.

If a type does not have at least 1 other field besides the primary key field, then no update mutation is generated.

#70 Generate ID if not provided in create mutation
#86 Add orderBy enums and orderBy field during augmentSchema
#87 Generate Query type from typeDefs
#90 Don't include computed fields in generated mutations
#92 Duplicated generated mutation names