### PR TITLE
Support arrays of orderBy arguments

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -88,8 +88,9 @@ export const relationFieldOnNodeType = ({
   tailParams,
   temporalClauses
 }) => {
-  const arrayFilterParams = _.pickBy(filterParams, param =>
-    Array.isArray(param.value)
+  const arrayFilterParams = _.pickBy(
+    filterParams,
+    (param, keyName) => Array.isArray(param.value) && !('orderBy' === keyName)
   );
 
   const allParams = innerFilterParams(filterParams, temporalArgs);


### PR DESCRIPTION
This allows us to support orderBy arguments passed as arrays. For example:

```cypher
{
  Repo (orderBy : [name_desc,owner_asc]) {
    name
  }
}
```

This brings the functionality inline with the plugin which auto-generates this as an array.

One extra issue I have noticed though is that neo4j-graphql-js doesn't support using orderBy on anything but the top level element of the graphql query. I looked at adding this myself but as the generated cypher uses pattern comprehensions which don't seem to support `order by` I'm not sure how this would be possible right now. I'd love some guidance here though as this is a bit of an issue for us.

Please let me know if there is anything else I can add here or to the above issue.

Thanks for the project!
Ben at Atomist