### PR TITLE
ID bugs

### DIFF
--- a/src/selections.js
+++ b/src/selections.js
@@ -162,7 +162,9 @@ export function buildCypherSelection({
   if (fieldName === '_id') {
     return recurse({
       initial: `${initial}${fieldName}: ID(${safeVar(
-        variableName
+        getRelationTypeDirectiveArgs(schemaTypeAstNode)
+          ? `${variableName}_relation`
+          : variableName
       )})${commaIfTail}`,
       ...tailParams
     });

--- a/src/translate.js
+++ b/src/translate.js
@@ -1027,7 +1027,7 @@ const relationshipCreate = ({
   const fromLabel = safeLabel(fromType);
   const toVariable = safeVar(toVar);
   const toLabel = safeLabel(toType);
-  const relationshipVariable = safeVar(lowercased + '_relation');
+  const relationshipVariable = safeVar(fromVar + '_relation');
   const relationshipLabel = safeLabel(relationshipName);
   const fromTemporalClauses = temporalPredicateClauses(
     preparedParams.from,


### PR DESCRIPTION
Two short fixes for (what I perceive as) bugs related to querying `_id` fields on relation types:

1. The first bug appears when using auto-generated node queries.  Consider a node type that has a field that returns a relation type.  Requesting the ID of that relation will cause an error.  See minimal example in Issue #220 .

2. The second bug appears when using auto-generated Add mutations.  If the client requests the ID of the newly created relation via the return payload, the value returned by the server is not the ID of the relation, but rather the ID of the "from" node.

The first commit fixes the first bug.  Both commits together fix the second bug.