### PR TITLE
add FRAGMENT_TYPE when customQuery and customMutation resolve interfaces

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -214,6 +214,10 @@ export function isGraphqlScalarType(type) {
   );
 }
 
+export function isGraphqlInterfaceType(type) {
+  return type.constructor.name === 'GraphQLInterfaceType';
+}
+
 export function isArrayType(type) {
   return type ? type.toString().startsWith('[') : false;
 }


### PR DESCRIPTION
Hi there

Currently we have our interfaces accompanied with a `__resolveType` resolver that checks for the FRAGMENT_TYPE field. Currently, when using a custom mutation or query with a cypher, the FRAGMENT_TYPE is not added to the result, whereas when using fragments it is.

This PR solves this inconsistency by adding the first label as the FRAGMENT_TYPE if the schema type is an interface, similar to how fragments are handled.

This is a followup to #270 
