### PR TITLE
Fixes: merging interface type nodes / using interfaces with no scalars

### DIFF
--- a/src/augment/fields.js
+++ b/src/augment/fields.js
@@ -229,3 +229,22 @@ export const buildNeo4jSystemIDField = ({
   }
   return [propertyOutputFields, nodeInputTypeMap];
 };
+
+export const propertyFieldExists = ({
+  definition = {},
+  typeDefinitionMap = {}
+}) => {
+  const fields = definition.fields || [];
+  return fields.find(field => {
+    const fieldName = field.name.value;
+    const fieldType = field.type;
+    const unwrappedType = unwrapNamedType({ type: fieldType });
+    const outputType = unwrappedType.name;
+    const outputDefinition = typeDefinitionMap[outputType];
+    const outputKind = outputDefinition ? outputDefinition.kind : '';
+    return isPropertyTypeField({
+      kind: outputKind,
+      type: outputType
+    });
+  });
+};

--- a/src/augment/types/node/node.js
+++ b/src/augment/types/node/node.js
@@ -124,16 +124,22 @@ export const augmentNodeTypeFields = ({
   const fields = definition.fields;
   let isIgnoredType = true;
   const propertyInputValues = [];
-  let nodeInputTypeMap = {
-    [FilteringArgument.FILTER]: {
+  let nodeInputTypeMap = {};
+  if (
+    !isQueryTypeDefinition({
+      definition,
+      operationTypeMap
+    })
+  ) {
+    nodeInputTypeMap[FilteringArgument.FILTER] = {
       name: `_${typeName}Filter`,
       fields: []
-    },
-    [OrderingArgument.ORDER_BY]: {
+    };
+    nodeInputTypeMap[OrderingArgument.ORDER_BY] = {
       name: `_${typeName}Ordering`,
       values: []
-    }
-  };
+    };
+  }
   let propertyOutputFields = fields.reduce((outputFields, field) => {
     let fieldType = field.type;
     let fieldArguments = field.arguments;
@@ -256,6 +262,7 @@ const augmentNodeTypeField = ({
     fieldDirectives,
     outputType,
     outputTypeWrappers,
+    typeDefinitionMap,
     config
   });
   if (

--- a/src/augment/types/node/query.js
+++ b/src/augment/types/node/query.js
@@ -56,6 +56,7 @@ export const augmentNodeQueryAPI = ({
         queryType,
         propertyInputValues,
         operationTypeMap,
+        typeDefinitionMap,
         config
       });
     }
@@ -83,6 +84,7 @@ export const augmentNodeTypeFieldArguments = ({
   fieldDirectives,
   outputType,
   outputTypeWrappers,
+  typeDefinitionMap,
   config
 }) => {
   const queryTypeNameLower = OperationType.QUERY.toLowerCase();
@@ -92,7 +94,8 @@ export const augmentNodeTypeFieldArguments = ({
       fieldArguments,
       fieldDirectives,
       outputType,
-      outputTypeWrappers
+      outputTypeWrappers,
+      typeDefinitionMap
     });
   }
   return fieldArguments;
@@ -136,6 +139,7 @@ const buildNodeQueryField = ({
   queryType,
   propertyInputValues,
   operationTypeMap,
+  typeDefinitionMap,
   config
 }) => {
   const queryFields = queryType.fields;
@@ -156,7 +160,8 @@ const buildNodeQueryField = ({
         }),
         args: buildNodeQueryArguments({
           typeName,
-          propertyInputValues
+          propertyInputValues,
+          typeDefinitionMap
         }),
         directives: buildNodeQueryDirectives({
           typeName,
@@ -173,7 +178,11 @@ const buildNodeQueryField = ({
  * Builds the AST for input value definitions used for the
  * arguments of the Query type field for a given node type
  */
-const buildNodeQueryArguments = ({ typeName, propertyInputValues }) => {
+const buildNodeQueryArguments = ({
+  typeName,
+  propertyInputValues,
+  typeDefinitionMap
+}) => {
   // Do not persist type wrappers
   propertyInputValues = propertyInputValues.map(arg =>
     buildInputValue({
@@ -199,7 +208,8 @@ const buildNodeQueryArguments = ({ typeName, propertyInputValues }) => {
     outputType: typeName,
     outputTypeWrappers: {
       [TypeWrappers.LIST_TYPE]: true
-    }
+    },
+    typeDefinitionMap
   });
   return propertyInputValues;
 };

--- a/src/augment/types/relationship/relationship.js
+++ b/src/augment/types/relationship/relationship.js
@@ -179,8 +179,7 @@ const augmentRelationshipTypeFields = ({
           fieldDirectives,
           outputType,
           outputKind,
-          outputTypeWrappers,
-          config
+          outputTypeWrappers
         });
         propertyInputValues.push({
           name: fieldName,

--- a/src/translate.js
+++ b/src/translate.js
@@ -1039,7 +1039,7 @@ export const translateMutation = ({
         selections,
         schemaType,
         params,
-        additionalLabels: additionalNodeLabels
+        additionalLabels: additionalNodeLabels.concat(interfaceLabels)
       });
     }
   } else if (isRemoveMutation(resolveInfo)) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -691,8 +691,14 @@ const firstField = fields => {
 export const getPrimaryKey = astNode => {
   let fields = astNode.fields;
   let pk = undefined;
-  // remove all ignored fields
-  fields = fields.filter(field => !getFieldDirective(field, 'neo4j_ignore'));
+  // prevent ignored, relation, and computed fields
+  // from being used as primary keys
+  fields = fields.filter(
+    field =>
+      !getFieldDirective(field, 'neo4j_ignore') &&
+      !getFieldDirective(field, 'relation') &&
+      !getFieldDirective(field, 'cypher')
+  );
   if (!fields.length) return pk;
   pk = firstNonNullAndIdField(fields);
   if (!pk) {

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -56,6 +56,10 @@ export const testSchema = /* GraphQL */ `
       @cypher(
         statement: "RETURN $cypherParams.currentUserId AS cypherParamsUserId"
       )
+    interfaceNoScalars(
+      orderBy: _InterfaceNoScalarsOrdering
+    ): [InterfaceNoScalars]
+      @relation(name: "INTERFACE_NO_SCALARS", direction: OUT)
   }
 
   type Genre {
@@ -212,6 +216,9 @@ export const testSchema = /* GraphQL */ `
     customWithArguments(strArg: String, strInputArg: strInput): String
       @cypher(statement: "RETURN $strInputArg.strArg")
     CasedType: [CasedType]
+    InterfaceNoScalars(
+      orderBy: _InterfaceNoScalarsOrdering
+    ): [InterfaceNoScalars]
   }
 
   type Mutation {
@@ -288,6 +295,14 @@ export const testSchema = /* GraphQL */ `
   type CasedType {
     name: String
     state: State @relation(name: "FILMED_IN", direction: "OUT")
+  }
+
+  interface InterfaceNoScalars {
+    movies: [Movie] @relation(name: "MOVIES", direction: OUT)
+  }
+
+  enum _InterfaceNoScalarsOrdering {
+    movies_asc
   }
 
   type SubscriptionC {

--- a/test/unit/augmentSchemaTest.test.js
+++ b/test/unit/augmentSchemaTest.test.js
@@ -132,6 +132,12 @@ test.cb('Test augmented schema', t => {
         orderBy: [_CasedTypeOrdering]
         filter: _CasedTypeFilter
       ): [CasedType]
+      InterfaceNoScalars(
+        orderBy: _InterfaceNoScalarsOrdering
+        first: Int
+        offset: Int
+        filter: _InterfaceNoScalarsFilter
+      ): [InterfaceNoScalars]
       Genre(
         _id: String
         name: String
@@ -359,6 +365,14 @@ test.cb('Test augmented schema', t => {
       ratings_none: _MovieRatedFilter
       ratings_single: _MovieRatedFilter
       ratings_every: _MovieRatedFilter
+      interfaceNoScalars: _InterfaceNoScalarsFilter
+      interfaceNoScalars_not: _InterfaceNoScalarsFilter
+      interfaceNoScalars_in: [_InterfaceNoScalarsFilter!]
+      interfaceNoScalars_not_in: [_InterfaceNoScalarsFilter!]
+      interfaceNoScalars_some: _InterfaceNoScalarsFilter
+      interfaceNoScalars_none: _InterfaceNoScalarsFilter
+      interfaceNoScalars_single: _InterfaceNoScalarsFilter
+      interfaceNoScalars_every: _InterfaceNoScalarsFilter
     }
 
     input _GenreFilter {
@@ -780,6 +794,13 @@ test.cb('Test augmented schema', t => {
         @cypher(
           statement: "RETURN $cypherParams.currentUserId AS cypherParamsUserId"
         )
+      interfaceNoScalars(
+        orderBy: _InterfaceNoScalarsOrdering
+        first: Int
+        offset: Int
+        filter: _InterfaceNoScalarsFilter
+      ): [InterfaceNoScalars]
+        @relation(name: "INTERFACE_NO_SCALARS", direction: OUT)
     }
 
     type _Neo4jDateTime {

--- a/test/unit/cypherTest.test.js
+++ b/test/unit/cypherTest.test.js
@@ -682,7 +682,7 @@ test.cb('Merge node mutation', t => {
       name
     }
   }`,
-    expectedCypherQuery = `MERGE (\`user\`:\`User\`{userId: $params.userId})
+    expectedCypherQuery = `MERGE (\`user\`:\`User\`:\`Person\`{userId: $params.userId})
   SET \`user\` += {name:$params.name} RETURN \`user\` { .userId , .name } AS \`user\``;
 
   t.plan(2);


### PR DESCRIPTION
This PR contains a few fixes:

##### Issue #361 [Merge node should add interface label](https://github.com/neo4j-graphql/neo4j-graphql-js/issues/361)

This issue / inconsistency occurs when a merge node operation creates a node. I realized after the initial PR for merge operations that we should implement the same behavior that the node creation mutation has when the node is an object type implementing an interface - the node recieves both the label of its type and the label of the implemented interface.

##### Issue #349 [Interfaces with no scalar fields generate invalid schemas](https://github.com/neo4j-graphql/neo4j-graphql-js/issues/349)

This issue concerns the ordering enum type, and corresponding `orderBy` field arguments, being generated for a node type even when that type does not contain at least 1 property type field which could be used for ordering (scalar, temporal, etc.). This issue is avoided when a node is represented by an object type definition, as in such cases we guarantee the existence of at least 1 field - the `_id` field. But when an interface definition represents a node, we do not currently generate an `_id` field for it, so it opened up the possibility of generating and trying to use an empty ordering enum, built for an interface type with no fields appropriate for ordering. 

This raises the question of whether we should add the `_id` field to interfaces representing nodes. If we were to do that, it seems we would also need add the `_id` field to all object types implementing that interface.

To resolve this issue for now, the generation of an ordering enum for an object or interface node type, and any field arguments that use it, is now conditional on that node type having at least 1 property type field.
