### PR TITLE
Initial support for Neo4j v4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,16 @@ references:
       NEO4J_VERSION: '3.5.4'
       APOC_VERSION: '3.5.0.2'
       DATASTORE_VERSION: '3_5'
+  env_neo4j40ce: &env_neo4j40ce
+      NEO4J_DIST: 'community'
+      NEO4J_VERSION: '4.0.0'
+      APOC_VERSION: '4.0.0-rc01'
+      DATASTORE_VERSION: '4_0'
+  env_neo4j40ee: &env_neo4j40ee
+      NEO4J_DIST: 'enterprise'
+      NEO4J_VERSION: '4.0.0'
+      APOC_VERSION: '4.0.0-rc01'
+      DATASTORE_VERSION: '4_0'
 
   install_neo4j_steps: &install_neo4j_steps
     - checkout
@@ -165,6 +175,16 @@ jobs:
     environment: *env_neo4j35ee
     steps: *install_neo4j_steps
 
+  install_neo4j40ce:
+    docker: *node10
+    environment: *env_neo4j40ce
+    steps: *install_neo4j_steps
+
+  install_neo4j40ee:
+    docker: *node10
+    environment: *env_neo4j40ee
+    steps: *install_neo4j_steps
+
   # Node 8
   install_for_node8:
     docker: *node8
@@ -188,6 +208,16 @@ jobs:
   neo4j35ee_node8:
     docker: *node8
     environment: *env_neo4j35ee
+    steps: *run_tests_steps
+
+  neo4j40ce_node8:
+    docker: *node8
+    environment: *env_neo4j40ce
+    steps: *run_tests_steps
+
+  neo4j40ee_node8:
+    docker: *node8
+    environment: *env_neo4j40ee
     steps: *run_tests_steps
 
   # Node 10
@@ -215,6 +245,16 @@ jobs:
     environment: *env_neo4j35ee
     steps: *run_tests_steps
 
+  neo4j40ce_node10:
+    docker: *node10
+    environment: *env_neo4j40ce
+    steps: *run_tests_steps
+
+  neo4j40ee_node10:
+    docker: *node10
+    environment: *env_neo4j40ee
+    steps: *run_tests_steps
+
 workflows:
   version: 2
   integration_test:
@@ -225,6 +265,8 @@ workflows:
       - install_neo4j34ce
       - install_neo4j35ce
       - install_neo4j35ee
+      - install_neo4j40ce
+      - install_neo4j40ee
 
       - neo4j34ee_node8:
           requires:
@@ -242,6 +284,14 @@ workflows:
           requires:
             - install_neo4j35ee
             - install_for_node8
+      - neo4j40ce_node8:
+          requires:
+            - install_neo4j40ce
+            - install_for_node8
+      - neo4j40ee_node8:
+          requires:
+            - install_neo4j40ee
+            - install_for_node8
 
       - neo4j34ee_node10:
           requires:
@@ -258,4 +308,12 @@ workflows:
       - neo4j35ee_node10:
           requires:
             - install_neo4j35ee
+            - install_for_node10
+      - neo4j40ce_node10:
+          requires:
+            - install_neo4j40ce
+            - install_for_node10
+      - neo4j40ee_node10:
+          requires:
+            - install_neo4j40ee
             - install_for_node10

--- a/example/apollo-server/movies-middleware.js
+++ b/example/apollo-server/movies-middleware.js
@@ -2,7 +2,7 @@ import { makeAugmentedSchema } from '../../src/index';
 import { ApolloServer } from 'apollo-server-express';
 import express from 'express';
 import bodyParser from 'body-parser';
