### PR TITLE
Exclude subscription type when augmenting queries

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1086,6 +1086,10 @@ export const excludeIgnoredTypes = (typeMap, config = {}) => {
   // If .query is an object and .exclude is provided, use it, else use new arr
   let excludedQueries = getExcludedTypes(config, 'query');
   let excludedMutations = getExcludedTypes(config, 'mutation');
+
+  // Exclude `type Subscription`, to prevent it from being misinterpreted as a query type
+  excludedQueries.push('Subscription');
+
   // Add any ignored types to exclusion arrays
   Object.keys(typeMap).forEach(name => {
     if (


### PR DESCRIPTION
Subscriptions are not yet supported, but it is still possible to implement it manually, see https://github.com/neo4j-graphql/neo4j-graphql-js/issues/164#issuecomment-450013413

I tried to do this for a personal project, and was met with the following error message:

```
Error: Unknown type "_SubscriptionFilter". Did you mean "Subscription", "_SubscriptionOrdering", "_UserFilter", "_ShareTokenFilter", or "_SiteInfoFilter"?
    at assertValidSDL (/Users/viktorstrate/Development/photoview/api/node_modules/graphql/validation/validate.js:108:11)
    at Object.buildASTSchema (/Users/viktorstrate/Development/photoview/api/node_modules/graphql/utilities/buildASTSchema.js:71:34)
    at Object.buildSchemaFromTypeDefinitions (/Users/viktorstrate/Development/photoview/api/node_modules/graphql-tools/dist/generate/buildSchemaFromTypeDefinitions.js:23:28)
    at makeExecutableSchema (/Users/viktorstrate/Development/photoview/api/node_modules/graphql-tools/dist/makeExecutableSchema.js:26:29)
    at makeAugmentedExecutableSchema (/Users/viktorstrate/Development/photoview/api/node_modules/neo4j-graphql-js/dist/augment.js:82:49)
    at makeAugmentedSchema (/Users/viktorstrate/Development/photoview/api/node_modules/neo4j-graphql-js/dist/index.js:229:53)
    at Object.<anonymous> (/Users/viktorstrate/Development/photoview/api/build/graphql-schema.js:61:54)
```

The problem is that the `Subscription` type is interpreted by the `augmentResolver` as a generic type, like `Post` in the example below.

```gql
const typeDefs = gql`
  type Subscription {
    postAdded: Post 
  }
  
  type Query {
    posts: [Post]
  }

  type Mutation {
    addPost(author: String, comment: String): Post
  }

  type Post {
    author: String
    comment: String
  }
`
```

A quick fix was to exclude `Subscription` in the config, like so:

```javascript
const schema = makeAugmentedSchema({
  typeDefs,
  config: {
    query: {
      exclude: ['Subscription'],
    },
  },
})
```

But this shouldn't really be necessary, since `Subscription` is a special type, like `Query` and `Mutation`.

And this pull request, just automatically excludes subscription types, until subscriptions are properly implemented, for those who want to implement subscriptions manually.