### PR TITLE
Fix error in extractTypeMapFromTypeDefs

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -798,7 +798,7 @@ export const extractTypeMapFromTypeDefs = typeDefs => {
   // into a single string for parse, add validatation
   const astNodes = parse(typeDefs).definitions;
   return astNodes.reduce((acc, t) => {
-    acc[t.name.value] = t;
+    if (t.name) acc[t.name.value] = t;
     return acc;
   }, {});
 };


### PR DESCRIPTION
Error: `TypeError: Cannot read property 'value' of undefined` when `t` is `{ kind: 'SchemaDefinition', ... }` because apparently `SchemaDefinition` has no `name`.

Admittedly, I'm not exactly sure why this fails for me, assuming it's working for others; I don't have time at the moment to dig deeper than this, but it seems like a simple enough fix. Cheers!