-import { v1 as neo4j } from 'neo4j-driver';
+import neo4j from 'neo4j-driver';
 import { typeDefs, resolvers } from './movies-schema';
 
 const schema = makeAugmentedSchema({

--- a/example/apollo-server/movies-schema.js
+++ b/example/apollo-server/movies-schema.js
@@ -14,16 +14,16 @@ type Movie {
   imdbRating: Float
   ratings: [Rated]
   genres: [Genre] @relation(name: "IN_GENRE", direction: "OUT")
-  similar(first: Int = 3, offset: Int = 0, limit: Int = 5): [Movie] @cypher(statement: "WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o LIMIT {limit}")
-  mostSimilar: Movie @cypher(statement: "WITH {this} AS this RETURN this")
-  degree: Int @cypher(statement: "WITH {this} AS this RETURN SIZE((this)--())")
+  similar(first: Int = 3, offset: Int = 0, limit: Int = 5): [Movie] @cypher(statement: "MATCH (this)--(:Genre)--(o:Movie) RETURN o LIMIT $limit")
+  mostSimilar: Movie @cypher(statement: "RETURN this")
+  degree: Int @cypher(statement: "RETURN SIZE((this)--())")
   actors(first: Int = 3, offset: Int = 0): [Actor] @relation(name: "ACTED_IN", direction:"IN")
   avgStars: Float
   filmedIn: State @relation(name: "FILMED_IN", direction: "OUT")
   location: Point
   locations: [Point]
-  scaleRating(scale: Int = 3): Float @cypher(statement: "WITH $this AS this RETURN $scale * this.imdbRating")
-  scaleRatingFloat(scale: Float = 1.5): Float @cypher(statement: "WITH $this AS this RETURN $scale * this.imdbRating")
+  scaleRating(scale: Int = 3): Float @cypher(statement: "RETURN $scale * this.imdbRating")
+  scaleRatingFloat(scale: Float = 1.5): Float @cypher(statement: "RETURN $scale * this.imdbRating")
   _id: ID
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4796,9 +4796,9 @@
       }
     },
     "handlebars": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
-      "integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -6519,11 +6519,12 @@
       "dev": true
     },
     "neo4j-driver": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-1.7.6.tgz",
-      "integrity": "sha512-6c3ALO3vYDfUqNoCy8OFzq+fQ7q/ab3LCuJrmm8P04M7RmyRCCnUtJ8IzSTGbiZvyhcehGK+azNDAEJhxPV/hA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/neo4j-driver/-/neo4j-driver-4.0.1.tgz",
+      "integrity": "sha512-SqBhXyyyayVs5gV/6BrgdKbcmU5AsYQXkFAiYO74XAE8XPLJ1HVR/Hu4wjonAX7+70DsalkWEiFN1c6UaCVzlQ==",
       "requires": {
         "@babel/runtime": "^7.5.5",
+        "rxjs": "^6.5.2",
         "text-encoding-utf-8": "^1.0.2",
         "uri-js": "^4.2.2"
       }
@@ -8035,7 +8036,6 @@
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
       "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
-      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -8899,9 +8899,9 @@
       }
     },
     "uglify-js": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.3.tgz",
-      "integrity": "sha512-KfQUgOqTkLp2aZxrMbCuKCDGW9slFYu2A23A36Gs7sGzTLcRBDORdOi5E21KWHFIfkY8kzgi/Pr1cXCh0yIp5g==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.2.tgz",
+      "integrity": "sha512-uhRwZcANNWVLrxLfNFEdltoPNhECUR3lc+UdJoG9CBpMcSnKyWA94tc3eAujB1GcMY5Uwq8ZMp4qWpxWYDQmaA==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "graphql": "^14.2.1",
     "graphql-auth-directives": "^2.1.0",
     "lodash": "^4.17.15",
