### PR TITLE
Fixes #295: Querying interface @relation fields with non-unique relationship names

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -226,17 +226,13 @@ export const relationFieldOnNodeType = ({
         relDirection === 'in' || relDirection === 'IN' ? '<' : ''
       }-[:${safeLabel([relType])}]-${
         relDirection === 'out' || relDirection === 'OUT' ? '>' : ''
-      }(${safeVariableName}${
-        !isInlineFragment
-          ? `:${safeLabel([
-              innerSchemaType.name,
-              ...getAdditionalLabels(
-                resolveInfo.schema.getType(innerSchemaType.name),
-                cypherParams
-              )
-            ])}`
-          : ''
-      }${queryParams})${
+      }(${safeVariableName}${`:${safeLabel([
+        innerSchemaType.name,
+        ...getAdditionalLabels(
+          resolveInfo.schema.getType(innerSchemaType.name),
+          cypherParams
+        )
+      ])}`}${queryParams})${
         whereClauses.length > 0 ? ` WHERE ${whereClauses.join(' AND ')}` : ''
       } | ${nestedVariable} {${
         isInlineFragment


### PR DESCRIPTION
Issue #295 resulted from no label being added to the Cypher path pattern for related nodes being matched when querying an interface type `@relation` field. To make the path pattern more specific and prevent matching inappropriate nodes, the interface type name is now added as a label. 

For example, given the following schema: 
```graphql
interface Tools {
  id: ID
}
type Screwdriver implements Tools {
  id: ID
  size: Int!
}
type Material {
  id: ID!
}
type Product {
  materials: [Material!]! @relation(name: "USES", direction: OUT)
  tools: [Tools!]! @relation(name: "USES", direction: OUT)
}
```
And this query over the `tools` interface type `@relation` field:
```graphql
query {
  Product {
    tools {
      id
    }
  }
}
```
Current translation:
```graphql
MATCH (`product`:`Product`) RETURN `product` {tools: [(`product`)-[:`USES`]->(`product_tools`) | product_tools {FRAGMENT_TYPE: head( [ label IN labels(product_tools) WHERE label IN $Tools_derivedTypes ] ),  .id }] } AS `product`
```
Translation with the fix:
```graphql
MATCH (`product`:`Product`) RETURN `product` {tools: [(`product`)-[:`USES`]->(`product_tools`:`Tools`) | product_tools {FRAGMENT_TYPE: head( [ label IN labels(product_tools) WHERE label IN $Tools_derivedTypes ] ),  .id }] } AS `product`
```
In this translation, ```tools: [(`product`)-[:`USES`]->(`product_tools`)``` becomes ```tools: [(`product`)-[:`USES`]->(`product_tools`:`Tools`)```.

