### PR TITLE
Pass cypher params to inline fragments (with @cypher fields)

### DIFF
--- a/src/selections.js
+++ b/src/selections.js
@@ -101,6 +101,7 @@ export function buildCypherSelection({
         );
         let fragmentTailParams = {
           selections: fragmentSelections,
+          cypherParams,
           variableName,
           schemaType: fragmentSchemaType,
           resolveInfo,

--- a/test/unit/cypherTest.test.js
+++ b/test/unit/cypherTest.test.js
@@ -2117,13 +2117,14 @@ test('query using inline fragment', t => {
           ... on User {
             name
             userId
+            currentUserId
           }
         }
       }
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .name , .userId }]) }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .name , .userId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: movie_ratings_User, cypherParams: $cypherParams, strArg: "Neo4j"}, false)}]) }] } AS \`movie\``;
 
   t.plan(1);
 


### PR DESCRIPTION
When querying fields with a custom `@cypher` statement given `$cypherParams` could not be used if they were selected within an inline fragment. This PR addresses the issue.