### PR TITLE
Initial support for graphql@14

### DIFF
--- a/src/augment.js
+++ b/src/augment.js
@@ -17,7 +17,8 @@ import {
   isKind,
   isNonNullType,
   isNodeType,
-  parseFieldSdl
+  parseFieldSdl,
+  addDirectiveDeclarations
 } from './utils';
 
 export const augmentTypeMap = typeMap => {
@@ -44,6 +45,7 @@ export const augmentTypeMap = typeMap => {
     typeMap[t] = astNode;
   });
   typeMap = augmentQueryArguments(typeMap);
+  typeMap = addDirectiveDeclarations(typeMap);
   return typeMap;
 };
 

--- a/src/augmentSchema.js
+++ b/src/augmentSchema.js
@@ -1,7 +1,7 @@
 import { makeExecutableSchema } from 'graphql-tools';
-import { parse } from 'graphql';
 import {
-  printTypeMap
+  printTypeMap,
+  extractTypeMapFromTypeDefs
 } from './utils';
 import { 
   augmentTypeMap,
@@ -49,26 +49,19 @@ export const makeAugmentedExecutableSchema = ({
   });
 }
 
-const extractTypeMapFromTypeDefs = (typeDefs) => {
-  // TODO: accept alternative typeDefs formats (arr of strings, ast, etc.)
-  // into a single string for parse, add validatation
-  const astNodes = parse(typeDefs).definitions;
-  return astNodes.reduce( (acc, t) => {
-    acc[t.name.value] = t;
-    return acc;
-  }, {});
-}
-
 export const extractTypeMapFromSchema = (schema) => {
   const typeMap = schema.getTypeMap();
+  const directives = schema.getDirectives();
+  const types = { ...typeMap, ...directives };
   let astNode = {};
-  return Object.keys(typeMap).reduce( (acc, t) => {
-    astNode = typeMap[t].astNode;
+  const extracted = Object.keys(types).reduce( (acc, t) => {
+    astNode = types[t].astNode;
     if(astNode !== undefined) {
       acc[astNode.name.value] = astNode;
     }
     return acc;
   }, {});
+  return extracted;
 }
 
 export const extractResolversFromSchema = (schema) => {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,10 @@ import {
   lowFirstLetter,
   typeIdentifiers,
   parameterizeRelationFields,
-  getFieldValueType
+  getFieldValueType,
+  extractTypeMapFromTypeDefs,
+  addDirectiveDeclarations,
+  printTypeMap
 } from './utils';
 import { buildCypherSelection } from './selections';
 import {
@@ -518,3 +521,9 @@ export const makeAugmentedSchema = ({
     inheritResolversFromInterfaces
   });
 };
+
+export const augmentTypeDefs = (typeDefs) => {
+  const typeMap = extractTypeMapFromTypeDefs(typeDefs);
+  const augmented = addDirectiveDeclarations(typeMap);
+  return printTypeMap(augmented);
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -625,3 +625,22 @@ export const decideNestedVariableName = ({
   }
   return variableName + '_' + fieldName;
 }
+
+export const extractTypeMapFromTypeDefs = (typeDefs) => {
+  // TODO: accept alternative typeDefs formats (arr of strings, ast, etc.)
+  // into a single string for parse, add validatation
+  const astNodes = parse(typeDefs).definitions;
+  return astNodes.reduce( (acc, t) => {
+    acc[t.name.value] = t;
+    return acc;
+  }, {});
+}
+
+export const addDirectiveDeclarations = (typeMap) => {
+  // overwrites any provided directive declarations for system directive names
+  typeMap['cypher'] = parse(`directive @cypher(statement: String) on FIELD_DEFINITION`);
+  typeMap['relation'] = parse(`directive @relation(name: String, direction: _RelationDirections, from: String, to: String) on OBJECT | FIELD_DEFINITION`);
+  typeMap['MutationMeta'] = parse(`directive @MutationMeta(relationship: String, from: String, to: String) on FIELD_DEFINITION`);
+  typeMap['_RelationDirections'] = parse(`enum _RelationDirections { IN OUT }`);
+  return typeMap;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -639,7 +639,7 @@ export const extractTypeMapFromTypeDefs = (typeDefs) => {
 export const addDirectiveDeclarations = (typeMap) => {
   // overwrites any provided directive declarations for system directive names
   typeMap['cypher'] = parse(`directive @cypher(statement: String) on FIELD_DEFINITION`);
-  typeMap['relation'] = parse(`directive @relation(name: String, direction: _RelationDirections, from: String, to: String) on OBJECT | FIELD_DEFINITION`);
+  typeMap['relation'] = parse(`directive @relation(name: String, direction: _RelationDirections, from: String, to: String) on FIELD_DEFINITION | OBJECT`);
   typeMap['MutationMeta'] = parse(`directive @MutationMeta(relationship: String, from: String, to: String) on FIELD_DEFINITION`);
   typeMap['_RelationDirections'] = parse(`enum _RelationDirections { IN OUT }`);
   return typeMap;

--- a/test/augmentSchemaTest.js
+++ b/test/augmentSchemaTest.js
@@ -5,7 +5,13 @@ import { printSchema } from 'graphql';
 test.cb('Test augmented schema', t => {
   let schema = augmentedSchema();
 
-  let expectedSchema = `input _ActorInput {
+  let expectedSchema = `directive @cypher(statement: String) on FIELD_DEFINITION
+
+directive @relation(name: String, direction: _RelationDirections, from: String, to: String) on FIELD_DEFINITION | OBJECT
+
+directive @MutationMeta(relationship: String, from: String, to: String) on FIELD_DEFINITION
+
+input _ActorInput {
   userId: ID!
 }
 
@@ -99,6 +105,11 @@ type _MovieRatings {
 
 input _RatedInput {
   rating: Int
+}
+
+enum _RelationDirections {
+  IN
+  OUT
 }
 
 type _RemoveActorMoviesPayload {


### PR DESCRIPTION
This PR is an initial attempt to address #100. In the case of using `makeAugmentedSchema`, directive declarations for `cypher`, `relation`, and `mutationMeta` (used during runtime for relation metadata) will be added to your typeDefs during the schema augmentation process. If you provide declarations for these directives, they will be overwritten. 

If you are using `augmentSchema`, you must use the new export, `augmentTypeDefs` in order to add the directive declarations to your typeDefs, as shown below:

```
import { augmentTypeDefs, augmentSchema } from 'neo4j-graphql-js';

const schema = makeExecutableSchema({
  typeDefs: augmentTypeDefs(typeDefs),
  resolvers,
});

const augmentedSchema = augmentSchema(schema);
```