### PR TITLE
Interfaces - Handle multiple fragments.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,7 @@
 {
-  "presets": ["env"],
+  "presets": [
+    "env"
+  ],
   "plugins": [
     "transform-runtime",
     "transform-async-generator-functions",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3668,7 +3668,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3692,13 +3693,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3715,19 +3718,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3858,7 +3864,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3872,6 +3879,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3888,6 +3896,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3896,13 +3905,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3923,6 +3934,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4011,7 +4023,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4025,6 +4038,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4120,7 +4134,8 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4162,6 +4177,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4183,6 +4199,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4231,13 +4248,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5886,9 +5886,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://npm.tools.chatlayer.ai/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -5963,9 +5963,9 @@
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "version": "4.6.2",
+      "resolved": "https://npm.tools.chatlayer.ai/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.once": {
@@ -6309,9 +6309,9 @@
       "dev": true
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://npm.tools.chatlayer.ai/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -6320,7 +6320,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://npm.tools.chatlayer.ai/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
@@ -9272,9 +9272,9 @@
       }
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://npm.tools.chatlayer.ai/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -9285,7 +9285,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://npm.tools.chatlayer.ai/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -9994,38 +9994,15 @@
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://npm.tools.chatlayer.ai/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "graphql": "^14.2.1",
     "graphql-auth-directives": "^2.1.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "neo4j-driver": "^1.7.3"
   },
   "prettier": {

--- a/src/selections.js
+++ b/src/selections.js
@@ -80,10 +80,6 @@ export function buildCypherSelection({
   };
 
   let fieldName;
-  const isInlineFragment =
-    innerSchemaType &&
-    innerSchemaType.astNode &&
-    innerSchemaType.astNode.kind === 'InterfaceTypeDefinition';
   if (headSelection) {
     if (headSelection.kind === 'InlineFragment') {
       // get selections for the fragment and recurse on those
@@ -126,8 +122,11 @@ export function buildCypherSelection({
     schemaTypeField && schemaTypeField.type ? schemaTypeField.type : {};
   const innerSchemaType = innerType(fieldType); // for target "type" aka label
 
+  const isInlineFragment =
+    innerSchemaType &&
+    innerSchemaType.astNode &&
+    innerSchemaType.astNode.kind === 'InterfaceTypeDefinition';
   const { statement: customCypher } = cypherDirective(schemaType, fieldName);
-
   const typeMap = resolveInfo.schema.getTypeMap();
   const schemaTypeAstNode = typeMap[schemaType].astNode;
 

--- a/src/selections.js
+++ b/src/selections.js
@@ -39,9 +39,7 @@ export function buildCypherSelection({
   parentSelectionInfo = {},
   secondParentSelectionInfo = {}
 }) {
-  if (!selections.length) {
-    return [initial, {}];
-  }
+  if (!selections.length) return [initial, {}];
   selections = removeIgnoredFields(schemaType, selections);
   let selectionFilters = filtersFromSelections(
     selections,
@@ -84,10 +82,13 @@ export function buildCypherSelection({
     if (headSelection.kind === 'InlineFragment') {
       // get selections for the fragment and recurse on those
       const fragmentSelections = headSelection.selectionSet.selections;
+      const fragmentSchemaType = resolveInfo.schema.getType(
+        headSelection.typeCondition.name.value
+      );
       let fragmentTailParams = {
         selections: fragmentSelections,
         variableName,
-        schemaType,
+        schemaType: fragmentSchemaType,
         resolveInfo,
         parentSelectionInfo,
         secondParentSelectionInfo

--- a/src/selections.js
+++ b/src/selections.js
@@ -98,7 +98,7 @@ export function buildCypherSelection({
           ...fragmentTailParams
         });
         return result;
-      }, initial);
+      }, initial || ['']);
   }
 
   const fieldName = headSelection.name.value;

--- a/src/translate.js
+++ b/src/translate.js
@@ -413,7 +413,7 @@ const directedNodeTypeFieldOnRelationType = ({
           )}:${safeLabel(relType)}${queryParams}]-${
             isToField ? '>' : ''
           }(${safeVar(nestedVariable)}${
-            !isInlineFragment ? `:${safeLabel(innerSchemaType.name)}` : ''
+            !isInlineFragment ? `:${safeLabel(fromTypeName)}` : ''
           }) ${
             whereClauses.length > 0
               ? `WHERE ${whereClauses.join(' AND ')} `
@@ -454,7 +454,7 @@ const directedNodeTypeFieldOnRelationType = ({
           nestedVariable
         )}${
           !isInlineFragment ? `:${safeLabel(innerSchemaType.name)}` : ''
-        }) | ${nestedVariable} {${
+        }${queryParams}) | ${nestedVariable} {${
           isInlineFragment
             ? `FRAGMENT_TYPE: labels(${nestedVariable})[0]${
                 subSelection[0] ? `, ${subSelection[0]}` : ''

--- a/src/translate.js
+++ b/src/translate.js
@@ -690,13 +690,11 @@ const customQuery = ({
 }) => {
   const safeVariableName = safeVar(variableName);
   const [subQuery, subParams] = buildCypherSelection({
-    initial: '',
     cypherParams,
     selections,
     variableName,
     schemaType,
-    resolveInfo,
-    paramIndex: 1
+    resolveInfo
   });
   const params = { ...nonNullParams, ...subParams };
   if (cypherParams) {
@@ -743,7 +741,6 @@ const nodeQuery = ({
   const safeLabelName = safeLabel(typeName);
   const rootParamIndex = 1;
   const [subQuery, subParams] = buildCypherSelection({
-    initial: '',
     cypherParams,
     selections,
     variableName,
@@ -911,12 +908,10 @@ const customMutation = ({
     return x.name.value === 'statement';
   });
   const [subQuery, subParams] = buildCypherSelection({
-    initial: '',
     selections,
     variableName,
     schemaType,
     resolveInfo,
-    paramIndex: 1,
     cypherParams
   });
   const isScalarType = isGraphqlScalarType(schemaType);
@@ -964,12 +959,10 @@ const nodeCreate = ({
     paramKey: 'params'
   });
   const [subQuery, subParams] = buildCypherSelection({
-    initial: ``,
     selections,
     variableName,
     schemaType,
-    resolveInfo,
-    paramIndex: 1
+    resolveInfo
   });
   params = { ...preparedParams, ...subParams };
   const query = `
@@ -1023,12 +1016,10 @@ const nodeUpdate = ({
     query += `SET ${safeVariableName} += {${paramUpdateStatements.join(',')}} `;
   }
   const [subQuery, subParams] = buildCypherSelection({
-    initial: ``,
     selections,
     variableName,
     schemaType,
-    resolveInfo,
-    paramIndex: 1
+    resolveInfo
   });
   preparedParams.params[primaryKeyArgName] = primaryKeyParam[primaryKeyArgName];
   params = { ...preparedParams, ...subParams };
@@ -1063,12 +1054,10 @@ const nodeDelete = ({
       : ` {${primaryKeyArgName}: $${primaryKeyArgName}})`
   }`;
   const [subQuery, subParams] = buildCypherSelection({
-    initial: ``,
     selections,
     variableName,
     schemaType,
-    resolveInfo,
-    paramIndex: 1
+    resolveInfo
   });
   params = { ...preparedParams, ...subParams };
   const deletionVariableName = safeVar(`${variableName}_toDelete`);
@@ -1172,11 +1161,9 @@ const relationshipCreate = ({
     'to'
   );
   const [subQuery, subParams] = buildCypherSelection({
-    initial: '',
     selections,
     schemaType,
     resolveInfo,
-    paramIndex: 1,
     parentSelectionInfo: {
       rootType: 'relationship',
       from: fromVar,
@@ -1291,12 +1278,10 @@ const relationshipDelete = ({
   );
   // TODO cleaner semantics: remove use of _ prefixes in root variableNames and variableName
   const [subQuery, subParams] = buildCypherSelection({
-    initial: '',
     selections,
     variableName,
     schemaType,
     resolveInfo,
-    paramIndex: 1,
     parentSelectionInfo: {
       rootType: 'relationship',
       from: `_${fromVar}`,

--- a/src/translate.js
+++ b/src/translate.js
@@ -412,7 +412,7 @@ const directedNodeTypeFieldOnRelationType = ({
             relationshipVariableName
           )}:${safeLabel(relType)}${queryParams}]-${
             isToField ? '>' : ''
-          }(${safeVar(nestedVariable)}:${
+          }(${safeVar(nestedVariable)}${
             !isInlineFragment ? `:${safeLabel(innerSchemaType.name)}` : ''
           }) ${
             whereClauses.length > 0
@@ -452,7 +452,7 @@ const directedNodeTypeFieldOnRelationType = ({
           isFromField ? '<' : ''
         }-[${safeVar(variableName)}]-${isToField ? '>' : ''}(${safeVar(
           nestedVariable
-        )}:${
+        )}${
           !isInlineFragment ? `:${safeLabel(innerSchemaType.name)}` : ''
         }) | ${nestedVariable} {${
           isInlineFragment

--- a/src/utils.js
+++ b/src/utils.js
@@ -431,6 +431,7 @@ export const possiblySetFirstId = ({ args, statements, params }) => {
 };
 
 export const getQueryArguments = resolveInfo => {
+  if (resolveInfo.fieldName === '_entities') return [];
   return resolveInfo.schema.getQueryType().getFields()[resolveInfo.fieldName]
     .astNode.arguments;
 };
@@ -645,6 +646,7 @@ export const addDirectiveDeclarations = (typeMap, config) => {
 };
 
 export const getQueryCypherDirective = resolveInfo => {
+  if (resolveInfo.fieldName === '_entities') return;
   return resolveInfo.schema
     .getQueryType()
     .getFields()


### PR DESCRIPTION
In this PR I have changed how the fragments are handled a bit.

Instead of relying on the node matching I would match all nodes that are related with the relation you are fetching. And pass the label as a FRAGMENT_TYPE so the default resolver can do the rest.

This will support default interface queries & multiple fragments and will still return the correct type.

However if your graph would contain multiple labels for a node we would have to pass the entire array of labels and check that instead in the default resolver, I didn't do that yet but if core contributors would like to see this "improvement" I can surely add this here.

I'm quite blocked by this PR so it would be great if there is some feedback here that we can solve this issue as fast as possible.

Looking forward to contribute more to this package as we started to rely heavily on neo4j & apollo.