### PR TITLE
Fix #126, default resolvers object 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -493,7 +493,7 @@ export const augmentSchema = (schema) => {
 export const makeAugmentedSchema = ({
   schema,
   typeDefs,
-  resolvers,
+  resolvers = {},
   logger,
   allowUndefinedInResolve = false,
   resolverValidationOptions = {},


### PR DESCRIPTION
It looks like in PR #125, I forgot to keep a default value for the `resolvers` argument of `makeAugmentedSchema`. This PR resolves that issue -- sorry about that folks!