### PR TITLE
Reflexive relation types, fixes for #113 and #124

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -1,0 +1,235 @@
+import {
+  isArrayType,
+  cypherDirectiveArgs
+} from './utils';
+
+export const customCypherField = ({
+  customCypher,
+  schemaTypeRelation,
+  initial,
+  fieldName,
+  fieldType,
+  nestedVariable,
+  variableName,
+  headSelection,
+  schemaType,
+  resolveInfo,
+  subSelection,
+  skipLimit,
+  commaIfTail,
+  tailParams
+}) => {
+  if (schemaTypeRelation) {
+    variableName = `${variableName}_relation`;
+  }
+  const fieldIsList = !!fieldType.ofType;
+  // similar: [ x IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie}, true) |x {.title}][1..2])
+  return {
+    initial: `${initial}${fieldName}: ${
+      fieldIsList ? '' : 'head('
+    }[ ${nestedVariable} IN apoc.cypher.runFirstColumn("${customCypher}", ${cypherDirectiveArgs(
+      variableName,
+      headSelection,
+      schemaType,
+      resolveInfo
+    )}, true) | ${nestedVariable} {${subSelection[0]}}]${
+      fieldIsList ? '' : ')'
+    }${skipLimit} ${commaIfTail}`,
+    ...tailParams,
+  };
+}
+
+export const relationFieldOnNodeType = ({
+  initial, 
+  fieldName, 
+  fieldType, 
+  variableName, 
+  relDirection, 
+  relType,
+  nestedVariable, 
+  isInlineFragment, 
+  interfaceLabel, 
+  innerSchemaType, 
+  queryParams, 
+  subSelection, 
+  skipLimit, 
+  commaIfTail,
+  tailParams
+}) => {
+  return {
+    initial: `${initial}${fieldName}: ${
+      !isArrayType(fieldType) ? 'head(' : ''
+    }[(${variableName})${
+      relDirection === 'in' || relDirection === 'IN' ? '<' : ''
+    }-[:${relType}]-${
+      relDirection === 'out' || relDirection === 'OUT' ? '>' : ''
+    }(${nestedVariable}:${
+      isInlineFragment ? interfaceLabel : innerSchemaType.name
+    }${queryParams}) | ${nestedVariable} {${
+      isInlineFragment
+        ? 'FRAGMENT_TYPE: "' + interfaceLabel + '",' + subSelection[0]
+        : subSelection[0]
+    }}]${!isArrayType(fieldType) ? ')' : ''}${skipLimit} ${commaIfTail}`,
+    ...tailParams
+  };
+}
+
+export const relationTypeFieldOnNodeType = ({
+  innerSchemaTypeRelation,
+  initial,
+  fieldName,
+  subSelection,
+  skipLimit,
+  commaIfTail,
+  tailParams, 
+  fieldType,
+  variableName,
+  schemaType,
+  nestedVariable,
+  queryParams
+}) => {
+  if (innerSchemaTypeRelation.from === innerSchemaTypeRelation.to) {
+    return {
+      initial: `${initial}${fieldName}: {${subSelection[0]}}${skipLimit} ${commaIfTail}`,
+      ...tailParams,
+    }  
+  }
+  return {
+    initial: `${initial}${fieldName}: ${
+      !isArrayType(fieldType) ? 'head(' : ''
+    }[(${variableName})${
+      schemaType.name === innerSchemaTypeRelation.to ? '<' : ''
+    }-[${nestedVariable}_relation:${innerSchemaTypeRelation.name}${queryParams}]-${
+      schemaType.name === innerSchemaTypeRelation.from ? '>' : ''
+    }(:${
+      schemaType.name === innerSchemaTypeRelation.from ? innerSchemaTypeRelation.to : innerSchemaTypeRelation.from
+    }) | ${nestedVariable}_relation {${subSelection[0]}}]${
+      !isArrayType(fieldType) ? ')' : ''
+    }${skipLimit} ${commaIfTail}`,
+    ...tailParams
+  }
+}
+
+export const nodeTypeFieldOnRelationType = ({
+  fieldInfo,
+  rootVariableNames,
+  schemaTypeRelation,
+  innerSchemaType,
+  isInlineFragment,
+  interfaceLabel,
+}) => {
+  if (rootVariableNames) {
+    // Special case used by relation mutation payloads
+    // rootVariableNames is persisted for sibling directed fields
+    return relationTypeMutationPayloadField({
+      ...fieldInfo,
+      rootVariableNames
+    });
+  }
+  else {
+    // Normal case of schemaType with a relationship directive
+    return directedFieldOnReflexiveRelationType({
+      ...fieldInfo,
+      schemaTypeRelation,
+      innerSchemaType,
+      isInlineFragment,
+      interfaceLabel,
+    });
+  }
+}
+
+const relationTypeMutationPayloadField = ({
+  initial,
+  fieldName,
+  variableName,
+  subSelection,
+  skipLimit,
+  commaIfTail,
+  tailParams,
+  rootVariableNames
+}) => {
+  return {
+    initial: `${initial}${fieldName}: ${variableName} {${subSelection[0]}}${skipLimit} ${commaIfTail}`,
+    ...tailParams,
+    rootVariableNames,
+    variableName: fieldName === 'from' ? rootVariableNames.to : rootVariableNames.from
+  }
+}
+
+const directedFieldOnReflexiveRelationType = ({
+  initial,
+  fieldName,
+  fieldType,
+  variableName,
+  queryParams,
+  nestedVariable,
+  subSelection,
+  skipLimit,
+  commaIfTail,
+  tailParams,
+  schemaTypeRelation,
+  innerSchemaType,
+  isInlineFragment,
+  interfaceLabel
+}) => {
+  const relType = schemaTypeRelation.name;
+  const fromTypeName = schemaTypeRelation.from;
+  const toTypeName = schemaTypeRelation.to;
+  const isFromField = fieldName === fromTypeName || fieldName === 'from';
+  const isToField = fieldName === toTypeName || fieldName === 'to';
+  const relationshipVariableName = `${variableName}_${isFromField ? 'from' : 'to'}_relation`;
+  // Since the translations are significantly different, 
+  // we first check whether the relationship is reflexive
+  if(fromTypeName === toTypeName) {
+    if(fieldName === "from" || fieldName === "to") {
+      return {
+        initial: `${initial}${fieldName}: ${
+          !isArrayType(fieldType) ? 'head(' : ''
+        }[(${variableName})${
+          isFromField ? '<' : ''
+        }-[${relationshipVariableName}:${relType}${queryParams}]-${
+          isToField ? '>' : ''
+        }(${nestedVariable}:${
+          isInlineFragment 
+          ? interfaceLabel 
+          : fromTypeName
+        }) | ${relationshipVariableName} {${
+          isInlineFragment
+            ? 'FRAGMENT_TYPE: "' + interfaceLabel + '",' + subSelection[0]
+            : subSelection[0]
+        }}]${
+          !isArrayType(fieldType) ? ')' : ''
+        }${skipLimit} ${commaIfTail}`,
+        ...tailParams
+      };
+    }
+    else {
+      // Case of a renamed directed field
+      return {
+        initial: `${initial}${fieldName}: ${variableName} {${subSelection[0]}}${skipLimit} ${commaIfTail}`,
+        ...tailParams
+      };
+    }
+  }
+  // Related node types are different
+  return {
+    initial: `${initial}${fieldName}: ${
+      !isArrayType(fieldType) ? 'head(' : ''
+    }[(:${
+      isFromField ? toTypeName : fromTypeName
+    })${
+      isFromField ? '<' : ''
+    }-[${variableName}_relation]-${
+      isToField ? '>' : ''
+    }(${nestedVariable}:${
+      isInlineFragment ? interfaceLabel : innerSchemaType.name
+    }${queryParams}) | ${nestedVariable} {${
+      isInlineFragment
+        ? 'FRAGMENT_TYPE: "' + interfaceLabel + '",' + subSelection[0]
+        : subSelection[0]
+    }}]${
+      !isArrayType(fieldType) ? ')' : ''
+    }${skipLimit} ${commaIfTail}`,
+    ...tailParams
+  }
+}

