### PR TITLE
Fix fragments on interfaced relational fields

### DIFF
--- a/src/selections.js
+++ b/src/selections.js
@@ -211,15 +211,15 @@ export function buildCypherSelection({
   });
 
   const skipLimit = computeSkipLimit(headSelection, resolveInfo.variableValues);
-
-  const subSelections = extractSelections(
-    headSelection.selectionSet ? headSelection.selectionSet.selections : [],
-    resolveInfo.fragments
-  );
+  const headSelectionSetSelections = headSelection.selectionSet
+    ? headSelection.selectionSet.selections
+    : [];
 
   let subSelection = recurse({
     initial: '',
-    selections: subSelections,
+    selections: headSelectionSetSelections.filter(
+      ({ kind }) => kind !== 'FragmentSpread'
+    ),
     variableName: nestedVariable,
     schemaType: innerSchemaType,
     resolveInfo,
@@ -235,6 +235,40 @@ export function buildCypherSelection({
     },
     secondParentSelectionInfo: parentSelectionInfo
   });
+
+  // The following code will create all field selections per FragmentSpread.
+  // Fragments can have a different schemaType than the upper field definition due to interfaces.
+  subSelection = headSelectionSetSelections
+    .filter(({ kind }) => kind === 'FragmentSpread')
+    .reduce((acc, cur, index) => {
+      const fragmentSelections = extractSelections(
+        resolveInfo.fragments[cur.name.value].selectionSet.selections,
+        resolveInfo.fragments
+      );
+
+      const fragmentSchemaType = resolveInfo.schema.getType(
+        resolveInfo.fragments[cur.name.value].typeCondition.name.value
+      );
+
+      return recurse({
+        initial: index === 0 || !acc[0] ? acc[0] : acc[0] + ',',
+        selections: fragmentSelections,
+        variableName: nestedVariable,
+        schemaType: fragmentSchemaType,
+        resolveInfo,
+        cypherParams,
+        parentSelectionInfo: {
+          fieldName,
+          schemaType,
+          variableName,
+          fieldType,
+          filterParams,
+          selections,
+          paramIndex
+        },
+        secondParentSelectionInfo: parentSelectionInfo
+      });
+    }, subSelection);
 
   let selection;
   const fieldArgs =

--- a/test/helpers/cypherTestHelpers.js
+++ b/test/helpers/cypherTestHelpers.js
@@ -152,6 +152,7 @@ export function augmentedSchemaCypherTestRunner(
 
   const resolvers = {
     QueryA: {
+      Actor: checkCypherQuery,
       User: checkCypherQuery,
       Movie: checkCypherQuery,
       MoviesByYear: checkCypherQuery,


### PR DESCRIPTION
Hi @johnymontana ,

We've encountered an issue when using Fragments on relational fields i.c.w. interfaces. Consider the following schema:

```graphql
interface LegalPersonInterface {
    id: ID!
}

type MusicGroup implements LegalPersonInterface {
    id: ID!
    name: String!
    members: [LegalPersonInterface] @relation(name: "MEMBER_OF", direction: "OUT")
}

type Actor implements LegalPersonInterface {
    id: ID!
    name: String!
    birthDate: _Neo4jDate
    birthPlace: String
}
```

With the schema definition from above, the following query resulted in an error:

```graphql
query {
    MusicGroup {
        members {
            ...actorFragment
        }
    }
}

fragment actorFragment on Actor {
    name
    birthDate
    birthPlace
}
```

This error is shown before this PR:

```
        "code": "INTERNAL_SERVER_ERROR",
        "exception": {
          "stacktrace": [
            "Error: Cannot return null for non-nullable field LegalPersonInterface.name.",
```

The problem was that all "subSelections" were being merged into a single "selectionSet". However, when converting these selections to cypher, the same "schemaType" was being used for all selections. This caused the converter to strip these fields because it couldn't find these fields in the schema.

Happy to hear your feedback!

Maybe fixes #103 