### PR TITLE
fix(misleading-error): allow to return better error messages

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -385,9 +385,9 @@ export const parameterizeRelationFields = (fields) => {
 export const getRelationTypeDirectiveArgs = (relationshipType) => {
   const directive = relationshipType.directives.find(e => e.name.value === "relation");
   return directive ? {
-    name: directive.arguments.find(e => e.name.value === "name").value.value, 
-    from: directive.arguments.find(e => e.name.value === "from").value.value, 
-    to: directive.arguments.find(e => e.name.value === "to").value.value 
+    name: directive.arguments.find(e => e.name.value === "name").value.value,
+    from: directive.arguments.find(e => e.name.value === "from").value.value,
+    to: directive.arguments.find(e => e.name.value === "to").value.value
   } : undefined;
 }
 
@@ -511,7 +511,7 @@ export const isNodeType = (astNode) => {
 }
 
 export const parseFieldSdl = (sdl) => {
-  return sdl 
+  return sdl
     ? parse(`type fieldToParse { ${sdl} }`).definitions[0].fields[0]
     : {};
 }
@@ -520,22 +520,22 @@ export const getRelationDirection = (relationDirective) => {
   let direction = {};
   try {
     direction = relationDirective.arguments.filter(a => a.name.value === 'direction')[0];
+    return direction.value.value;
   } catch (e) {
     // FIXME: should we ignore this error to define default behavior?
     throw new Error('No direction argument specified on @relation directive');
   }
-  return direction.value.value;
 }
 
 export const getRelationName = (relationDirective) => {
   let name = {};
   try {
     name = relationDirective.arguments.filter(a => a.name.value === 'name')[0];
+    return name.value.value;
   } catch (e) {
     // FIXME: should we ignore this error to define default behavior?
     throw new Error('No name argument specified on @relation directive');
   }
-  return name.value.value;
 }
 
 export const createRelationMap = (typeMap) => {


### PR DESCRIPTION
The point of this change is to return better error message in case name or direction haven't been specified into the directive.

If nothing was specified the filter was returning an empty array, and gettting the [0] element was getting undefined in variable direction, and an exception was thrown at the line `return direction.value.value;` : TypeError: Cannot read property 'value' of undefined.

The same apply to getRelationDirection and getRelationName method.

before :
<img width="826" alt="image" src="https://user-images.githubusercontent.com/3169331/46588048-8aa3f300-ca8d-11e8-842b-85de59756534.png">
after:
<img width="724" alt="image" src="https://user-images.githubusercontent.com/3169331/46588051-92fc2e00-ca8d-11e8-89e6-cf820217a60b.png">


background of the change:
During some discovery of the GRANDStack with my own `schema.graphql` 
I specified the direction: "IN" but on the other type I forgot the "OUT". and when starting docker I received the error message (see first image). Which didn't help me at all until i go to see the source code.





