### PR TITLE
Fix for _id fields in graphql@14

### DIFF
--- a/src/augment.js
+++ b/src/augment.js
@@ -98,7 +98,7 @@ export const augmentTypeMap = (typeMap, config) => {
 
 const augmentType = (astNode, typeMap, config, queryType) => {
   if (isNodeType(astNode)) {
-    astNode.fields = addOrReplaceNodeIdField(astNode, 'ID');
+    astNode.fields = addOrReplaceNodeIdField(astNode);
     astNode.fields = possiblyAddTypeFieldArguments(astNode, typeMap, config, queryType);
   }
   return astNode;
@@ -944,7 +944,7 @@ const possiblyAddRelationTypeFieldPayload = (
   return typeMap;
 };
 
-const addOrReplaceNodeIdField = (astNode, valueType) => {
+const addOrReplaceNodeIdField = (astNode) => {
   const fields = astNode ? astNode.fields : [];
   const index = fields.findIndex(e => e.name.value === '_id');
   const definition = {
@@ -958,12 +958,11 @@ const addOrReplaceNodeIdField = (astNode, valueType) => {
       kind: 'NamedType',
       name: {
         kind: 'Name',
-        value: valueType
+        value: 'String'
       }
     },
     directives: []
   };
-  ``;
   // If it has already been provided, replace it to force valueType,
   // else add it as the last field
   index >= 0 ? fields.splice(index, 1, definition) : fields.push(definition);
@@ -1034,7 +1033,7 @@ const capitalizeName = name => {
 const createQueryArguments = (astNode, typeMap) => {
   let type = {};
   let valueTypeName = '';
-  astNode.fields = addOrReplaceNodeIdField(astNode, 'Int');
+  astNode.fields = addOrReplaceNodeIdField(astNode);
   return astNode.fields.reduce((acc, t) => {
     type = getNamedType(t);
     valueTypeName = type.name.value;

--- a/test/augmentSchemaTest.js
+++ b/test/augmentSchemaTest.js
@@ -195,12 +195,12 @@ type Actor implements Person {
   userId: ID!
   name: String
   movies(first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
-  _id: Int
+  _id: String
 }
 
 type Book {
   genre: BookGenre
-  _id: Int
+  _id: String
 }
 
 enum BookGenre {
@@ -218,14 +218,14 @@ type FriendOf {
 }
 
 type Genre {
-  _id: Int
+  _id: String
   name: String
   movies(first: Int = 3, offset: Int = 0, orderBy: _MovieOrdering): [Movie]
   highestRatedMovie: Movie
 }
 
 type Movie {
-  _id: ID
+  _id: String
   movieId: ID!
   title: String
   year: Int
@@ -286,17 +286,17 @@ interface Person {
 }
 
 type Query {
-  Movie(_id: Int, movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float, first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
+  Movie(_id: String, movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float, first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
   MoviesByYear(year: Int, first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
   MovieById(movieId: ID!): Movie
-  MovieBy_Id(_id: Int!): Movie
+  MovieBy_Id(_id: String!): Movie
   GenresBySubstring(substring: String, first: Int, offset: Int, orderBy: _GenreOrdering): [Genre]
   Books(first: Int, offset: Int, orderBy: _BookOrdering): [Book]
-  Genre(_id: Int, name: String, first: Int, offset: Int, orderBy: _GenreOrdering): [Genre]
-  Actor(userId: ID, name: String, _id: Int, first: Int, offset: Int, orderBy: _ActorOrdering): [Actor]
-  State(name: String, _id: Int, first: Int, offset: Int, orderBy: _StateOrdering): [State]
-  User(userId: ID, name: String, _id: Int, first: Int, offset: Int, orderBy: _UserOrdering): [User]
-  Book(genre: BookGenre, _id: Int, first: Int, offset: Int, orderBy: _BookOrdering): [Book]
+  Genre(_id: String, name: String, first: Int, offset: Int, orderBy: _GenreOrdering): [Genre]
+  Actor(userId: ID, name: String, _id: String, first: Int, offset: Int, orderBy: _ActorOrdering): [Actor]
+  State(name: String, _id: String, first: Int, offset: Int, orderBy: _StateOrdering): [State]
+  User(userId: ID, name: String, _id: String, first: Int, offset: Int, orderBy: _UserOrdering): [User]
+  Book(genre: BookGenre, _id: String, first: Int, offset: Int, orderBy: _BookOrdering): [Book]
 }
 
 type Rated {
@@ -307,7 +307,7 @@ type Rated {
 
 type State {
   name: String
-  _id: Int
+  _id: String
 }
 
 type User implements Person {
@@ -315,7 +315,7 @@ type User implements Person {
   name: String
   rated(rating: Int): [_UserRated]
   friends: _UserFriendsDirections
-  _id: Int
+  _id: String
 }
 `;
 

--- a/test/cypherTest.js
+++ b/test/cypherTest.js
@@ -356,7 +356,7 @@ test('Pass @cypher directive params to sub-query', t => {
 
 test('Query for Neo4js internal _id', t => {
   const graphQLQuery = `{
-    Movie(_id: 0) {
+    Movie(_id: "0") {
       title
       year
     }
@@ -376,7 +376,7 @@ test('Query for Neo4js internal _id', t => {
 
 test('Query for Neo4js internal _id and another param before _id', t => {
   const graphQLQuery = `{
-    Movie(title: "River Runs Through It, A", _id: 0) {
+    Movie(title: "River Runs Through It, A", _id: "0") {
       title
       year
     }
@@ -397,7 +397,7 @@ test('Query for Neo4js internal _id and another param before _id', t => {
 
 test('Query for Neo4js internal _id and another param after _id', t => {
   const graphQLQuery = `{
-    Movie(_id: 0, year: 2010) {
+    Movie(_id: "0", year: 2010) {
       title
       year
     }
@@ -416,9 +416,9 @@ test('Query for Neo4js internal _id and another param after _id', t => {
   ]);
 });
 
-test('Query for Neo4js internal _id by dedicated Query MovieBy_Id(_id: Int!)', t => {
+test('Query for Neo4js internal _id by dedicated Query MovieBy_Id(_id: String!)', t => {
   const graphQLQuery = `{
-    MovieBy_Id(_id: 0) {
+    MovieBy_Id(_id: "0") {
       title
       year
     }
@@ -457,7 +457,7 @@ test(`Query for null value translates to 'IS NULL' WHERE clause`, t => {
 
 test(`Query for null value combined with internal ID and another param`, t => {
   const graphQLQuery = `{
-      Movie(poster: null, _id: 0, year: 2010) {
+      Movie(poster: null, _id: "0", year: 2010) {
         title
         year
       }

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -1,5 +1,5 @@
 export const testSchema = `type Movie {
-  _id: ID
+  _id: String
   movieId: ID!
   title: String
   year: Int
@@ -21,7 +21,7 @@ export const testSchema = `type Movie {
 }
 
 type Genre {
-  _id: ID!
+  _id: String!
   name: String
   movies(first: Int = 3, offset: Int = 0): [Movie] @relation(name: "IN_GENRE", direction: "IN")
   highestRatedMovie: Movie @cypher(statement: "MATCH (m:Movie)-[:IN_GENRE]->(this) RETURN m ORDER BY m.imdbRating DESC LIMIT 1")
@@ -82,10 +82,10 @@ enum _GenreOrdering {
 }
 
 type Query {
-  Movie(_id: Int, movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float, first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
+  Movie(_id: String, movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float, first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
   MoviesByYear(year: Int): [Movie]
   MovieById(movieId: ID!): Movie
-  MovieBy_Id(_id: Int!): Movie
+  MovieBy_Id(_id: String!): Movie
   GenresBySubstring(substring: String): [Genre] @cypher(statement: "MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g")
   Books: [Book]
 }


### PR DESCRIPTION
Upon upgrading to GraphQL v14, any return of an `_id` field resulted in an error of the format "Int cannot represent non-integer value: { low: 1, high: 0 }”. In order to resolve this, resources from `neo4j-driver` are now used for reading Integers. In all cases, `_id` fields are now converted to type `String`.