### PR TITLE
Support for federated schema.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -431,6 +431,7 @@ export const possiblySetFirstId = ({ args, statements, params }) => {
 };
 
 export const getQueryArguments = resolveInfo => {
+  if (resolveInfo.fieldName === '_entities') return [];
   return resolveInfo.schema.getQueryType().getFields()[resolveInfo.fieldName]
     .astNode.arguments;
 };
@@ -645,6 +646,7 @@ export const addDirectiveDeclarations = (typeMap, config) => {
 };
 
 export const getQueryCypherDirective = resolveInfo => {
+  if (resolveInfo.fieldName === '_entities') return;
   return resolveInfo.schema
     .getQueryType()
     .getFields()


### PR DESCRIPTION
This does not make that augmented schema's automaticly support federated schema's.
But then again I don't think anyone who uses augmented schema's will be using federation.

Example usage: 
``` javascript
__resolveReference: async (foo: { id: string }, context, resolveInfo) => {
  resolveInfo.returnType = 'Foo';
  const result = await neo4jgraphql({}, { id: foo.id }, context, resolveInfo);
  return result;
}
```