### PR TITLE
 Merge instead of Create in create relationship method to avoid duplicated relationships

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -1294,7 +1294,7 @@ const relationshipCreate = ({
       ? `) WHERE ${toTemporalClauses.join(' AND ')} `
       : ` {${toParam}: $to.${toParam}})`
   }
-      CREATE (${fromVariable})-[${relationshipVariable}:${relationshipLabel}${
+      MERGE (${fromVariable})-[${relationshipVariable}:${relationshipLabel}${
     paramStatements.length > 0 ? ` {${paramStatements.join(',')}}` : ''
   }]->(${toVariable})
       RETURN ${relationshipVariable} { ${subQuery} } AS ${schemaTypeName};


### PR DESCRIPTION
During the development of an application on several occasions my team and I found ourselves with the possibility of duplicating relationships with the same information (usually by mistake). Since the Neo4j documentation mentions that to avoid duplicate relationships, the MERGE method is used since there is no Constraint for relationships, why not do it this way?