### PR TITLE
ID generation, scalar mutation args, tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,19 @@ export function cypherMutation(
       paramIndex: 1
     });
     params = { ...params, ...subParams };
+    
+    const args = resolveInfo.schema
+      .getMutationType()
+      .getFields()[resolveInfo.fieldName].astNode.arguments;
 
+    const firstIdArg = args.find(e => getNamedType(e).type.name.value);
+    if(firstIdArg) {
+      const argName = firstIdArg.name.value;
+      if(params.params[argName] === undefined) {
+        query += `SET ${variableName}.${argName} = apoc.create.uuid() `;
+      }
+    }
+    
     query += `RETURN ${variableName} {${subQuery}} AS ${variableName}`;
   } else if (isAddMutation(resolveInfo)) {
     let mutationMeta, relationshipNameArg, fromTypeArg, toTypeArg;

--- a/test/augmentSchemaTest.js
+++ b/test/augmentSchemaTest.js
@@ -5,7 +5,11 @@ import { printSchema } from 'graphql';
 test.cb('Test augmented schema', t => {
   let schema = augmentedSchema();
 
-  let expectedSchema = `enum _ActorOrdering {
+let expectedSchema = `input _ActorInput {
+  id: ID!
+}
+
+enum _ActorOrdering {
   id_asc
   id_desc
   name_asc
@@ -14,9 +18,42 @@ test.cb('Test augmented schema', t => {
   _id_desc
 }
 
+type _AddActorMoviesPayload {
+  from: Actor
+  to: Movie
+}
+
+type _AddGenreMoviesPayload {
+  from: Movie
+  to: Genre
+}
+
+type _AddMovieActorsPayload {
+  from: Actor
+  to: Movie
+}
+
+type _AddMovieFilmedInPayload {
+  from: Movie
+  to: State
+}
+
+type _AddMovieGenresPayload {
+  from: Movie
+  to: Genre
+}
+
+input _BookInput {
+  genre: BookGenre!
+}
+
 enum _BookOrdering {
   _id_asc
   _id_desc
+}
+
+input _GenreInput {
+  name: String!
 }
 
 enum _GenreOrdering {
@@ -24,9 +61,42 @@ enum _GenreOrdering {
   name_asc
 }
 
+input _MovieInput {
+  movieId: ID!
+}
+
 enum _MovieOrdering {
   title_desc
   title_asc
+}
+
+type _RemoveActorMoviesPayload {
+  from: Actor
+  to: Movie
+}
+
+type _RemoveGenreMoviesPayload {
+  from: Movie
+  to: Genre
+}
+
+type _RemoveMovieActorsPayload {
+  from: Actor
+  to: Movie
+}
+
+type _RemoveMovieFilmedInPayload {
+  from: Movie
+  to: State
+}
+
+type _RemoveMovieGenresPayload {
+  from: Movie
+  to: Genre
+}
+
+input _StateInput {
+  name: String!
 }
 
 enum _StateOrdering {
@@ -34,6 +104,10 @@ enum _StateOrdering {
   name_desc
   _id_asc
   _id_desc
+}
+
+input _UserInput {
+  id: ID!
 }
 
 enum _UserOrdering {
@@ -94,17 +168,21 @@ type Mutation {
   CreateMovie(movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float, avgStars: Float): Movie
   UpdateMovie(movieId: ID!, title: String, year: Int, plot: String, poster: String, imdbRating: Float, avgStars: Float): Movie
   DeleteMovie(movieId: ID!): Movie
-  AddMovieGenres(moviemovieId: ID!, genrename: String!): Movie
-  RemoveMovieGenres(moviemovieId: ID!, genrename: String!): Movie
-  AddMovieFilmedIn(moviemovieId: ID!, statename: String!): Movie
-  RemoveMovieFilmedIn(moviemovieId: ID!, statename: String!): Movie
+  AddMovieGenres(from: _MovieInput!, to: _GenreInput!): _AddMovieGenresPayload
+  RemoveMovieGenres(from: _MovieInput!, to: _GenreInput!): _RemoveMovieGenresPayload
+  AddMovieActors(from: _ActorInput!, to: _MovieInput!): _AddMovieActorsPayload
+  RemoveMovieActors(from: _ActorInput!, to: _MovieInput!): _RemoveMovieActorsPayload
+  AddMovieFilmedIn(from: _MovieInput!, to: _StateInput!): _AddMovieFilmedInPayload
+  RemoveMovieFilmedIn(from: _MovieInput!, to: _StateInput!): _RemoveMovieFilmedInPayload
   CreateGenre(name: String): Genre
   DeleteGenre(name: String!): Genre
+  AddGenreMovies(from: _MovieInput!, to: _GenreInput!): _AddGenreMoviesPayload
+  RemoveGenreMovies(from: _MovieInput!, to: _GenreInput!): _RemoveGenreMoviesPayload
   CreateActor(id: ID, name: String): Actor
   UpdateActor(id: ID!, name: String): Actor
   DeleteActor(id: ID!): Actor
-  AddActorMovies(actorid: ID!, moviemovieId: ID!): Actor
-  RemoveActorMovies(actorid: ID!, moviemovieId: ID!): Actor
+  AddActorMovies(from: _ActorInput!, to: _MovieInput!): _AddActorMoviesPayload
+  RemoveActorMovies(from: _ActorInput!, to: _MovieInput!): _RemoveActorMoviesPayload
   CreateState(name: String): State
   DeleteState(name: String!): State
   CreateBook(genre: BookGenre): Book

--- a/test/augmentSchemaTest.js
+++ b/test/augmentSchemaTest.js
@@ -43,6 +43,18 @@ type _AddMovieGenresPayload {
   to: Genre
 }
 
+type _AddMovieWatchedByPayload {
+  from: User
+  to: Movie
+  rating: Int
+}
+
+type _AddUserWatchedPayload {
+  from: User
+  to: Movie
+  rating: Int
+}
+
 input _BookInput {
   genre: BookGenre!
 }
@@ -70,6 +82,11 @@ enum _MovieOrdering {
   title_asc
 }
 
+type _MovieWatchedBy {
+  rating: Int
+  User(first: Int, offset: Int, orderBy: _UserOrdering): User
+}
+
 type _RemoveActorMoviesPayload {
   from: Actor
   to: Movie
@@ -93,6 +110,16 @@ type _RemoveMovieFilmedInPayload {
 type _RemoveMovieGenresPayload {
   from: Movie
   to: Genre
+}
+
+type _RemoveMovieWatchedByPayload {
+  from: User
+  to: Movie
+}
+
+type _RemoveUserWatchedPayload {
+  from: User
+  to: Movie
 }
 
 input _StateInput {
@@ -119,6 +146,15 @@ enum _UserOrdering {
   _id_desc
 }
 
+type _UserWatched {
+  rating: Int
+  Movie(first: Int, offset: Int, orderBy: _MovieOrdering): Movie
+}
+
+input _WatchedInput {
+  rating: Int
+}
+
 type Actor implements Person {
   id: ID!
   name: String
@@ -137,6 +173,8 @@ enum BookGenre {
   Math
 }
 
+scalar DateTime
+
 type Genre {
   _id: Int
   name: String
@@ -149,6 +187,7 @@ type Movie {
   movieId: ID!
   title: String
   year: Int
+  released: DateTime
   plot: String
   poster: String
   imdbRating: Float
@@ -162,11 +201,12 @@ type Movie {
   scaleRating(scale: Int = 3): Float
   scaleRatingFloat(scale: Float = 1.5): Float
   actorMovies(first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
+  watchedBy: [_MovieWatchedBy]
 }
 
 type Mutation {
-  CreateMovie(movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float, avgStars: Float): Movie
-  UpdateMovie(movieId: ID!, title: String, year: Int, plot: String, poster: String, imdbRating: Float, avgStars: Float): Movie
+  CreateMovie(movieId: ID, title: String, year: Int, released: DateTime, plot: String, poster: String, imdbRating: Float, avgStars: Float): Movie
+  UpdateMovie(movieId: ID!, title: String, year: Int, released: DateTime, plot: String, poster: String, imdbRating: Float, avgStars: Float): Movie
   DeleteMovie(movieId: ID!): Movie
   AddMovieGenres(from: _MovieInput!, to: _GenreInput!): _AddMovieGenresPayload
   RemoveMovieGenres(from: _MovieInput!, to: _GenreInput!): _RemoveMovieGenresPayload
@@ -174,6 +214,8 @@ type Mutation {
   RemoveMovieActors(from: _ActorInput!, to: _MovieInput!): _RemoveMovieActorsPayload
   AddMovieFilmedIn(from: _MovieInput!, to: _StateInput!): _AddMovieFilmedInPayload
   RemoveMovieFilmedIn(from: _MovieInput!, to: _StateInput!): _RemoveMovieFilmedInPayload
+  AddMovieWatchedBy(from: _UserInput!, to: _MovieInput!, data: _WatchedInput!): _AddMovieWatchedByPayload
+  RemoveMovieWatchedBy(from: _UserInput!, to: _MovieInput!): _RemoveMovieWatchedByPayload
   CreateGenre(name: String): Genre
   DeleteGenre(name: String!): Genre
   AddGenreMovies(from: _MovieInput!, to: _GenreInput!): _AddGenreMoviesPayload
@@ -185,11 +227,13 @@ type Mutation {
   RemoveActorMovies(from: _ActorInput!, to: _MovieInput!): _RemoveActorMoviesPayload
   CreateState(name: String): State
   DeleteState(name: String!): State
-  CreateBook(genre: BookGenre): Book
-  DeleteBook(genre: BookGenre!): Book
   CreateUser(id: ID, name: String): User
   UpdateUser(id: ID!, name: String): User
   DeleteUser(id: ID!): User
+  AddUserWatched(from: _UserInput!, to: _MovieInput!, data: _WatchedInput!): _AddUserWatchedPayload
+  RemoveUserWatched(from: _UserInput!, to: _MovieInput!): _RemoveUserWatchedPayload
+  CreateBook(genre: BookGenre): Book
+  DeleteBook(genre: BookGenre!): Book
 }
 
 interface Person {
@@ -207,8 +251,8 @@ type Query {
   Genre(_id: Int, name: String, first: Int, offset: Int, orderBy: _GenreOrdering): [Genre]
   Actor(id: ID, name: String, _id: Int, first: Int, offset: Int, orderBy: _ActorOrdering): [Actor]
   State(name: String, _id: Int, first: Int, offset: Int, orderBy: _StateOrdering): [State]
-  Book(genre: BookGenre, _id: Int, first: Int, offset: Int, orderBy: _BookOrdering): [Book]
   User(id: ID, name: String, _id: Int, first: Int, offset: Int, orderBy: _UserOrdering): [User]
+  Book(genre: BookGenre, _id: Int, first: Int, offset: Int, orderBy: _BookOrdering): [Book]
 }
 
 type State {
@@ -219,7 +263,14 @@ type State {
 type User implements Person {
   id: ID!
   name: String
+  watched: [_UserWatched]
   _id: Int
+}
+
+type Watched {
+  from(first: Int, offset: Int, orderBy: _UserOrdering): User
+  rating: Int
+  to(first: Int, offset: Int, orderBy: _MovieOrdering): Movie
 }
 `;
 

--- a/test/helpers/cypherTestHelpers.js
+++ b/test/helpers/cypherTestHelpers.js
@@ -14,7 +14,7 @@ export function cypherTestRunner(
     `
 type Mutation {
     CreateGenre(name: String): Genre @cypher(statement: "CREATE (g:Genre) SET g.name = $name RETURN g")
-    CreateMovie(movieId: ID!, title: String, year: Int, plot: String, poster: String, imdbRating: Float): Movie
+    CreateMovie(movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float): Movie
     UpdateMovie(movieId: ID!, title: String, year: Int, plot: String, poster: String, imdbRating: Float): Movie
     DeleteMovie(movieId: ID!): Movie
     AddMovieGenre(moviemovieId: ID!, genrename: String): Movie @MutationMeta(relationship: "IN_GENRE", from:"Movie", to:"Genre")

--- a/test/helpers/cypherTestHelpers.js
+++ b/test/helpers/cypherTestHelpers.js
@@ -1,4 +1,4 @@
-import { cypherQuery, cypherMutation, augmentSchema } from '../../dist/index';
+import { cypherQuery, cypherMutation, augmentSchema, makeAugmentedSchema } from '../../dist/index';
 import { graphql } from 'graphql';
 import { makeExecutableSchema } from 'graphql-tools';
 import { testSchema } from './testSchema';
@@ -17,8 +17,6 @@ type Mutation {
     CreateMovie(movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float): Movie
     UpdateMovie(movieId: ID!, title: String, year: Int, plot: String, poster: String, imdbRating: Float): Movie
     DeleteMovie(movieId: ID!): Movie
-    AddMovieGenre(moviemovieId: ID!, genrename: String): Movie @MutationMeta(relationship: "IN_GENRE", from:"Movie", to:"Genre")
-    RemoveMovieGenre(moviemovieId: ID!, genrename: String): Movie @MutationMeta(relationship: "IN_GENRE", from:"Movie", to:"Genre")
 }
 `;
 
@@ -79,18 +77,6 @@ type Mutation {
         t.is(query, expectedCypherQuery);
         t.deepEqual(queryParams, expectedCypherParams);
         t.end();
-      },
-      AddMovieGenre(object, params, ctx, resolveInfo) {
-        const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
-        t.is(query, expectedCypherQuery);
-        t.deepEqual(queryParams, expectedCypherParams);
-        t.end();
-      },
-      RemoveMovieGenre(object, params, ctx, resolveInfo) {
-        const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
-        t.is(query, expectedCypherQuery);
-        t.deepEqual(queryParams, expectedCypherParams);
-        t.end();
       }
     }
   };
@@ -146,18 +132,30 @@ export function augmentedSchemaCypherTestRunner(
         t.is(query, expectedCypherQuery);
         t.deepEqual(queryParams, expectedCypherParams);
       }
+    },
+    Mutation: {
+      AddMovieGenres(object, params, ctx, resolveInfo) {
+        const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
+        t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
+        t.end();
+      },
+      RemoveMovieGenres(object, params, ctx, resolveInfo) {
+        const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
+        t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
+        t.end();
+      }
     }
   };
 
-  const schema = makeExecutableSchema({
+  const augmentedSchema = makeAugmentedSchema({
     typeDefs: testSchema,
     resolvers,
     resolverValidationOptions: {
       requireResolversForResolveType: false
     }
   });
-
-  const augmentedSchema = augmentSchema(schema);
 
   return graphql(augmentedSchema, graphqlQuery, null, null, graphqlParams);
 }

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -1,8 +1,9 @@
 export const testSchema = `type Movie {
   _id: ID
   movieId: ID!
-    title: String
+  title: String
   year: Int
+  released: DateTime
   plot: String
   poster: String
   imdbRating: Float
@@ -16,11 +17,12 @@ export const testSchema = `type Movie {
   scaleRating(scale: Int = 3): Float @cypher(statement: "WITH $this AS this RETURN $scale * this.imdbRating")
   scaleRatingFloat(scale: Float = 1.5): Float @cypher(statement: "WITH $this AS this RETURN $scale * this.imdbRating")
   actorMovies: [Movie] @cypher(statement: "MATCH (this)-[:ACTED_IN*2]-(other:Movie) RETURN other")
+  watchedBy: [Watched]
 }
 
 type Genre {
   _id: ID!
-    name: String
+  name: String
   movies(first: Int = 3, offset: Int = 0): [Movie] @relation(name: "IN_GENRE", direction: "IN")
   highestRatedMovie: Movie @cypher(statement: "MATCH (m:Movie)-[:IN_GENRE]->(this) RETURN m ORDER BY m.imdbRating DESC LIMIT 1")
 }
@@ -31,24 +33,31 @@ type State {
 
 interface Person {
   id: ID!
-    name: String
+  name: String
 }
 
 type Actor implements Person {
   id: ID!
-    name: String
+  name: String
   movies: [Movie] @relation(name: "ACTED_IN", direction:"OUT")
 }
 
 type User implements Person {
   id: ID!
-    name: String
+  name: String
+  watched: [Watched]
+}
+
+type Watched {
+  from: User
+  rating: Int
+  to: Movie
 }
 
 enum BookGenre {
   Mystery,
-    Science,
-    Math
+  Science,
+  Math
 }
 
 type Book {
@@ -72,4 +81,7 @@ type Query {
   MovieBy_Id(_id: Int!): Movie
   GenresBySubstring(substring: String): [Genre] @cypher(statement: "MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g")
   Books: [Book]
-}`;
+}
+
+scalar DateTime
+`;


### PR DESCRIPTION
In line with #70, if no value is provided for the first ID type field of a generated node creation mutation, then the value will be set using `apoc.create.uuid()` in the cypher translation.

Custom scalars are now included in the arguments of the generated create and update node mutations, and in the `data` argument of relation addition mutations (#109).

The schema augmentation and relation mutation tests have been updated to reflect the API changes made in #108.