### PR TITLE
Fix nested fragments on relations

### DIFF
--- a/src/selections.js
+++ b/src/selections.js
@@ -240,7 +240,7 @@ export function buildCypherSelection({
   // Fragments can have a different schemaType than the upper field definition due to interfaces.
   subSelection = headSelectionSetSelections
     .filter(({ kind }) => kind === 'FragmentSpread')
-    .reduce((acc, cur, index) => {
+    .reduce((acc, cur) => {
       const fragmentSelections = extractSelections(
         resolveInfo.fragments[cur.name.value].selectionSet.selections,
         resolveInfo.fragments
@@ -251,7 +251,7 @@ export function buildCypherSelection({
       );
 
       return recurse({
-        initial: index === 0 || !acc[0] ? acc[0] : acc[0] + ',',
+        initial: !acc[0] ? acc[0] : acc[0] + ',',
         selections: fragmentSelections,
         variableName: nestedVariable,
         schemaType: fragmentSchemaType,

--- a/test/unit/cypherTest.test.js
+++ b/test/unit/cypherTest.test.js
@@ -1833,6 +1833,7 @@ test('nested fragments on relations', t => {
     fragment Foo on Movie {
       title
       actors {
+        userId
         ...Bar
       }
     }
@@ -1840,7 +1841,7 @@ test('nested fragments on relations', t => {
     fragment Bar on Actor {
       name
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .name }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .userId , .name }] } AS \`movie\``;
 
   t.plan(3);
   return Promise.all([


### PR DESCRIPTION
This pull request will fix nested fragments on relations combined with properties.

The following query resulted in an error:

```graphql
fragment moreProperties on Camera {
  type
}

fragment properties on CameraMan {
  cameras {
    id
    ...moreProperties
  }
}

query {
  CameraMan {
    ...properties
  }
}
```

Caused by #377