### PR TITLE
Make integration tests atomic

### DIFF
--- a/example/apollo-server/movies-schema.js
+++ b/example/apollo-server/movies-schema.js
@@ -14,7 +14,7 @@ type Movie {
   imdbRating: Float
   ratings: [Rated]
   genres: [Genre] @relation(name: "IN_GENRE", direction: "OUT")
-  similar(first: Int = 3, offset: Int = 0, limit: Int = 5): [Movie] @cypher(statement: "WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o LIMIT {limit}")
+  similar(first: Int = 3, offset: Int = 0, limit: Int = 5): [Movie] @cypher(statement: "WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o ORDER BY o.title LIMIT {limit}")
   mostSimilar: Movie @cypher(statement: "WITH {this} AS this RETURN this")
   degree: Int @cypher(statement: "WITH {this} AS this RETURN SIZE((this)--())")
   actors(first: Int = 3, offset: Int = 0): [Actor] @relation(name: "ACTED_IN", direction:"IN")

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "test-tck": "nyc ava --fail-fast test/tck/*.test.js",
     "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "test-all": "nyc ava --verbose",
-    "test-isolated": "nyc ava test/**/*.test.js --verbose --match='!*not-isolated*'",
     "debug": "nodemon ./example/apollo-server/movies.js --exec babel-node --inspect-brk=9229 --nolazy",
     "debug-typedefs": "nodemon ./example/apollo-server/movies-typedefs.js --exec babel-node --inspect-brk=9229 --nolazy",
     "debug-interface": "nodemon ./example/apollo-server/interfaceError.js --exec babel-node --inspect-brk=9229 --nolazy"

--- a/scripts/install-neo4j.sh
+++ b/scripts/install-neo4j.sh
@@ -8,10 +8,6 @@ if [ ! -d "neo4j/data/databases/graph.db" ]; then
     tar -xzf neo4j-$NEO4J_DIST-$NEO4J_VERSION-unix.tar.gz -C neo4j --strip-components 1
     neo4j/bin/neo4j-admin set-initial-password letmein
     curl -L https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/$APOC_VERSION/apoc-$APOC_VERSION-all.jar > ./neo4j/plugins/apoc-$APOC_VERSION-all.jar
-    wget https://s3.amazonaws.com/neo4j-sandbox-usecase-datastores/v$DATASTORE_VERSION/recommendations.db.zip
-    sudo apt-get install unzip
-    unzip recommendations.db.zip
-    mv recommendations.db neo4j/data/databases/graph.db
 else
     echo "Database is already installed, skipping"
 fi

--- a/scripts/start-neo4j.sh
+++ b/scripts/start-neo4j.sh
@@ -7,6 +7,9 @@ if [ ! -d "neo4j/data/databases/graph.db" ]; then
     exit 1
 else
     echo "dbms.allow_upgrade=true" >> ./neo4j/conf/neo4j.conf
+    echo "dbms.security.procedures.unrestricted=apoc.export.*,apoc.import.*" >> ./neo4j/conf/neo4j.conf
+    echo "apoc.import.file.enabled=true" >> ./neo4j/conf/neo4j.conf
+    echo "apoc.import.file.use_neo4j_config=false" >> ./neo4j/conf/neo4j.conf
     # Set initial and max heap to workaround JVM in docker issues
     dbms_memory_heap_initial_size="2048m" dbms_memory_heap_max_size="2048m" ./neo4j/bin/neo4j start
     echo "Waiting up to 2 minutes for neo4j bolt port ($BOLT_PORT)"

--- a/test/helpers/integrationTestHelpers.js
+++ b/test/helpers/integrationTestHelpers.js
@@ -1,0 +1,25 @@
+import { v1 as neo4j } from 'neo4j-driver';
+import path from 'path';
+
+const driver = neo4j.driver(
+  process.env.NEO4J_URI || 'bolt://localhost:7687',
+  neo4j.auth.basic(
+    process.env.NEO4J_USER || 'neo4j',
+    process.env.NEO4J_PASSWORD || 'letmein'
+  )
+);
+
+export const resetDatabase = async () => {
+  const seedPath = path.resolve(__dirname, '../fixtures/seed.graphml');
+  const session = driver.session();
+  await session.run(`
+    MATCH (n) WHERE n:Actor OR n:Director OR n:Genre OR n:Movie OR n:OnlyDate OR n:User DETACH DELETE n RETURN count(n);
+  `);
+  await session.run(
+    `
+    CALL apoc.import.graphml($seedPath, {batchSize: 10000, storeNodeIds: false, readLabels:true});
+  `,
+    { seedPath }
+  );
+  session.close(() => driver.close());
+};


### PR DESCRIPTION
Addresses #252. Summary of changes:

- Added a .graphml file exported from the current database used for the tests
- Added a `beforeEach` hook to the integration tests that wipes the database and then imports the data from file
- Refactored the integration tests to run atomically. In addition to forcing the tests to run serially, I also moved any required set up (i.e. creating the node being mutated or queried) to inside each test.
- Updated some of the queries in the integration tests to include `orderBy` arguments to ensure the tests are deterministic regardless of internal node id
- Updated the scripts to include some additional lines to neo4j.conf necessary to use `apoc.import.graphml`

Some additional considerations:
- Outside of improving the tests themselves, this also means the tests can be ran multiple times without having to re-import the database. In fact, it's not necessary to import the data at all when setting up the dev environment. Importing the data from the repo is itself a big plus too, especially if the data needs to be changed in the future.
- Running the tests serially slows down the suite considerably, especially with the hook. Ideally we'd be able to run the tests concurrently, but this would require each test to run against its own database instance. Even with this approach, though, I think the benefits outweigh the cost in performance.
- There's some redundancy between the tests with regard to setup. Ideally, we'd move the setup for each test inside a hook but since ava [doesn't support grouping](https://github.com/avajs/ava/issues/222) like mocha or jest, this is a bit tricky to do.
- If the integration tests are broken into multiple files, they will need to be run with the `--serial` flag :(