### PR TITLE
Fix for incorrect behavior in filters 

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -2524,13 +2524,13 @@ const buildRelatedTypeListComprehension = ({
   if (rootIsRelationType) {
     relationVariable = variableName;
   }
-  const thisTypeVariable = safeVar(lowFirstLetter(thisType));
+  const safeVariableName = safeVar(variableName);
   // prevents related node variable from
   // conflicting with parent variables
   const relatedTypeVariable = safeVar(`_${relatedType.toLowerCase()}`);
   // builds a path pattern within a list comprehension
   // that extracts related nodes
-  return `[(${thisTypeVariable})${relationDirection === 'IN' ? '<' : ''}-[${
+  return `[(${safeVariableName})${relationDirection === 'IN' ? '<' : ''}-[${
     isRelationType
       ? safeVar(`_${relationVariable}`)
       : isRelationTypeNode

--- a/src/translate.js
+++ b/src/translate.js
@@ -2521,16 +2521,23 @@ const buildRelatedTypeListComprehension = ({
   isRelationType
 }) => {
   let relationVariable = buildRelationVariable(thisType, relatedType);
+  let nodeVariable = safeVar(variableName);
+
+  // prevents related node variable from
+  // conflicting with parent variables and relation variable
+  // and conflicting with left node variable
   if (rootIsRelationType) {
     relationVariable = variableName;
+    nodeVariable = safeVar(lowFirstLetter(thisType));
   }
-  const safeVariableName = safeVar(variableName);
-  // prevents related node variable from
-  // conflicting with parent variables
+  if (relationVariable === variableName) {
+    nodeVariable = safeVar(lowFirstLetter(thisType));
+  }
+
   const relatedTypeVariable = safeVar(`_${relatedType.toLowerCase()}`);
   // builds a path pattern within a list comprehension
   // that extracts related nodes
-  return `[(${safeVariableName})${relationDirection === 'IN' ? '<' : ''}-[${
+  return `[(${nodeVariable})${relationDirection === 'IN' ? '<' : ''}-[${
     isRelationType
       ? safeVar(`_${relationVariable}`)
       : isRelationTypeNode


### PR DESCRIPTION
FIx for  incorrect behaviour when filters are defined on types below the root. Variable created from type-name is replaced with the variableName the function receives which more accurately represents the set that the filter should be applied to. See issue #326