### PR TITLE
Fix for _id field on generated ordering types

### DIFF
--- a/example/apollo-server/movies-schema.js
+++ b/example/apollo-server/movies-schema.js
@@ -24,6 +24,7 @@ type Movie {
   locations: [Point]
   scaleRating(scale: Int = 3): Float @cypher(statement: "WITH $this AS this RETURN $scale * this.imdbRating")
   scaleRatingFloat(scale: Float = 1.5): Float @cypher(statement: "WITH $this AS this RETURN $scale * this.imdbRating")
+  _id: ID
 }
 
 type Genre {

--- a/src/augment/fields.js
+++ b/src/augment/fields.js
@@ -213,11 +213,19 @@ export const buildNeo4jSystemIDField = ({
     } else {
       propertyOutputFields.push(systemIDField);
     }
-    nodeInputTypeMap[OrderingArgument.ORDER_BY].values.push(
-      ...buildPropertyOrderingValues({
-        fieldName: neo4jInternalIDConfig.name
-      })
+    const orderingValues = nodeInputTypeMap[OrderingArgument.ORDER_BY].values;
+    const systemIDOrderingValue = orderingValues.find(
+      value =>
+        value.name.value === `${Neo4jSystemIDField}_asc` ||
+        value.name.value === `${Neo4jSystemIDField}_desc`
     );
+    if (!systemIDOrderingValue) {
+      nodeInputTypeMap[OrderingArgument.ORDER_BY].values.push(
+        ...buildPropertyOrderingValues({
+          fieldName: neo4jInternalIDConfig.name
+        })
+      );
+    }
   }
   return [propertyOutputFields, nodeInputTypeMap];
 };

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -158,11 +158,6 @@ export const testSchema = /* GraphQL */ `
     genre: BookGenre
   }
 
-  enum _MovieOrdering {
-    title_desc
-    title_asc
-  }
-
   enum _GenreOrdering {
     name_desc
     name_asc
@@ -181,7 +176,6 @@ export const testSchema = /* GraphQL */ `
       location: Point
       first: Int
       offset: Int
-      orderBy: _MovieOrdering
     ): [Movie]
     MoviesByYear(year: Int): [Movie]
     MoviesByYears(year: [Int]): [Movie]

--- a/test/unit/augmentSchemaTest.test.js
+++ b/test/unit/augmentSchemaTest.test.js
@@ -207,8 +207,36 @@ test.cb('Test augmented schema', t => {
     }
 
     enum _MovieOrdering {
-      title_desc
+      _id_asc
+      _id_desc
+      movieId_asc
+      movieId_desc
       title_asc
+      title_desc
+      someprefix_title_with_underscores_asc
+      someprefix_title_with_underscores_desc
+      year_asc
+      year_desc
+      released_asc
+      released_desc
+      plot_asc
+      plot_desc
+      poster_asc
+      poster_desc
+      imdbRating_asc
+      imdbRating_desc
+      degree_asc
+      degree_desc
+      avgStars_asc
+      avgStars_desc
+      location_asc
+      location_desc
+      scaleRating_asc
+      scaleRating_desc
+      scaleRatingFloat_asc
+      scaleRatingFloat_desc
+      currentUserId_asc
+      currentUserId_desc
     }
 
     input _MovieFilter {


### PR DESCRIPTION
This PR resolves issue #359, where if an `_id` field is provided on a type, the augmentation process fails due to an incorrect duplication of corresponding values (`_id_asc`, `_id_desc`) added to the ordering enum generated for that type. 