### PR TITLE
Fix for input type @cypher argument parameters

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -16,7 +16,7 @@ function parseArg(arg, variableValues) {
       return variableValues[arg.value.name.value];
     }
     case 'ObjectValue': {
-      return parseArgs(arg.value.fields, {});
+      return parseArgs(arg.value.fields, variableValues);
     }
     case 'ListValue': {
       return _.map(arg.value.values, value =>
@@ -160,7 +160,8 @@ export function cypherDirectiveArgs(
     // Use only if default value exists and no value has been provided
     if (defaultArgs[e] !== undefined && queryArgs[e] === undefined) {
       // Values are inlined
-      args.push(`${e}: ${defaultArgs[e]}`);
+      const inlineDefaultValue = JSON.stringify(defaultArgs[e]);
+      args.push(`${e}: ${inlineDefaultValue}`);
     }
   });
   // Add arguments that have provided values

--- a/test/augmentSchemaTest.js
+++ b/test/augmentSchemaTest.js
@@ -634,7 +634,7 @@ scalar Time
 type User implements Person {
   userId: ID!
   name: String
-  currentUserId(strArg: String, strInputArg: strInput): String
+  currentUserId(strArg: String = "Neo4j", strInputArg: strInput): String
   rated(rating: Int, time: _Neo4jTimeInput, date: _Neo4jDateInput, datetime: _Neo4jDateTimeInput, localtime: _Neo4jLocalTimeInput, localdatetime: _Neo4jLocalDateTimeInput): [_UserRated]
   friends: _UserFriendsDirections
   favorites(first: Int, offset: Int, orderBy: [_MovieOrdering]): [Movie]

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -81,7 +81,7 @@ export const testSchema = `
   type User implements Person {
     userId: ID!
     name: String
-    currentUserId(strArg: String, strInputArg: strInput): String
+    currentUserId(strArg: String = "Neo4j", strInputArg: strInput): String
       @cypher(
         statement: "RETURN $cypherParams.currentUserId AS cypherParamsUserId"
       )


### PR DESCRIPTION
This PR contains an additional fix for #136 in order to support providing GraphQL query variables for the individual values of an input type argument on a `@cypher` field.