### PR TITLE
Nested ordering, temporal / enum ordering, large schemas

### DIFF
--- a/src/selections.js
+++ b/src/selections.js
@@ -227,7 +227,9 @@ export function buildCypherSelection({
       fieldName,
       schemaType,
       variableName,
-      fieldType
+      fieldType,
+      filterParams,
+      selections
     },
     secondParentSelectionInfo: parentSelectionInfo
   });
@@ -283,6 +285,8 @@ export function buildCypherSelection({
     selection = recurse(
       relationFieldOnNodeType({
         ...fieldInfo,
+        schemaType,
+        selections,
         relDirection,
         relType,
         isInlineFragment,

--- a/test/augmentSchemaTest.js
+++ b/test/augmentSchemaTest.js
@@ -99,6 +99,8 @@ input _BookInput {
 }
 
 enum _BookOrdering {
+  genre_asc
+  genre_desc
   _id_asc
   _id_desc
 }
@@ -330,8 +332,18 @@ input _TemporalNodeInput {
 }
 
 enum _TemporalNodeOrdering {
+  datetime_asc
+  datetime_desc
   name_asc
   name_desc
+  time_asc
+  time_desc
+  date_asc
+  date_desc
+  localtime_asc
+  localtime_desc
+  localdatetime_asc
+  localdatetime_desc
   _id_asc
   _id_desc
 }
@@ -380,7 +392,7 @@ type _UserRated {
 type Actor implements Person {
   userId: ID!
   name: String
-  movies(first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
+  movies(first: Int, offset: Int, orderBy: [_MovieOrdering]): [Movie]
   _id: String
 }
 
@@ -414,7 +426,7 @@ type FriendOf {
 type Genre {
   _id: String
   name: String
-  movies(first: Int = 3, offset: Int = 0, orderBy: _MovieOrdering): [Movie]
+  movies(first: Int = 3, offset: Int = 0, orderBy: [_MovieOrdering]): [Movie]
   highestRatedMovie: Movie
 }
 
@@ -435,16 +447,16 @@ type Movie {
   plot: String
   poster: String
   imdbRating: Float
-  genres(first: Int, offset: Int, orderBy: _GenreOrdering): [Genre]
-  similar(first: Int = 3, offset: Int = 0, orderBy: _MovieOrdering): [Movie]
+  genres(first: Int, offset: Int, orderBy: [_GenreOrdering]): [Genre]
+  similar(first: Int = 3, offset: Int = 0, orderBy: [_MovieOrdering]): [Movie]
   mostSimilar: Movie
   degree: Int
-  actors(first: Int = 3, offset: Int = 0, name: String, names: [String], orderBy: _ActorOrdering): [Actor]
+  actors(first: Int = 3, offset: Int = 0, name: String, names: [String], orderBy: [_ActorOrdering]): [Actor]
   avgStars: Float
   filmedIn: State
   scaleRating(scale: Int = 3): Float
   scaleRatingFloat(scale: Float = 1.5): Float
-  actorMovies(first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
+  actorMovies(first: Int, offset: Int, orderBy: [_MovieOrdering]): [Movie]
   ratings(rating: Int, time: _Neo4jTimeInput, date: _Neo4jDateInput, datetime: _Neo4jDateTimeInput, localtime: _Neo4jLocalTimeInput, localdatetime: _Neo4jLocalDateTimeInput): [_MovieRatings]
   years: [Int]
   titles: [String]
@@ -486,7 +498,7 @@ type Mutation {
   CreateBook(genre: BookGenre): Book
   DeleteBook(genre: BookGenre!): Book
   CreateTemporalNode(datetime: _Neo4jDateTimeInput, name: String, time: _Neo4jTimeInput, date: _Neo4jDateInput, localtime: _Neo4jLocalTimeInput, localdatetime: _Neo4jLocalDateTimeInput, localdatetimes: [_Neo4jLocalDateTimeInput]): TemporalNode
-  UpdateTemporalNode(datetime: _Neo4jDateTimeInput, name: String, time: _Neo4jTimeInput, date: _Neo4jDateInput, localtime: _Neo4jLocalTimeInput, localdatetime: _Neo4jLocalDateTimeInput, localdatetimes: [_Neo4jLocalDateTimeInput]): TemporalNode
+  UpdateTemporalNode(datetime: _Neo4jDateTimeInput!, name: String, time: _Neo4jTimeInput, date: _Neo4jDateInput, localtime: _Neo4jLocalTimeInput, localdatetime: _Neo4jLocalDateTimeInput, localdatetimes: [_Neo4jLocalDateTimeInput]): TemporalNode
   DeleteTemporalNode(datetime: _Neo4jDateTimeInput!): TemporalNode
   AddTemporalNodeTemporalNodes(from: _TemporalNodeInput!, to: _TemporalNodeInput!): _AddTemporalNodeTemporalNodesPayload
   RemoveTemporalNodeTemporalNodes(from: _TemporalNodeInput!, to: _TemporalNodeInput!): _RemoveTemporalNodeTemporalNodesPayload
@@ -498,19 +510,19 @@ interface Person {
 }
 
 type Query {
-  Movie(_id: String, movieId: ID, title: String, year: Int, released: _Neo4jDateTimeInput, plot: String, poster: String, imdbRating: Float, first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
-  MoviesByYear(year: Int, first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
-  MoviesByYears(year: [Int], first: Int, offset: Int, orderBy: _MovieOrdering): [Movie]
+  Movie(_id: String, movieId: ID, title: String, year: Int, released: _Neo4jDateTimeInput, plot: String, poster: String, imdbRating: Float, first: Int, offset: Int, orderBy: [_MovieOrdering]): [Movie]
+  MoviesByYear(year: Int, first: Int, offset: Int, orderBy: [_MovieOrdering]): [Movie]
+  MoviesByYears(year: [Int], first: Int, offset: Int, orderBy: [_MovieOrdering]): [Movie]
   MovieById(movieId: ID!): Movie
   MovieBy_Id(_id: String!): Movie
-  GenresBySubstring(substring: String, first: Int, offset: Int, orderBy: _GenreOrdering): [Genre]
-  State(first: Int, offset: Int, orderBy: _StateOrdering): [State]
-  Books(first: Int, offset: Int, orderBy: _BookOrdering): [Book]
-  Genre(_id: String, name: String, first: Int, offset: Int, orderBy: _GenreOrdering): [Genre]
-  Actor(userId: ID, name: String, _id: String, first: Int, offset: Int, orderBy: _ActorOrdering): [Actor]
-  User(userId: ID, name: String, _id: String, first: Int, offset: Int, orderBy: _UserOrdering): [User]
-  Book(genre: BookGenre, _id: String, first: Int, offset: Int, orderBy: _BookOrdering): [Book]
-  TemporalNode(datetime: _Neo4jDateTimeInput, name: String, time: _Neo4jTimeInput, date: _Neo4jDateInput, localtime: _Neo4jLocalTimeInput, localdatetime: _Neo4jLocalDateTimeInput, localdatetimes: _Neo4jLocalDateTimeInput, _id: String, first: Int, offset: Int, orderBy: _TemporalNodeOrdering): [TemporalNode]
+  GenresBySubstring(substring: String, first: Int, offset: Int, orderBy: [_GenreOrdering]): [Genre]
+  State(first: Int, offset: Int, orderBy: [_StateOrdering]): [State]
+  Books(first: Int, offset: Int, orderBy: [_BookOrdering]): [Book]
+  Genre(_id: String, name: String, first: Int, offset: Int, orderBy: [_GenreOrdering]): [Genre]
+  Actor(userId: ID, name: String, _id: String, first: Int, offset: Int, orderBy: [_ActorOrdering]): [Actor]
+  User(userId: ID, name: String, _id: String, first: Int, offset: Int, orderBy: [_UserOrdering]): [User]
+  Book(genre: BookGenre, _id: String, first: Int, offset: Int, orderBy: [_BookOrdering]): [Book]
+  TemporalNode(datetime: _Neo4jDateTimeInput, name: String, time: _Neo4jTimeInput, date: _Neo4jDateInput, localtime: _Neo4jLocalTimeInput, localdatetime: _Neo4jLocalDateTimeInput, localdatetimes: _Neo4jLocalDateTimeInput, _id: String, first: Int, offset: Int, orderBy: [_TemporalNodeOrdering]): [TemporalNode]
 }
 
 type Rated {
@@ -540,7 +552,7 @@ type TemporalNode {
   localtime: _Neo4jLocalTime
   localdatetime: _Neo4jLocalDateTime
   localdatetimes: [_Neo4jLocalDateTime]
-  temporalNodes(time: _Neo4jTimeInput, date: _Neo4jDateInput, datetime: _Neo4jDateTimeInput, localtime: _Neo4jLocalTimeInput, localdatetime: _Neo4jLocalDateTimeInput, first: Int, offset: Int, orderBy: _TemporalNodeOrdering): [TemporalNode]
+  temporalNodes(time: _Neo4jTimeInput, date: _Neo4jDateInput, datetime: _Neo4jDateTimeInput, localtime: _Neo4jLocalTimeInput, localdatetime: _Neo4jLocalDateTimeInput, first: Int, offset: Int, orderBy: [_TemporalNodeOrdering]): [TemporalNode]
   _id: String
 }
 

--- a/test/configTest.js
+++ b/test/configTest.js
@@ -146,7 +146,7 @@ test.cb(
 
     const queryType = `
 type Query {
-  Tweet(id: ID, timestamp: _Neo4jDateTimeInput, text: String, _id: String, first: Int, offset: Int, orderBy: _TweetOrdering): [Tweet]
+  Tweet(id: ID, timestamp: _Neo4jDateTimeInput, text: String, _id: String, first: Int, offset: Int, orderBy: [_TweetOrdering]): [Tweet]
 }
 `;
 
@@ -168,7 +168,7 @@ test.cb('Config - augmentSchema - specify types to exclude for query', t => {
 
   const queryType = `
 type Query {
-  Tweet(id: ID, timestamp: _Neo4jDateTimeInput, text: String, _id: String, first: Int, offset: Int, orderBy: _TweetOrdering): [Tweet]
+  Tweet(id: ID, timestamp: _Neo4jDateTimeInput, text: String, _id: String, first: Int, offset: Int, orderBy: [_TweetOrdering]): [Tweet]
 }
 `;
 

--- a/test/cypherTest.js
+++ b/test/cypherTest.js
@@ -2026,7 +2026,7 @@ test('Update temporal and non-temporal properties on node using temporal propert
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`temporalNode\`:\`TemporalNode\`) WHERE \`temporalNode\`.datetime.year = $params.datetime.year AND \`temporalNode\`.datetime.month = $params.datetime.month AND \`temporalNode\`.datetime.day = $params.datetime.day AND \`temporalNode\`.datetime.hour = $params.datetime.hour AND \`temporalNode\`.datetime.minute = $params.datetime.minute AND \`temporalNode\`.datetime.second = $params.datetime.second AND \`temporalNode\`.datetime.millisecond = $params.datetime.millisecond AND \`temporalNode\`.datetime.microsecond = $params.datetime.microsecond AND \`temporalNode\`.datetime.nanosecond = $params.datetime.nanosecond AND \`temporalNode\`.datetime.timezone = $params.datetime.timezone AND \`temporalNode\`.datetime.year = $params.datetime.year AND \`temporalNode\`.datetime.month = $params.datetime.month AND \`temporalNode\`.datetime.day = $params.datetime.day AND \`temporalNode\`.datetime.hour = $params.datetime.hour AND \`temporalNode\`.datetime.minute = $params.datetime.minute AND \`temporalNode\`.datetime.second = $params.datetime.second AND \`temporalNode\`.datetime.millisecond = $params.datetime.millisecond AND \`temporalNode\`.datetime.microsecond = $params.datetime.microsecond AND \`temporalNode\`.datetime.nanosecond = $params.datetime.nanosecond AND \`temporalNode\`.datetime.timezone = $params.datetime.timezone  
+    expectedCypherQuery = `MATCH (\`temporalNode\`:\`TemporalNode\`) WHERE \`temporalNode\`.datetime.year = $params.datetime.year AND \`temporalNode\`.datetime.month = $params.datetime.month AND \`temporalNode\`.datetime.day = $params.datetime.day AND \`temporalNode\`.datetime.hour = $params.datetime.hour AND \`temporalNode\`.datetime.minute = $params.datetime.minute AND \`temporalNode\`.datetime.second = $params.datetime.second AND \`temporalNode\`.datetime.millisecond = $params.datetime.millisecond AND \`temporalNode\`.datetime.microsecond = $params.datetime.microsecond AND \`temporalNode\`.datetime.nanosecond = $params.datetime.nanosecond AND \`temporalNode\`.datetime.timezone = $params.datetime.timezone  
   SET \`temporalNode\` += {name:$params.name,localdatetime: localdatetime($params.localdatetime)} RETURN \`temporalNode\` {_id: ID(\`temporalNode\`), .name ,time: { hour: \`temporalNode\`.time.hour , minute: \`temporalNode\`.time.minute , second: \`temporalNode\`.time.second , millisecond: \`temporalNode\`.time.millisecond , microsecond: \`temporalNode\`.time.microsecond , nanosecond: \`temporalNode\`.time.nanosecond , timezone: \`temporalNode\`.time.timezone , formatted: toString(\`temporalNode\`.time) },date: { year: \`temporalNode\`.date.year , month: \`temporalNode\`.date.month , day: \`temporalNode\`.date.day , formatted: toString(\`temporalNode\`.date) },datetime: { year: \`temporalNode\`.datetime.year , month: \`temporalNode\`.datetime.month , day: \`temporalNode\`.datetime.day , hour: \`temporalNode\`.datetime.hour , minute: \`temporalNode\`.datetime.minute , second: \`temporalNode\`.datetime.second , millisecond: \`temporalNode\`.datetime.millisecond , microsecond: \`temporalNode\`.datetime.microsecond , nanosecond: \`temporalNode\`.datetime.nanosecond , timezone: \`temporalNode\`.datetime.timezone , formatted: toString(\`temporalNode\`.datetime) },localtime: { hour: \`temporalNode\`.localtime.hour , minute: \`temporalNode\`.localtime.minute , second: \`temporalNode\`.localtime.second , millisecond: \`temporalNode\`.localtime.millisecond , microsecond: \`temporalNode\`.localtime.microsecond , nanosecond: \`temporalNode\`.localtime.nanosecond , formatted: toString(\`temporalNode\`.localtime) },localdatetime: { year: \`temporalNode\`.localdatetime.year , month: \`temporalNode\`.localdatetime.month , day: \`temporalNode\`.localdatetime.day , hour: \`temporalNode\`.localdatetime.hour , minute: \`temporalNode\`.localdatetime.minute , second: \`temporalNode\`.localdatetime.second , millisecond: \`temporalNode\`.localdatetime.millisecond , microsecond: \`temporalNode\`.localdatetime.microsecond , nanosecond: \`temporalNode\`.localdatetime.nanosecond , formatted: toString(\`temporalNode\`.localdatetime) }} AS \`temporalNode\``;
 
   t.plan(1);
@@ -2080,7 +2080,7 @@ test('Update temporal list property on node using temporal property node selecti
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`temporalNode\`:\`TemporalNode\`) WHERE \`temporalNode\`.datetime.year = $params.datetime.year AND \`temporalNode\`.datetime.month = $params.datetime.month AND \`temporalNode\`.datetime.day = $params.datetime.day AND \`temporalNode\`.datetime.hour = $params.datetime.hour AND \`temporalNode\`.datetime.minute = $params.datetime.minute AND \`temporalNode\`.datetime.second = $params.datetime.second AND \`temporalNode\`.datetime.millisecond = $params.datetime.millisecond AND \`temporalNode\`.datetime.microsecond = $params.datetime.microsecond AND \`temporalNode\`.datetime.nanosecond = $params.datetime.nanosecond AND \`temporalNode\`.datetime.timezone = $params.datetime.timezone AND \`temporalNode\`.datetime.year = $params.datetime.year AND \`temporalNode\`.datetime.month = $params.datetime.month AND \`temporalNode\`.datetime.day = $params.datetime.day AND \`temporalNode\`.datetime.hour = $params.datetime.hour AND \`temporalNode\`.datetime.minute = $params.datetime.minute AND \`temporalNode\`.datetime.second = $params.datetime.second AND \`temporalNode\`.datetime.millisecond = $params.datetime.millisecond AND \`temporalNode\`.datetime.microsecond = $params.datetime.microsecond AND \`temporalNode\`.datetime.nanosecond = $params.datetime.nanosecond AND \`temporalNode\`.datetime.timezone = $params.datetime.timezone  
+    expectedCypherQuery = `MATCH (\`temporalNode\`:\`TemporalNode\`) WHERE \`temporalNode\`.datetime.year = $params.datetime.year AND \`temporalNode\`.datetime.month = $params.datetime.month AND \`temporalNode\`.datetime.day = $params.datetime.day AND \`temporalNode\`.datetime.hour = $params.datetime.hour AND \`temporalNode\`.datetime.minute = $params.datetime.minute AND \`temporalNode\`.datetime.second = $params.datetime.second AND \`temporalNode\`.datetime.millisecond = $params.datetime.millisecond AND \`temporalNode\`.datetime.microsecond = $params.datetime.microsecond AND \`temporalNode\`.datetime.nanosecond = $params.datetime.nanosecond AND \`temporalNode\`.datetime.timezone = $params.datetime.timezone  
   SET \`temporalNode\` += {localdatetimes: [value IN $params.localdatetimes | localdatetime(value)]} RETURN \`temporalNode\` {_id: ID(\`temporalNode\`), .name ,localdatetimes: reduce(a = [], TEMPORAL_INSTANCE IN temporalNode.localdatetimes | a + { year: TEMPORAL_INSTANCE.year , month: TEMPORAL_INSTANCE.month , day: TEMPORAL_INSTANCE.day , hour: TEMPORAL_INSTANCE.hour , minute: TEMPORAL_INSTANCE.minute , second: TEMPORAL_INSTANCE.second , millisecond: TEMPORAL_INSTANCE.millisecond , microsecond: TEMPORAL_INSTANCE.microsecond , nanosecond: TEMPORAL_INSTANCE.nanosecond , formatted: toString(TEMPORAL_INSTANCE) })} AS \`temporalNode\``;
 
   t.plan(1);
@@ -3773,6 +3773,115 @@ test('Query nested node with ignored field (inferred from resolver)', t => {
     }
   }`,
     expectedCypherQuery = `MATCH (\`movie\`:\`Movie\` ) RETURN \`movie\` {filmedIn: head([(\`movie\`)-[:\`FILMED_IN\`]->(\`movie_filmedIn\`:\`State\`) | movie_filmedIn { .name }]) } AS \`movie\` SKIP $offset`;
+
+  t.plan(1);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('Deeply nested orderBy', t => {
+  const graphQLQuery = `query {
+    Movie(orderBy:title_desc) {
+      title
+      actors(orderBy:name_desc) {
+        name
+        movies(orderBy:[title_asc, title_desc]) {
+          title
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = "MATCH (`movie`:`Movie` ) RETURN `movie` { .title ,actors: apoc.coll.sortMulti([(`movie`)<-[:`ACTED_IN`]-(`movie_actors`:`Actor`) | movie_actors { .name ,movies: apoc.coll.sortMulti([(`movie_actors`)-[:`ACTED_IN`]->(`movie_actors_movies`:`Movie`) | movie_actors_movies { .title }], ['^title','title']) }], ['name']) } AS `movie` ORDER BY movie.title DESC  SKIP $offset";
+
+  t.plan(1);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('Query using enum orderBy', t => {
+  const graphQLQuery = `query {
+    Book(orderBy: [genre_asc]) {
+      _id
+      genre
+    }
+  }`,
+    expectedCypherQuery = "MATCH (`book`:`Book` ) RETURN `book` {_id: ID(`book`), .genre } AS `book` ORDER BY book.genre ASC  SKIP $offset";
+
+  t.plan(1);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('Query using temporal orderBy', t => {
+  const graphQLQuery = `query {
+    TemporalNode(
+      orderBy: [datetime_desc, datetime_asc]
+    ) {
+      datetime {
+        formatted
+      }
+    }
+  }`,
+    expectedCypherQuery = "MATCH (\`temporalNode\`:\`TemporalNode\` ) RETURN \`temporalNode\` {datetime: { formatted: toString(\`temporalNode\`.datetime) }} AS \`temporalNode\` ORDER BY temporalNode.datetime DESC , temporalNode.datetime ASC  SKIP $offset";
+
+  t.plan(1);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('Deeply nested query using temporal orderBy', t => {
+  const graphQLQuery = `query {
+    TemporalNode(orderBy: [datetime_desc]) {
+      _id
+      datetime {
+        year
+        month
+        day
+        hour
+        minute
+        second
+        millisecond
+        microsecond
+        nanosecond
+        timezone
+        formatted
+      }
+      temporalNodes(orderBy: datetime_asc) {
+        _id
+        datetime {
+          year
+          month
+          day
+          hour
+          minute
+          second
+          millisecond
+          microsecond
+          nanosecond
+          timezone
+          formatted
+        }
+        time {
+          hour
+        }
+        temporalNodes(first: 2, offset: 1, orderBy: [datetime_desc, time_desc]) {
+          _id
+          datetime {
+            year
+            formatted
+          }
+          time {
+            hour
+          }
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = "MATCH (`temporalNode`:`TemporalNode` ) RETURN `temporalNode` {_id: ID(`temporalNode`),datetime: { year: `temporalNode`.datetime.year , month: `temporalNode`.datetime.month , day: `temporalNode`.datetime.day , hour: `temporalNode`.datetime.hour , minute: `temporalNode`.datetime.minute , second: `temporalNode`.datetime.second , millisecond: `temporalNode`.datetime.millisecond , microsecond: `temporalNode`.datetime.microsecond , nanosecond: `temporalNode`.datetime.nanosecond , timezone: `temporalNode`.datetime.timezone , formatted: toString(`temporalNode`.datetime) },temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | temporalNode_temporalNodes {_id: ID(`temporalNode_temporalNodes`),datetime: `temporalNode_temporalNodes`.datetime,time: `temporalNode_temporalNodes`.time,temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode_temporalNodes`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes_temporalNodes`:`TemporalNode`) | temporalNode_temporalNodes_temporalNodes {_id: ID(`temporalNode_temporalNodes_temporalNodes`),datetime: `temporalNode_temporalNodes_temporalNodes`.datetime,time: `temporalNode_temporalNodes_temporalNodes`.time}], ['datetime','time']) | sortedElement { .*,  datetime: {year: sortedElement.datetime.year,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}][1..3] }], ['^datetime']) | sortedElement { .*,  datetime: {year: sortedElement.datetime.year,month: sortedElement.datetime.month,day: sortedElement.datetime.day,hour: sortedElement.datetime.hour,minute: sortedElement.datetime.minute,second: sortedElement.datetime.second,millisecond: sortedElement.datetime.millisecond,microsecond: sortedElement.datetime.microsecond,nanosecond: sortedElement.datetime.nanosecond,timezone: sortedElement.datetime.timezone,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}] } AS `temporalNode` ORDER BY temporalNode.datetime DESC  SKIP $offset";
 
   t.plan(1);
   return Promise.all([

--- a/test/helpers/cypherTestHelpers.js
+++ b/test/helpers/cypherTestHelpers.js
@@ -179,6 +179,11 @@ export function augmentedSchemaCypherTestRunner(
         t.is(query, expectedCypherQuery);
         t.deepEqual(queryParams, expectedCypherParams);
       },
+      Book(object, params, ctx, resolveInfo) {
+        let [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
+        t.is(query, expectedCypherQuery);
+        t.deepEqual(queryParams, expectedCypherParams);
+      },
       Books(object, params, ctx, resolveInfo) {
         let [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
         t.is(query, expectedCypherQuery);


### PR DESCRIPTION
This PR contains initial support for nested ordering with the use of `apoc.coll.sortMulti`, to handle for providing a list of values for an `orderBy` argument. Enums and temporal types have also been added as valid ordering values.

#### Fixes
##### Ordering
#47 (Nested ordering) Specify ordering
#162 Ordering by temporal type
#168 Enum types not added to orderBy

##### Large Schemas
#172 'Maximum call stack size exceeded' on large schema

##### Other
The `_id` field is no longer added to a type when it is excluded from the generated Query API.

##### Planned
The `first`, `offset`, and `orderBy` arguments can be added to relation type fields during the augmentation process. After which, we can address #173 for ordering by temporal fields on relation types.
