### PR TITLE
Allow interface type to be used when no fragments

### DIFF
--- a/src/selections.js
+++ b/src/selections.js
@@ -141,8 +141,12 @@ export function buildCypherSelection({
     // FIXME: this will only handle the first inline fragment
     const fragment = fragments[0];
 
-    interfaceLabel = fragment.typeCondition.name.value;
-    const implementationName = fragment.typeCondition.name.value;
+    interfaceLabel = fragment
+      ? fragment.typeCondition.name.value
+      : interfaceName;
+    const implementationName = fragment
+      ? fragment.typeCondition.name.value
+      : interfaceName;
 
     const schemaType = resolveInfo.schema._implementations[interfaceName].find(
       intfc => intfc.name === implementationName


### PR DESCRIPTION
This addresses a bug where querying for an interface type without fragments blows up.

I think this is pretty valid - whilst you sometimes want to query with fragments and thus choose one of the implementations of that interface to query I also think it's very valid to query for just the fields on the interface and not choose to extend it to one of the implementations. This does however require that your node has the label of the interface (otherwise there is no label to query on). But that seems pretty reasonable.

Right now I think this is especially important as there seem to be a few other issues around inline fragment support.

I also note there are a few lines of code around these two that don't seem to do anything. Also that `const implementationName` is just a copy of `interfaceLabel` at this point. The const on the line below is also seemingly not used. I decided not to do anything with these as I was a bit unsure if they were part of a plan for further interface support. Hope that's OK!

Let me know if this needs any more work.

Thanks!