### PR TITLE
Configuring the schema augmentation process

### DIFF
--- a/src/augmentSchema.js
+++ b/src/augmentSchema.js
@@ -8,8 +8,13 @@ import {
   augmentResolvers
 } from "./augment";
 
-export const augmentedSchema = (typeMap, resolvers) => {
-  const augmentedTypeMap = augmentTypeMap(typeMap);
+
+// TODO put every extract- helper in extract.js along with moving 
+// TODO extractTypeMapFromTypeDefs from utils.js
+
+
+export const augmentedSchema = (typeMap, resolvers, config) => {
+  const augmentedTypeMap = augmentTypeMap(typeMap, config);
   const augmentedResolvers = augmentResolvers(augmentedTypeMap, resolvers);
   // TODO extract and persist logger and schemaDirectives, at least
   return makeExecutableSchema({
@@ -30,10 +35,11 @@ export const makeAugmentedExecutableSchema = ({
   directiveResolvers,
   schemaDirectives,
   parseOptions,
-  inheritResolversFromInterfaces
+  inheritResolversFromInterfaces, 
+  config
 }) => {
   const typeMap = extractTypeMapFromTypeDefs(typeDefs);
-  const augmentedTypeMap = augmentTypeMap(typeMap);
+  const augmentedTypeMap = augmentTypeMap(typeMap, config);
   const augmentedResolvers = augmentResolvers(augmentedTypeMap, resolvers);
   resolverValidationOptions.requireResolversForResolveType = false;
   return makeExecutableSchema({
@@ -54,14 +60,13 @@ export const extractTypeMapFromSchema = (schema) => {
   const directives = schema.getDirectives();
   const types = { ...typeMap, ...directives };
   let astNode = {};
-  const extracted = Object.keys(types).reduce( (acc, t) => {
+  return Object.keys(types).reduce( (acc, t) => {
     astNode = types[t].astNode;
     if(astNode !== undefined) {
       acc[astNode.name.value] = astNode;
     }
     return acc;
   }, {});
-  return extracted;
 }
 
 export const extractResolversFromSchema = (schema) => {

--- a/src/index.js
+++ b/src/index.js
@@ -487,10 +487,10 @@ RETURN ${variableName}`;
   return [query, params];
 }
 
-export const augmentSchema = (schema) => {
+export const augmentSchema = (schema, config) => {
   const typeMap = extractTypeMapFromSchema(schema);
   const resolvers = extractResolversFromSchema(schema);
-  return augmentedSchema(typeMap, resolvers);
+  return augmentedSchema(typeMap, resolvers, config);
 };
 
 export const makeAugmentedSchema = ({
@@ -503,10 +503,14 @@ export const makeAugmentedSchema = ({
   directiveResolvers = null,
   schemaDirectives = null,
   parseOptions = {},
-  inheritResolversFromInterfaces = false
+  inheritResolversFromInterfaces = false,
+  config = {
+    query: true,
+    mutation: true
+  }
 }) => {
   if (schema) {
-    return augmentSchema(schema);
+    return augmentSchema(schema, config);
   }
   if (!typeDefs) throw new Error('Must provide typeDefs');
   return makeAugmentedExecutableSchema({
@@ -518,12 +522,14 @@ export const makeAugmentedSchema = ({
     directiveResolvers,
     schemaDirectives,
     parseOptions,
-    inheritResolversFromInterfaces
+    inheritResolversFromInterfaces,
+    config
   });
 };
 
 export const augmentTypeDefs = (typeDefs) => {
   const typeMap = extractTypeMapFromTypeDefs(typeDefs);
+  // overwrites any provided declarations of system directives
   const augmented = addDirectiveDeclarations(typeMap);
   return printTypeMap(augmented);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -517,10 +517,18 @@ export const createOperationMap = (type) => {
 
 export const isNodeType = (astNode) => {
   // TODO: check for @ignore and @model directives
-  return astNode && astNode.kind === "ObjectTypeDefinition"
+  return astNode
+    // must be graphql object type
+    && astNode.kind === "ObjectTypeDefinition"
+    // is not Query or Mutation type
     && astNode.name.value !== "Query"
     && astNode.name.value !== "Mutation"
-    && getTypeDirective(astNode, "relation") === undefined;
+    // does not have relation type directive
+    && getTypeDirective(astNode, "relation") === undefined
+    // does not have from and to fields; not relation type
+    && astNode.fields
+    && astNode.fields.find(e => e.name.value === "from") === undefined 
+    && astNode.fields.find(e => e.name.value === "to") === undefined;
 }
 
 export const parseFieldSdl = (sdl) => {


### PR DESCRIPTION
This PR contains initial support for configuring the schema augmentation process, resolving the following issues:

* How to disable generated mutations? #117
* Prevent auto generation of update, create, ... methods #128

A `config` key is added to the `makeAugmentedSchema` argument object:
```js
const augmentedSchema = makeAugmentedSchema({ 
  typeDefs,
  config: {
    query: true, // default
    mutation: false
  }
}
```
And the same configuration object is added as a second argument to `augmentSchema`:
```js
const augmentedSchema = augmentSchema(schema, {
  mutation: false
});
```
By providing a boolean value, you can prevent the generation of the Query or Mutation API generally. For more fine-grained control, you can provide an array of type names to exclude (such as payload types, etc.) from the schema augmentation process. Excluding a type blocks the following associated API features from being generated during the schema augmentation process.
##### Query API
* A query for the excluded type is not generated.
* Any field or query that returns a list of the excluded type will not recieve first / offset / orderBy arguments.
##### Mutation API
* The `create`, `update`, and `delete` node mutations are not generated.
* The `Add` and `Remove` relation mutations are not generated for any relation in the schema coming from or going to excluded type.
##### Example
```js
const config =  {
  query: {
    exclude: ["MyCustomPayload"]
  },
  mutation: {
    exclude: ["MyCustomPayload"]
  }
};
// const augmentedSchema = augmentSchema(schema, config);
const augmentedSchema = makeAugmentedSchema({ 
  typeDefs,
  config
}
```