### PR TITLE
Fixes for generated schema type and default config

### DIFF
--- a/src/augment/augment.js
+++ b/src/augment/augment.js
@@ -233,10 +233,9 @@ export const mergeDefinitionMaps = ({
   let definitions = Object.values({
     ...generatedTypeMap,
     ...typeExtensionDefinitionMap,
-    ...operationTypeMap,
     ...directiveDefinitionMap
   });
-  [definitions, operationTypeMap] = augmentSchemaType({
+  definitions = augmentSchemaType({
     definitions,
     schemaTypeDefinition,
     operationTypeMap
@@ -322,6 +321,7 @@ const extractSchemaDefinitions = ({ schema = {} }) => {
     const astNode = definition.astNode;
     if (astNode) {
       astNodes.push(astNode);
+      // Extract embedded type extensions
       const extensionASTNodes = definition.extensionASTNodes;
       if (extensionASTNodes) {
         astNodes.push(...extensionASTNodes);

--- a/src/augment/types/node/query.js
+++ b/src/augment/types/node/query.js
@@ -12,12 +12,7 @@ import {
   useAuthDirective
 } from '../../directives';
 import { shouldAugmentType } from '../../augment';
-import {
-  OperationType,
-  isQueryTypeDefinition,
-  isMutationTypeDefinition,
-  isSubscriptionTypeDefinition
-} from '../../types/types';
+import { OperationType } from '../../types/types';
 import { TypeWrappers, getFieldDefinition } from '../../fields';
 import {
   FilteringArgument,
@@ -80,66 +75,18 @@ export const augmentNodeQueryAPI = ({
 };
 
 /**
- * Given a node type field, builds the input value definitions
- * for its Query arguments, along with those needed for input
- * types generated to support the same Query API for the given
- * field of the given node type
- */
-export const augmentNodeTypeFieldInput = ({
-  typeName,
-  definition,
-  fieldName,
-  fieldArguments,
-  fieldDirectives,
-  outputType,
-  config,
-  relationshipDirective,
-  outputTypeWrappers,
-  nodeInputTypeMap,
-  operationTypeMap
-}) => {
-  fieldArguments = augmentNodeTypeFieldArguments({
-    definition,
-    fieldArguments,
-    fieldDirectives,
-    outputType,
-    outputTypeWrappers,
-    operationTypeMap,
-    config
-  });
-  nodeInputTypeMap = augmentNodeQueryArgumentTypes({
-    typeName,
-    definition,
-    fieldName,
-    outputType,
-    outputTypeWrappers,
-    relationshipDirective,
-    nodeInputTypeMap,
-    operationTypeMap,
-    config
-  });
-  return [fieldArguments, nodeInputTypeMap];
-};
-
-/**
  * Builds the AST for the input value definitions used for
  * node type Query field arguments
  */
-const augmentNodeTypeFieldArguments = ({
-  definition,
+export const augmentNodeTypeFieldArguments = ({
   fieldArguments,
   fieldDirectives,
   outputType,
   outputTypeWrappers,
-  operationTypeMap,
   config
 }) => {
   const queryTypeNameLower = OperationType.QUERY.toLowerCase();
-  if (
-    !isMutationTypeDefinition({ definition, operationTypeMap }) &&
-    !isSubscriptionTypeDefinition({ definition, operationTypeMap }) &&
-    shouldAugmentType(config, queryTypeNameLower, outputType)
-  ) {
+  if (shouldAugmentType(config, queryTypeNameLower, outputType)) {
     fieldArguments = buildQueryFieldArguments({
       argumentMap: NodeQueryArgument,
       fieldArguments,
@@ -156,21 +103,16 @@ const augmentNodeTypeFieldArguments = ({
  * for associated input value definitions used by input types
  * generated for the Query API
  */
-const augmentNodeQueryArgumentTypes = ({
+export const augmentNodeQueryArgumentTypes = ({
   typeName,
-  definition,
   fieldName,
   outputType,
   outputTypeWrappers,
-  relationshipDirective,
   nodeInputTypeMap,
-  operationTypeMap,
   config
 }) => {
-  if (
-    relationshipDirective &&
-    !isQueryTypeDefinition({ definition, operationTypeMap })
-  ) {
+  const queryTypeNameLower = OperationType.QUERY.toLowerCase();
+  if (shouldAugmentType(config, queryTypeNameLower, outputType)) {
     nodeInputTypeMap[FilteringArgument.FILTER].fields.push(
       ...buildRelationshipFilters({
         typeName,

--- a/src/augment/types/relationship/query.js
+++ b/src/augment/types/relationship/query.js
@@ -1,10 +1,6 @@
 import { RelationshipDirectionField } from './relationship';
 import { shouldAugmentRelationshipField } from '../../augment';
-import {
-  OperationType,
-  isMutationTypeDefinition,
-  isSubscriptionTypeDefinition
-} from '../../types/types';
+import { OperationType } from '../../types/types';
 import { TypeWrappers, isListTypeField, unwrapNamedType } from '../../fields';
 import {
   FilteringArgument,
@@ -39,7 +35,6 @@ const RelationshipQueryArgument = {
  */
 export const augmentRelationshipQueryAPI = ({
   typeName,
-  definition,
   fieldArguments,
   fieldName,
   outputType,
@@ -53,8 +48,7 @@ export const augmentRelationshipQueryAPI = ({
   config,
   relationshipName,
   fieldType,
-  propertyOutputFields,
-  operationTypeMap
+  propertyOutputFields
 }) => {
   const queryTypeNameLower = OperationType.QUERY.toLowerCase();
   if (
@@ -95,7 +89,6 @@ export const augmentRelationshipQueryAPI = ({
         nodeInputTypeMap
       ] = augmentRelationshipTypeFieldInput({
         typeName,
-        definition,
         relatedType,
         fieldArguments,
         fieldName,
@@ -107,7 +100,6 @@ export const augmentRelationshipQueryAPI = ({
         nodeInputTypeMap,
         relationshipInputTypeMap,
         outputTypeWrappers,
-        operationTypeMap,
         config
       });
     }
@@ -129,7 +121,6 @@ export const augmentRelationshipQueryAPI = ({
  */
 const augmentRelationshipTypeFieldInput = ({
   typeName,
-  definition,
   relatedType,
   fieldArguments,
   fieldName,
@@ -141,7 +132,6 @@ const augmentRelationshipTypeFieldInput = ({
   nodeInputTypeMap,
   relationshipInputTypeMap,
   outputTypeWrappers,
-  operationTypeMap,
   config
 }) => {
   const nodeFilteringFields = nodeInputTypeMap[FilteringArgument.FILTER].fields;
@@ -164,7 +154,6 @@ const augmentRelationshipTypeFieldInput = ({
   [fieldArguments, generatedTypeMap] = augmentRelationshipTypeFieldArguments({
     fieldArguments,
     typeName,
-    definition,
     fromType,
     toType,
     outputType,
@@ -173,7 +162,6 @@ const augmentRelationshipTypeFieldInput = ({
     outputTypeWrappers,
     typeDefinitionMap,
     generatedTypeMap,
-    operationTypeMap,
     relationshipInputTypeMap
   });
   return [fieldArguments, generatedTypeMap, nodeInputTypeMap];
@@ -186,7 +174,6 @@ const augmentRelationshipTypeFieldInput = ({
 const augmentRelationshipTypeFieldArguments = ({
   fieldArguments,
   typeName,
-  definition,
   fromType,
   toType,
   outputType,
@@ -195,23 +182,17 @@ const augmentRelationshipTypeFieldArguments = ({
   outputTypeWrappers,
   typeDefinitionMap,
   generatedTypeMap,
-  operationTypeMap,
   relationshipInputTypeMap
 }) => {
-  if (
-    !isMutationTypeDefinition({ definition, operationTypeMap }) &&
-    !isSubscriptionTypeDefinition({ definition, operationTypeMap })
-  ) {
-    if (fromType !== toType) {
-      fieldArguments = buildQueryFieldArguments({
-        argumentMap: RelationshipQueryArgument,
-        fieldArguments,
-        outputType: `${typeName}${outputType}`,
-        outputTypeWrappers
-      });
-    } else {
-      fieldArguments = [];
-    }
+  if (fromType !== toType) {
+    fieldArguments = buildQueryFieldArguments({
+      argumentMap: RelationshipQueryArgument,
+      fieldArguments,
+      outputType: `${typeName}${outputType}`,
+      outputTypeWrappers
+    });
+  } else {
+    fieldArguments = [];
   }
   generatedTypeMap = buildRelationshipSelectionArgumentInputTypes({
     fromType,

--- a/src/augment/types/relationship/relationship.js
+++ b/src/augment/types/relationship/relationship.js
@@ -81,7 +81,6 @@ export const augmentRelationshipTypeField = ({
         nodeInputTypeMap
       ] = augmentRelationshipQueryAPI({
         typeName,
-        definition,
         fieldArguments,
         fieldName,
         outputType,
@@ -95,8 +94,7 @@ export const augmentRelationshipTypeField = ({
         config,
         relationshipName,
         fieldType,
-        propertyOutputFields,
-        operationTypeMap
+        propertyOutputFields
       });
       [
         typeDefinitionMap,

--- a/src/augment/types/types.js
+++ b/src/augment/types/types.js
@@ -631,14 +631,13 @@ export const augmentSchemaType = ({
     operationTypes = schemaTypeDefinition.operationTypes;
   // Only persist operation types that have at least 1 field, and for those add
   // a schema type operation field if one does not exist
-  operationTypeMap = Object.entries(operationTypeMap).reduce(
-    (operationMap, [typeName, operationType]) => {
+  operationTypeMap = Object.entries(operationTypeMap).forEach(
+    ([typeName, operationType]) => {
       // Keep the operation type only if there are fields,
       if (operationType.fields.length) {
-        // Query -> query, etc.
         const typeNameLow = typeName.toLowerCase();
         // Keep this operation type definition
-        operationMap[typeName] = operationType;
+        definitions.push(operationType);
         // Add schema type field for any generated default operation types (Query, etc.)
         if (
           !operationTypes.find(operation => operation.operation === typeNameLow)
@@ -651,9 +650,7 @@ export const augmentSchemaType = ({
           );
         }
       }
-      return operationMap;
-    },
-    {}
+    }
   );
   // If a schema type was regenerated or provided and at least one operation type
   // exists, then update its operation types and keep it
@@ -661,5 +658,5 @@ export const augmentSchemaType = ({
     schemaTypeDefinition.operationTypes = operationTypes;
     definitions.push(schemaTypeDefinition);
   }
-  return [definitions, operationTypeMap];
+  return definitions;
 };

--- a/src/augment/types/types.js
+++ b/src/augment/types/types.js
@@ -13,6 +13,8 @@ import {
   getDirective
 } from '../directives';
 import {
+  buildOperationType,
+  buildSchemaDefinition,
   buildName,
   buildNamedType,
   buildObjectType,
@@ -35,7 +37,7 @@ import {
   isTemporalField
 } from '../fields';
 
-import { augmentNodeType } from './node/node';
+import { augmentNodeType, augmentNodeTypeFields } from './node/node';
 import { RelationshipDirectionField } from '../types/relationship/relationship';
 
 /**
@@ -244,7 +246,17 @@ export const augmentTypes = ({
     ...typeDefinitionMap,
     ...operationTypeMap
   }).forEach(([typeName, definition]) => {
-    if (isNodeType({ definition })) {
+    if (isOperationTypeDefinition({ definition, operationTypeMap })) {
+      // Overwrite existing operation map entry with augmented type
+      operationTypeMap[typeName] = augmentOperationType({
+        typeName,
+        definition,
+        typeDefinitionMap,
+        generatedTypeMap,
+        operationTypeMap,
+        config
+      });
+    } else if (isNodeType({ definition })) {
       [definition, generatedTypeMap, operationTypeMap] = augmentNodeType({
         typeName,
         definition,
@@ -253,8 +265,10 @@ export const augmentTypes = ({
         operationTypeMap,
         config
       });
+      // Add augmented type to generated type map
       generatedTypeMap[typeName] = definition;
     } else {
+      // Persist any other type definition
       generatedTypeMap[typeName] = definition;
     }
     return definition;
@@ -411,4 +425,241 @@ export const transformNeo4jTypes = ({ definitions = [], config }) => {
       return field;
     }
   });
+};
+
+/**
+ * Builds any operation types that do not exist but should
+ */
+export const initializeOperationTypes = ({
+  typeDefinitionMap,
+  schemaTypeDefinition,
+  config = {}
+}) => {
+  let queryTypeName = OperationType.QUERY;
+  let mutationTypeName = OperationType.MUTATION;
+  let subscriptionTypeName = OperationType.SUBSCRIPTION;
+  [
+    queryTypeName,
+    mutationTypeName,
+    subscriptionTypeName
+  ] = getSchemaTypeOperationNames({
+    schemaTypeDefinition,
+    queryTypeName,
+    mutationTypeName,
+    subscriptionTypeName
+  });
+  // Build default operation type definitions if none are provided,
+  // only kept if at least 1 field is added for generated API
+  let operationTypeMap = {};
+  typeDefinitionMap = initializeOperationType({
+    typeName: queryTypeName,
+    typeDefinitionMap,
+    config
+  });
+  typeDefinitionMap = initializeOperationType({
+    typeName: mutationTypeName,
+    typeDefinitionMap,
+    config
+  });
+  typeDefinitionMap = initializeOperationType({
+    typeName: subscriptionTypeName,
+    typeDefinitionMap,
+    config
+  });
+  // Separate operation types out from other type definitions
+  [typeDefinitionMap, operationTypeMap] = buildAugmentationTypeMaps({
+    queryTypeName,
+    mutationTypeName,
+    subscriptionTypeName,
+    typeDefinitionMap
+  });
+  return [typeDefinitionMap, operationTypeMap];
+};
+
+/**
+ * Given a schema type, extracts possibly custom operation type names
+ */
+const getSchemaTypeOperationNames = ({
+  schemaTypeDefinition,
+  queryTypeName,
+  mutationTypeName,
+  subscriptionTypeName
+}) => {
+  // Get operation type names, which may be non-default
+  if (schemaTypeDefinition) {
+    const operationTypes = schemaTypeDefinition.operationTypes;
+    operationTypes.forEach(definition => {
+      const operation = definition.operation;
+      const unwrappedType = unwrapNamedType({ type: definition.type });
+      if (operation === queryTypeName.toLowerCase()) {
+        queryTypeName = unwrappedType.name;
+      } else if (operation === mutationTypeName.toLowerCase()) {
+        mutationTypeName = unwrappedType.name;
+      } else if (operation === subscriptionTypeName.toLowerCase()) {
+        subscriptionTypeName = unwrappedType.name;
+      }
+    });
+  }
+  return [queryTypeName, mutationTypeName, subscriptionTypeName];
+};
+
+/**
+ * Builds an operation type if it does not exist but should
+ */
+const initializeOperationType = ({
+  typeName = '',
+  typeDefinitionMap = {},
+  config = {}
+}) => {
+  const typeNameLower = typeName.toLowerCase();
+  let operationType = typeDefinitionMap[typeName];
+  if (!operationType && config[typeNameLower]) {
+    operationType = buildObjectType({
+      name: buildName({ name: typeName })
+    });
+  }
+  if (operationType) typeDefinitionMap[typeName] = operationType;
+  return typeDefinitionMap;
+};
+
+/**
+ * Builds a typeDefinitionMap that excludes operation types, instead placing them
+ * within an operationTypeMap
+ */
+const buildAugmentationTypeMaps = ({
+  queryTypeName,
+  mutationTypeName,
+  subscriptionTypeName,
+  typeDefinitionMap = {}
+}) => {
+  return Object.entries(typeDefinitionMap).reduce(
+    ([typeMap, operationTypeMap], [typeName, definition]) => {
+      if (typeName === queryTypeName) {
+        operationTypeMap[OperationType.QUERY] = definition;
+      } else if (typeName === mutationTypeName) {
+        operationTypeMap[OperationType.MUTATION] = definition;
+      } else if (typeName === subscriptionTypeName) {
+        operationTypeMap[OperationType.SUBSCRIPTION] = definition;
+      } else {
+        typeMap[typeName] = definition;
+      }
+      return [typeMap, operationTypeMap];
+    },
+    [{}, {}]
+  );
+};
+
+/**
+ * The augmentation entry point for a GraphQL operation
+ * type (Query, Mutation, etc.)
+ */
+const augmentOperationType = ({
+  typeName,
+  definition,
+  typeDefinitionMap,
+  generatedTypeMap,
+  operationTypeMap,
+  config
+}) => {
+  if (isObjectTypeDefinition({ definition })) {
+    if (isQueryTypeDefinition({ definition, operationTypeMap })) {
+      let [
+        nodeInputTypeMap,
+        propertyOutputFields,
+        propertyInputValues,
+        isIgnoredType
+      ] = augmentNodeTypeFields({
+        typeName,
+        definition,
+        typeDefinitionMap,
+        generatedTypeMap,
+        operationTypeMap,
+        config
+      });
+      if (!isIgnoredType) {
+        definition.fields = propertyOutputFields;
+      }
+    }
+  }
+  return definition;
+};
+
+/**
+ * Regenerates the schema type definition using any existing operation types
+ */
+export const regenerateSchemaType = ({ schema = {}, definitions = [] }) => {
+  const operationTypes = [];
+  Object.values(OperationType).forEach(name => {
+    let operationType = undefined;
+    if (name === OperationType.QUERY) operationType = schema.getQueryType();
+    else if (name === OperationType.MUTATION)
+      operationType = schema.getMutationType();
+    else if (name === OperationType.SUBSCRIPTION)
+      operationType = schema.getSubscriptionType();
+    if (operationType) {
+      operationTypes.push(
+        buildOperationType({
+          operation: name.toLowerCase(),
+          type: buildNamedType({ name: operationType.name })
+        })
+      );
+    }
+  });
+  if (operationTypes.length) {
+    definitions.push(
+      buildSchemaDefinition({
+        operationTypes
+      })
+    );
+  }
+  return definitions;
+};
+
+/**
+ * Builds any schema type entry that should exist but doesn't, and
+ * decides to only keep operation type definitions that contain at least
+ * 1 field
+ */
+export const augmentSchemaType = ({
+  definitions,
+  schemaTypeDefinition,
+  operationTypeMap
+}) => {
+  let operationTypes = [];
+  // If schema type provided or regenerated, get its operation types
+  if (schemaTypeDefinition)
+    operationTypes = schemaTypeDefinition.operationTypes;
+  // Only persist operation types that have at least 1 field, and for those add
+  // a schema type operation field if one does not exist
+  operationTypeMap = Object.entries(operationTypeMap).reduce(
+    (operationMap, [typeName, operationType]) => {
+      // Keep the operation type only if there are fields,
+      if (operationType.fields.length) {
+        // Query -> query, etc.
+        const typeNameLow = typeName.toLowerCase();
+        // Keep this operation type definition
+        operationMap[typeName] = operationType;
+        // Add schema type field for any generated default operation types (Query, etc.)
+        if (
+          !operationTypes.find(operation => operation.operation === typeNameLow)
+        ) {
+          operationTypes.push(
+            buildOperationType({
+              operation: typeNameLow,
+              type: buildNamedType({ name: operationType.name.value })
+            })
+          );
+        }
+      }
+      return operationMap;
+    },
+    {}
+  );
+  // If a schema type was regenerated or provided and at least one operation type
+  // exists, then update its operation types and keep it
+  if (schemaTypeDefinition && operationTypes.length) {
+    schemaTypeDefinition.operationTypes = operationTypes;
+    definitions.push(schemaTypeDefinition);
+  }
+  return [definitions, operationTypeMap];
 };

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,8 @@ export const augmentTypeDefs = (typeDefs, config = {}) => {
     typeDefinitionMap,
     typeExtensionDefinitionMap,
     directiveDefinitionMap,
-    operationTypeMap
+    operationTypeMap,
+    schemaTypeDefinition
   ] = mapDefinitions({
     definitions,
     config
@@ -154,7 +155,8 @@ export const augmentTypeDefs = (typeDefs, config = {}) => {
     generatedTypeMap,
     typeExtensionDefinitionMap,
     operationTypeMap,
-    directiveDefinitionMap
+    directiveDefinitionMap,
+    schemaTypeDefinition
   });
   const transformedDefinitions = transformNeo4jTypes({
     definitions: mergedDefinitions,
@@ -167,15 +169,7 @@ export const augmentTypeDefs = (typeDefs, config = {}) => {
   return typeDefs;
 };
 
-export const augmentSchema = (
-  schema,
-  config = {
-    query: true,
-    mutation: true,
-    temporal: true,
-    spatial: true
-  }
-) => {
+export const augmentSchema = (schema, config) => {
   return augmentedSchema(schema, config);
 };
 
@@ -190,12 +184,7 @@ export const makeAugmentedSchema = ({
   schemaDirectives = {},
   parseOptions = {},
   inheritResolversFromInterfaces = false,
-  config = {
-    query: true,
-    mutation: true,
-    temporal: true,
-    spatial: true
-  }
+  config
 }) => {
   if (schema) {
     return augmentedSchema(schema, config);

--- a/test/helpers/cypherTestHelpers.js
+++ b/test/helpers/cypherTestHelpers.js
@@ -19,7 +19,7 @@ export function cypherTestRunner(
   const testMovieSchema =
     testSchema +
     `
-type MutationB {
+type Mutation {
     CreateGenre(name: String): Genre @cypher(statement: "CREATE (g:Genre) SET g.name = $name RETURN g")
     CreateMovie(movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float): Movie
     CreateState(name: String!): State
@@ -69,7 +69,7 @@ type MutationB {
       computedIntList: checkCypherQuery,
       customWithArguments: checkCypherQuery
     },
-    MutationB: {
+    Mutation: {
       CreateGenre: checkCypherMutation,
       CreateMovie: checkCypherMutation,
       CreateState: checkCypherMutation,
@@ -182,7 +182,7 @@ export function augmentedSchemaCypherTestRunner(
       computedIntList: checkCypherQuery,
       customWithArguments: checkCypherQuery
     },
-    MutationB: {
+    Mutation: {
       CreateMovie: checkCypherMutation,
       CreateState: checkCypherMutation,
       CreateTemporalNode: checkCypherMutation,

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -220,7 +220,7 @@ export const testSchema = /* GraphQL */ `
     CasedType: [CasedType]
   }
 
-  type MutationB {
+  type Mutation {
     currentUserId: String
       @cypher(statement: "RETURN $cypherParams.currentUserId")
     computedObjectWithCypherParams: currentUserId
@@ -302,7 +302,7 @@ export const testSchema = /* GraphQL */ `
 
   schema {
     query: QueryA
-    mutation: MutationB
+    mutation: Mutation
     subscription: SubscriptionC
   }
 `;

--- a/test/unit/augmentSchemaTest.test.js
+++ b/test/unit/augmentSchemaTest.test.js
@@ -1118,7 +1118,7 @@ test.cb('Test augmented schema', t => {
       _id: String
     }
 
-    type MutationB {
+    type Mutation {
       currentUserId: String
         @cypher(statement: "RETURN $cypherParams.currentUserId")
       computedObjectWithCypherParams: currentUserId
@@ -1722,7 +1722,7 @@ test.cb('Test augmented schema', t => {
 
     schema {
       query: QueryA
-      mutation: MutationB
+      mutation: Mutation
       subscription: SubscriptionC
     }
   `;
@@ -1749,6 +1749,7 @@ const compareSchema = ({ test, sourceSchema = {}, expectedSchema = {} }) => {
         def => def.kind === Kind.SCHEMA_DEFINITION
       );
     } else {
+      const name = definition.name.value;
       augmented = augmentedDefinitions.find(augmentedDefinition => {
         if (augmentedDefinition.name) {
           if (definition.name.value === augmentedDefinition.name.value) {

--- a/test/unit/configTest.test.js
+++ b/test/unit/configTest.test.js
@@ -239,3 +239,15 @@ test.cb(
     t.end();
   }
 );
+
+test.cb('Config - default configuration persistence', t => {
+  const schema = makeAugmentedSchema({
+    typeDefs,
+    config: {
+      temporal: false
+    }
+  });
+  t.is(printSchema(schema).includes('Query'), true);
+  t.is(printSchema(schema).includes('Mutation'), true);
+  t.end();
+});


### PR DESCRIPTION
This PR addresses issues #337 and #338 and contains some refactoring of how operation types (Query, Mutation, etc.) get handled in the augmentation process. 