-    "neo4j-driver": "^1.7.3"
+    "neo4j-driver": "^4.0.1"
   },
   "ava": {
     "require": [

--- a/scripts/start-neo4j.sh
+++ b/scripts/start-neo4j.sh
@@ -16,6 +16,7 @@ else
             nc -z 127.0.0.1 $BOLT_PORT
             is_up=$?
             if [ $is_up -eq 0 ]; then
+                ./neo4j/bin/neo4j-admin set-initial-password letmein
                 echo
                 echo "Successfully started, neo4j bolt available on $BOLT_PORT"
                 break

--- a/scripts/start-neo4j.sh
+++ b/scripts/start-neo4j.sh
@@ -7,6 +7,7 @@ if [ ! -d "neo4j/data/databases/graph.db" ]; then
     exit 1
 else
     echo "dbms.allow_upgrade=true" >> ./neo4j/conf/neo4j.conf
+    echo "dbms.recovery.fail_on_missing_files=false" >> ./neo4j/conf/neo4j.conf
     # Set initial and max heap to workaround JVM in docker issues
     dbms_memory_heap_initial_size="2048m" dbms_memory_heap_max_size="2048m" ./neo4j/bin/neo4j start
     echo "Waiting up to 2 minutes for neo4j bolt port ($BOLT_PORT)"
@@ -16,7 +17,6 @@ else
             nc -z 127.0.0.1 $BOLT_PORT
             is_up=$?
             if [ $is_up -eq 0 ]; then
-                ./neo4j/bin/neo4j-admin set-initial-password letmein
                 echo
                 echo "Successfully started, neo4j bolt available on $BOLT_PORT"
                 break

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ instead: \`DEBUG=neo4j-graphql-js\`.
   debug('%s', query);
   debug('%s', JSON.stringify(cypherParams, null, 2));
 
+  // TODO: Is this a 4.0 driver instance? Check bolt path for default database name and use that when creating the session
   const session = context.driver.session();
   let result;
 

--- a/src/translate.js
+++ b/src/translate.js
@@ -56,7 +56,7 @@ import {
 } from 'graphql';
 import { buildCypherSelection } from './selections';
 import _ from 'lodash';
-import { v1 as neo4j } from 'neo4j-driver';
+import neo4j from 'neo4j-driver';
 
 const derivedTypesParamName = interfaceName => `${interfaceName}_derivedTypes`;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -809,7 +809,9 @@ export const initializeMutationParams = ({
 };
 
 export const getOuterSkipLimit = (first, offset) =>
-  `${offset > 0 ? ` SKIP $offset` : ''}${first > -1 ? ' LIMIT $first' : ''}`;
+  `${offset > 0 ? ` SKIP toInteger($offset)` : ''}${
+    first > -1 ? ' LIMIT toInteger($first)' : ''
+  }`;
 
 export const getPayloadSelections = resolveInfo => {
   const filteredFieldNodes = filter(

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 import { isObjectType, parse, GraphQLInt } from 'graphql';
-import { v1 as neo4j } from 'neo4j-driver';
+import neo4j from 'neo4j-driver';
 import _ from 'lodash';
 import filter from 'lodash/filter';
 import { Neo4jTypeName } from './augment/types/types';

--- a/test/integration/integration.test.js
+++ b/test/integration/integration.test.js
@@ -226,8 +226,8 @@ test.serial('Create node mutation (not-isolated)', async t => {
         imdbRating: 1,
         location: {
           __typename: '_Neo4jPoint',
-          longitude: 46.870035,
-          latitude: -113.990976,
+          longitude: -113.990976,
+          latitude: 46.870035,
           height: 12.3
         }
       }
@@ -246,8 +246,8 @@ test.serial('Create node mutation (not-isolated)', async t => {
             poster: "www.movieposter.com/img.png"
             imdbRating: 1.0
             location: {
-              longitude: 46.870035
-              latitude: -113.990976
+              latitude: 46.870035
+              longitude: -113.990976
               height: 12.3
             }
           ) {
@@ -287,8 +287,8 @@ test.serial('Merge node mutation (not-isolated)', async t => {
         imdbRating: 1,
         location: {
           __typename: '_Neo4jPoint',
-          longitude: 46.870035,
-          latitude: -113.990976,
+          latitude: 46.870035,
+          longitude: -113.990976,
           height: 12.3
         }
       }
@@ -307,8 +307,8 @@ test.serial('Merge node mutation (not-isolated)', async t => {
             poster: "www.movieposter.com/img.png"
             imdbRating: 1.0
             location: {
-              longitude: 46.870035
-              latitude: -113.990976
+              latitude: 46.870035
+              longitude: -113.990976
               height: 12.3
             }
           ) {
@@ -318,8 +318,8 @@ test.serial('Merge node mutation (not-isolated)', async t => {
             poster
             imdbRating
             location {
-              longitude
               latitude
+              longitude
               height
             }
           }

--- a/test/unit/cypherTest.test.js
+++ b/test/unit/cypherTest.test.js
@@ -38,7 +38,7 @@ test('Simple skip limit', t => {
   }
 }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title , .year } AS \`movie\` SKIP $offset LIMIT $first`;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title , .year } AS \`movie\` SKIP toInteger($offset) LIMIT toInteger($first)`;
 
   t.plan(3);
   return Promise.all([
@@ -1748,7 +1748,7 @@ test('orderBy test - descending, top level - augmented schema', t => {
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) WITH \`movie\` ORDER BY movie.title DESC RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .name }][..3] } AS \`movie\` LIMIT $first`;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) WITH \`movie\` ORDER BY movie.title DESC RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .name }][..3] } AS \`movie\` LIMIT toInteger($first)`;
 
   t.plan(1);
 


### PR DESCRIPTION
This PR adds support and testing for Neo4j v4.0.

NOTE: The Neo4j v4.0 multi-database functionality is not yet directly exposed via neo4j-graphql.js, instead only the default database is used. Exposing multi-database via neo4j-graphql.js will be addressed in an upcoming release.