### PR TITLE
(fix) comma-separate properties from inlinefragment

### DIFF
--- a/src/selections.js
+++ b/src/selections.js
@@ -72,7 +72,7 @@ export function buildCypherSelection({
       resolveInfo
     };
     return recurse({
-      initial: tailSelections.length
+      initial: fragmentSelections.length
         ? initial
         : initial.substring(0, initial.lastIndexOf(',')),
       ...fragmentTailParams


### PR DESCRIPTION
When querying an inlinefragment, its properties are not separated by commas resulting in a invalid cypher query.
For example querying the props `name` and `type` of a `CSVResource`, which implements a `Resource` interface: 
```
(resourcePool_resources:CSVResource) | resourcePool_resources {FRAGMENT_TYPE: "CSVResource", .name  .type }]
```
The bug is that we're looking at the `tailSelections` when checking for adding a comma, but the actual selections which need to be done are inside the inlinefragment. This is why I used `fragmentSelections` here.