### PR TITLE
Initial support for #88

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,10 @@ import {
 } from './utils';
 import { buildCypherSelection } from './selections';
 import {
-  extractAstNodesFromSchema,
+  extractTypeMapFromSchema,
   extractResolvers,
-  makeAugmentedSchema
+  augmentedSchema,
+  makeAugmentedExecutableSchema
 } from './augmentSchema';
 import { checkRequestError } from './auth';
 
@@ -440,8 +441,39 @@ RETURN ${fromVar} {${subQuery}} AS ${fromVar};`;
 }
 
 export const augmentSchema = (schema) => {
-  let typeMap = extractAstNodesFromSchema(schema);
+  let typeMap = extractTypeMapFromSchema(schema);
   let queryResolvers = extractResolvers(schema.getQueryType());
   let mutationResolvers = extractResolvers(schema.getMutationType());
-  return makeAugmentedSchema(typeMap, queryResolvers, mutationResolvers);
+  return augmentedSchema(typeMap, queryResolvers, mutationResolvers);
+}
+
+export const makeAugmentedSchema = ({
+   schema,
+   typeDefs,
+   resolvers,
+   logger,
+   allowUndefinedInResolve=false,
+   resolverValidationOptions={},
+   directiveResolvers=null,
+   schemaDirectives=null,
+   parseOptions={},
+   inheritResolversFromInterfaces=false
+  }) => {
+    if(schema) {
+      return augmentSchema(schema);
+    }
+    if(!typeDefs) throw new Error(
+      'Must provide typeDefs'
+    );
+    return makeAugmentedExecutableSchema({
+      typeDefs,
+      resolvers,
+      logger,
+      allowUndefinedInResolve,
+      resolverValidationOptions,
+      directiveResolvers,
+      schemaDirectives,
+      parseOptions,
+      inheritResolversFromInterfaces
+    });
 }


### PR DESCRIPTION
This contains initial support for makeAugmentedSchema, which returns an augmented schema just like augmentSchema, but can accept typeDefs (see: #88) instead of an already built schema, along with all other arguments of makeExecutableSchema from graphql-tools (resolvers, etc.).