### PR TITLE
Fix for #169

### DIFF
--- a/src/augment.js
+++ b/src/augment.js
@@ -154,10 +154,14 @@ const augmentQueryArguments = (typeMap, config, queryType) => {
   return typeMap;
 };
 
-export const augmentResolvers = (augmentedTypeMap, resolvers) => {
+export const augmentResolvers = (augmentedTypeMap, resolvers, config) => {
   let queryResolvers = resolvers && resolvers.Query ? resolvers.Query : {};
   const generatedQueryMap = createOperationMap(augmentedTypeMap.Query);
-  queryResolvers = possiblyAddResolvers(generatedQueryMap, queryResolvers);
+  queryResolvers = possiblyAddResolvers(
+    generatedQueryMap,
+    queryResolvers,
+    config
+  );
   if (Object.keys(queryResolvers).length > 0) {
     resolvers.Query = queryResolvers;
   }
@@ -166,7 +170,8 @@ export const augmentResolvers = (augmentedTypeMap, resolvers) => {
   const generatedMutationMap = createOperationMap(augmentedTypeMap.Mutation);
   mutationResolvers = possiblyAddResolvers(
     generatedMutationMap,
-    mutationResolvers
+    mutationResolvers,
+    config
   );
   if (Object.keys(mutationResolvers).length > 0) {
     resolvers.Mutation = mutationResolvers;
@@ -210,13 +215,15 @@ export const possiblyAddArgument = (args, fieldName, fieldType) => {
   return args;
 };
 
-const possiblyAddResolvers = (operationTypeMap, resolvers) => {
+const possiblyAddResolvers = (operationTypeMap, resolvers, config) => {
   let operationName = '';
   return Object.keys(operationTypeMap).reduce((acc, t) => {
     // if no resolver provided for this operation type field
     operationName = operationTypeMap[t].name.value;
     if (acc[operationName] === undefined) {
-      acc[operationName] = neo4jgraphql;
+      acc[operationName] = function(...args) {
+        return neo4jgraphql(...args, config.debug);
+      };
     }
     return acc;
   }, resolvers);

--- a/src/augmentSchema.js
+++ b/src/augmentSchema.js
@@ -10,7 +10,7 @@ import {
 
 export const augmentedSchema = (typeMap, resolvers, config) => {
   const augmentedTypeMap = augmentTypeMap(typeMap, config);
-  const augmentedResolvers = augmentResolvers(augmentedTypeMap, resolvers);
+  const augmentedResolvers = augmentResolvers(augmentedTypeMap, resolvers, config);
   return makeExecutableSchema({
     typeDefs: printTypeMap(augmentedTypeMap),
     resolvers: augmentedResolvers,
@@ -34,7 +34,7 @@ export const makeAugmentedExecutableSchema = ({
 }) => {
   const typeMap = extractTypeMapFromTypeDefs(typeDefs);
   const augmentedTypeMap = augmentTypeMap(typeMap, config);
-  const augmentedResolvers = augmentResolvers(augmentedTypeMap, resolvers);
+  const augmentedResolvers = augmentResolvers(augmentedTypeMap, resolvers, config);
   resolverValidationOptions.requireResolversForResolveType = false;
   return makeExecutableSchema({
     typeDefs: printTypeMap(augmentedTypeMap),

--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,12 @@ export function cypherMutation(
   });
 }
 
-export const augmentSchema = (schema, config) => {
+export const augmentSchema = (schema, config = {
+  query: true,
+  mutation: true,
+  temporal: true,
+  debug: true
+}) => {
   const typeMap = extractTypeMapFromSchema(schema);
   const resolvers = extractResolversFromSchema(schema);
   return augmentedSchema(typeMap, resolvers, config);
@@ -118,7 +123,8 @@ export const makeAugmentedSchema = ({
   config = {
     query: true,
     mutation: true,
-    temporal: true
+    temporal: true,
+    debug: true
   }
 }) => {
   if (schema) {


### PR DESCRIPTION
This PR contains a fix for #169, adding a `debug` argument to the `config` object used by `makeAugmentedSchema` and `augmentSchema` as shown below: 

```
const augmentedSchema = makeAugmentedSchema({
  typeDefs,
  config: {
    debug: false
  }
});
```