--- a/test/augmentSchemaTest.js
+++ b/test/augmentSchemaTest.js
@@ -49,6 +49,12 @@ type _AddMovieRatingsPayload {
   rating: Int
 }
 
+type _AddUserFriendsPayload {
+  from: User
+  to: User
+  since: Int
+}
+
 type _AddUserRatedPayload {
   from: User
   to: Movie
@@ -62,6 +68,10 @@ input _BookInput {
 enum _BookOrdering {
   _id_asc
   _id_desc
+}
+
+input _FriendOfInput {
+  since: Int
 }
 
 input _GenreInput {
@@ -84,7 +94,7 @@ enum _MovieOrdering {
 
 type _MovieRatings {
   rating: Int
-  User(first: Int, offset: Int, orderBy: _UserOrdering): User
+  User: User
 }
 
 input _RatedInput {
@@ -121,6 +131,11 @@ type _RemoveMovieRatingsPayload {
   to: Movie
 }
 
+type _RemoveUserFriendsPayload {
+  from: User
+  to: User
+}
+
 type _RemoveUserRatedPayload {
   from: User
   to: Movie
@@ -135,6 +150,16 @@ enum _StateOrdering {
   name_desc
   _id_asc
   _id_desc
+}
+
+type _UserFriends {
+  since: Int
+  User: User
+}
+
+type _UserFriendsDirections {
+  from(since: Int): [_UserFriends]
+  to(since: Int): [_UserFriends]
 }
 
 input _UserInput {
@@ -152,7 +177,7 @@ enum _UserOrdering {
 
 type _UserRated {
   rating: Int
-  Movie(first: Int, offset: Int, orderBy: _MovieOrdering): Movie
+  Movie: Movie
 }
 
 type Actor implements Person {
@@ -174,6 +199,12 @@ enum BookGenre {
 }
 
 scalar DateTime
+
+type FriendOf {
+  from: User
+  since: Int
+  to: User
+}
 
 type Genre {
   _id: Int
@@ -232,6 +263,8 @@ type Mutation {
   DeleteUser(userId: ID!): User
   AddUserRated(from: _UserInput!, to: _MovieInput!, data: _RatedInput!): _AddUserRatedPayload
   RemoveUserRated(from: _UserInput!, to: _MovieInput!): _RemoveUserRatedPayload
+  AddUserFriends(from: _UserInput!, to: _UserInput!, data: _FriendOfInput!): _AddUserFriendsPayload
+  RemoveUserFriends(from: _UserInput!, to: _UserInput!): _RemoveUserFriendsPayload
   CreateBook(genre: BookGenre): Book
   DeleteBook(genre: BookGenre!): Book
 }
@@ -256,9 +289,9 @@ type Query {
 }
 
 type Rated {
-  from(first: Int, offset: Int, orderBy: _UserOrdering): User
+  from: User
   rating: Int
-  to(first: Int, offset: Int, orderBy: _MovieOrdering): Movie
+  to: Movie
 }
 
 type State {
@@ -269,7 +302,8 @@ type State {
 type User implements Person {
   userId: ID!
   name: String
-  rated: [_UserRated]
+  rated(rating: Int): [_UserRated]
+  friends: _UserFriendsDirections
   _id: Int
 }
 `;

--- a/test/helpers/cypherTestHelpers.js
+++ b/test/helpers/cypherTestHelpers.js
@@ -102,6 +102,11 @@ export function augmentedSchemaCypherTestRunner(
   //t.plan(1);
   const resolvers = {
     Query: {
+      User(object, params, ctx, resolveInfo) {
+        let [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
+        t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
+      },
       Movie(object, params, ctx, resolveInfo) {
         let [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);
@@ -145,9 +150,27 @@ export function augmentedSchemaCypherTestRunner(
         t.is(query, expectedCypherQuery);
         t.deepEqual(queryParams, expectedCypherParams);
         t.end();
+      },
+      AddUserRated(object, params, ctx, resolveInfo) {
+        const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
+        t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
+        t.end();
+      },
+      AddUserFriends(object, params, ctx, resolveInfo) {
+        const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
+        t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
+        t.end();
+      },
+      RemoveUserFriends(object, params, ctx, resolveInfo) {
+        const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
+        t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
+        t.end();
       }
     }
-  };
+  }
 
   const augmentedSchema = makeAugmentedSchema({
     typeDefs: testSchema,
@@ -159,6 +182,9 @@ export function augmentedSchemaCypherTestRunner(
 
   return graphql(augmentedSchema, graphqlQuery, null, null, graphqlParams);
 }
+
+
+
 
 export function augmentedSchema() {
   const schema = makeExecutableSchema({

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -45,7 +45,14 @@ type Actor implements Person {
 type User implements Person {
   userId: ID!
   name: String
-  rated: [Rated]
+  rated(rating: Int): [Rated]
+  friends(since: Int): [FriendOf]
+}
+
+type FriendOf {
+  from: User
+  since: Int
+  to: User
 }
 
 type Rated {


### PR DESCRIPTION
#### Fixes

* Don't drop non-Query/Mutation resolvers passed into makeAugmentedExecutableSchema #113

* Basic schema with non nullable property gives error when calling mutation #124

#### Features: 

##### Reflexive Relation API 

The following `FriendOf` relation type is <i>reflexive</i> in the sense that it comes `from` and goes `to` the same type. There is now support in the generated Query and Mutation API for reflexive relation types. 
```graphql
type User implements Person {
  ...
  rated(rating: Int): [Rated]
  friends(since: Int): [FriendOf]
}

# Reflexive relation type
type FriendOf {
  from: User
  since: Int
  to: User
}

type Rated {
  from: User
  rating: Int
  to: Movie
}
```

Given the above SDL format (what you write), the following SDL is generated as a result of the schema augmentation process (`augmentSchema` or `makeAugmentedSchema`). The `since` argument on the `friends` is distributed over the directed fields, `from` and `to`. 

```graphql
type User implements Person {
  userId: ID!
  name: String
  rated(rating: Int): [_UserRated]
  friends: _UserFriendsDirections
}

type _UserFriendsDirections {
  from(since: Int): [_UserFriends]
  to(since: Int): [_UserFriends]
}

type _UserFriends {
  since: Int
  User: User
}
```

This results in support for the following selection set format: 

```graphql
User {
  userId
  name
  friends {
    from(since: 1) {
      since
      User {
        name
      }
    }
    to(since: 2) {
      since
      User {
        name
      }
    }
  }
}
```

#### Tests

The following tests have been added in `cypherTest.js` for the reflexive relation type API:

* Add relationship mutation with relationship property (reflexive)
* Remove relationship mutation (reflexive)
* query reflexive relation nested in non-reflexive relation
* query non-reflexive relation nested in reflexive relation
* query relation type with argument
* query reflexive relation type with arguments

#### Other

This PR also introduces a new `translate.js` file, from which helpers are exported and used in `index.js`, refactoring the recursive GraphQL to Cypher translation process.