### PR TITLE
Remove spaces from generated scopes

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -96,14 +96,14 @@ export const possiblyAddScopeDirective = ({
         operationType === 'Delete'
       ) {
         return parseDirectiveSdl(
-          `@hasScope(scopes: ["${typeName}: ${operationType}"])`
+          `@hasScope(scopes: ["${typeName}:${operationType}"])`
         );
       }
     }
     if (entityType === 'relation') {
       if (operationType === 'Add') operationType = 'Create';
       else if (operationType === 'Remove') operationType = 'Delete';
-      return `@hasScope(scopes: ["${typeName}: ${operationType}", "${relatedTypeName}: ${operationType}"])`;
+      return `@hasScope(scopes: ["${typeName}:${operationType}", "${relatedTypeName}:${operationType}"])`;
     }
   }
   return undefined;


### PR DESCRIPTION
Generated scopes contain a space in their name. 
By standard scopes are sent to the backend as a space separated list. 
See [RFC 6749](https://tools.ietf.org/html/rfc6749#section-3.3)

This change removes the spaces from generated scopes and allows standard handling by existing libraries.

This breaking change as old scopes would not work anymore.

-----------------

I'm not sure how others handled this I saw some solutions that separate scopes by colons but this would make it standard compatible.