### PR TITLE
POC fixing extend

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "precommit": "lint-staged",
     "prepublish": "npm run build",
     "pretest": "npm run build",
-    "test": "nyc --reporter=lcov ava test/unit/ --verbose",
+    "test": "nyc --reporter=lcov ava test/unit/augmentSchemaTest.test.js --verbose",
     "parse-tck": "babel-node test/helpers/tck/parseTck.js",
     "test-tck": "nyc ava --fail-fast test/tck/",
     "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",

--- a/src/augment.js
+++ b/src/augment.js
@@ -34,7 +34,27 @@ import {
 } from './auth';
 
 export const augmentedSchema = (typeMap, resolvers, config) => {
+  console.log('/***********/');
+  console.log(
+    JSON.stringify(
+      Object.entries(typeMap).map(([name, { kind }]) => `${name}: ${kind}`),
+      null,
+      2
+    )
+  );
+
   const augmentedTypeMap = augmentTypeMap(typeMap, resolvers, config);
+  console.log('/***********/');
+  console.log(
+    JSON.stringify(
+      Object.entries(augmentedTypeMap).map(
+        ([name, { kind }]) => `${name}: ${kind}`
+      ),
+      null,
+      2
+    )
+  );
+
   const augmentedResolvers = augmentResolvers(
     augmentedTypeMap,
     resolvers,
@@ -1346,7 +1366,7 @@ const addRelationTypeDirectives = typeMap => {
           // replace it if it exists in order to force correct configuration
           astNode.directives[typeDirectiveIndex] = parseDirectiveSdl(`
             @relation(
-              name: \"${relationName}\", 
+              name: \"${relationName}\",
               from: \"${fromTypeName}\",
               to: \"${toTypeName}\"
             )
@@ -1355,7 +1375,7 @@ const addRelationTypeDirectives = typeMap => {
           astNode.directives.push(
             parseDirectiveSdl(`
             @relation(
-              name: \"${relationName}\", 
+              name: \"${relationName}\",
               from: \"${fromTypeName}\",
               to: \"${toTypeName}\"
             )
@@ -1563,7 +1583,7 @@ const temporalTypes = (typeMap, types) => {
         millisecond: Int
         microsecond: Int
         nanosecond: Int
-        timezone: String 
+        timezone: String
         formatted: String
       }
     `).definitions[0];

--- a/src/augment.js
+++ b/src/augment.js
@@ -34,17 +34,6 @@ import {
 } from './auth';
 
 export const augmentedSchema = (typeMap, resolvers, config) => {
-  console.log('/***********/');
-  console.log(
-    JSON.stringify(
-      Object.entries(typeMap).map(([name, { kind }]) => `${name}: ${kind}`),
-      null,
-      2
-    )
-  );
-
-  const augmentedTypeMap = augmentTypeMap(typeMap, resolvers, config);
-  console.log('/***********/');
   console.log(
     JSON.stringify(
       Object.entries(augmentedTypeMap).map(

--- a/src/index.js
+++ b/src/index.js
@@ -157,6 +157,14 @@ export const makeAugmentedSchema = ({
 
 export const augmentTypeDefs = (typeDefs, config) => {
   let typeMap = extractTypeMapFromTypeDefs(typeDefs);
+  console.log('/***********/');
+  console.log(
+    JSON.stringify(
+      Object.entries(typeMap).map(([name, { kind }]) => `${name}: ${kind}`),
+      null,
+      2
+    )
+  );
   // overwrites any provided declarations of system directives
   typeMap = addDirectiveDeclarations(typeMap, config);
   // adds managed types; tepmoral, spatial, etc.

--- a/src/utils.js
+++ b/src/utils.js
@@ -83,7 +83,20 @@ export const extractTypeMapFromTypeDefs = typeDefs => {
   // into a single string for parse, add validatation
   const astNodes = parse(typeDefs).definitions;
   return astNodes.reduce((acc, t) => {
-    if (t.name) acc[t.name.value] = t;
+    if (t.name) {
+      if (t.name.value === 'State') {
+        console.log(t);
+      }
+      if (!acc[t.name.value]) {
+        acc[t.name.value] = t;
+      }
+      if (
+        t.kind === 'ObjectTypeExtension' &&
+        acc[t.name.value].kind === 'ObjectTypeDefinition'
+      ) {
+        acc[t.name.value].fields.push(...t.fields);
+      }
+    }
     return acc;
   }, {});
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -84,9 +84,6 @@ export const extractTypeMapFromTypeDefs = typeDefs => {
   const astNodes = parse(typeDefs).definitions;
   return astNodes.reduce((acc, t) => {
     if (t.name) {
-      if (t.name.value === 'State') {
-        console.log(t);
-      }
       if (!acc[t.name.value]) {
         acc[t.name.value] = t;
       }
@@ -95,6 +92,8 @@ export const extractTypeMapFromTypeDefs = typeDefs => {
         acc[t.name.value].kind === 'ObjectTypeDefinition'
       ) {
         acc[t.name.value].fields.push(...t.fields);
+        acc[t.name.value].directives.push(...t.directives);
+        acc[t.name.value].interfaces.push(...t.interfaces);
       }
     }
     return acc;

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -243,8 +243,13 @@ export const testSchema = `
     ): [TemporalNode] @relation(name: "TEMPORAL", direction: OUT)
   }
 
+
   type ignoredType {
     ignoredField: String @neo4j_ignore
+  }
+
+  extend type State {
+    lala: String
   }
 
   scalar Time


### PR DESCRIPTION
Before I start working on fixing tests I thought I'd share this for comment.

The underlying issue is that the library uses a name keyed map of type definitions when beginning its augmentation step. As a type and extensions to it share the same name, the extension definition overwrites the type, and when the schema is finally parsed when being converted into an executable schema the type definition is missing.

The ideal fix would be to refactor the library to not iterate through a data structure keyed by name. The fix in this PR takes the step of merging fields, directives and interfaces defined in extensions with the original list from the definition. I'm guessing this is functionally equivalent to having the extension (`extend` is more of an authoring utility as far as I can see, rather than offering  api capabilities above and beyond using a type definition alone), though am happy to be corrected. Even if it is functionally equivalent, this manipulation of the types does feel a bit dirty.

Let me know what you think @johnymontana 	

Addresses https://github.com/neo4j-graphql/neo4j-graphql-js/issues/208