### PR TITLE
Carry non-fragment fields into the result for a fragment

### DIFF
--- a/src/selections.js
+++ b/src/selections.js
@@ -81,7 +81,9 @@ export function buildCypherSelection({
     return selections
       .filter(({ kind }) => kind && kind === 'InlineFragment')
       .reduce((query, selection, index) => {
-        const fragmentSelections = selection.selectionSet.selections;
+        const fragmentSelections = selections
+          .filter(({ kind }) => kind && kind !== 'InlineFragment')
+          .concat(selection.selectionSet.selections);
         const fragmentSchemaType = resolveInfo.schema.getType(
           selection.typeCondition.name.value
         );


### PR DESCRIPTION
A query on an interface that specifies common fields outside the fragment and other fields inside the fragment will fail with an error on the common fields. E.g.
```
query Area {
  Area {
    name
    __typename
    includes{
      name
      ...on Partition {
        resident
      }
    }
  }
}
```
This results in an "unable to resolve field Partition.name" error, while this works.

```
query Area {
  Area {
    name
    __typename
    includes{
      ...on Partition {
        name
        resident
      }
    }
  }
}
```

This fix keeps the common-level fields when processing a fragment