### PR TITLE
Translating fragments on interface types

### DIFF
--- a/example/apollo-server/movies-schema.js
+++ b/example/apollo-server/movies-schema.js
@@ -46,6 +46,7 @@ type Actor {
   id: ID!
   name: String
   movies: [Movie] @relation(name: "ACTED_IN", direction: "OUT")
+  knows: [Person] @relation(name: "KNOWS", direction: "OUT")
 }
 
 type User implements Person {
@@ -87,6 +88,8 @@ interface Camera {
   type: String
   make: String
   weight: Int
+  operators: [Person] @relation(name: "cameras", direction: IN)
+  computedOperators(name: String): [Person] @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
 }
 
 type OldCamera implements Camera {
@@ -95,6 +98,8 @@ type OldCamera implements Camera {
   make: String
   weight: Int
   smell: String
+  operators: [Person] @relation(name: "cameras", direction: IN)
+  computedOperators(name: String): [Person] @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
 }
 
 type NewCamera implements Camera {
@@ -103,6 +108,8 @@ type NewCamera implements Camera {
   make: String
   weight: Int
   features: [String]
+  operators: [Person] @relation(name: "cameras", direction: IN)
+  computedOperators(name: String): [Person] @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
 }
 
 type CameraMan implements Person {
@@ -115,11 +122,19 @@ type CameraMan implements Person {
 }
 
 type Query {
-  Movie(movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float): [Movie]  MoviesByYear(year: Int, first: Int = 10, offset: Int = 0): [Movie]
+  Movie(movieId: ID, title: String, year: Int, plot: String, poster: String, imdbRating: Float): [Movie]
+  MoviesByYear(year: Int, first: Int = 10, offset: Int = 0): [Movie]
   AllMovies: [Movie]
   MovieById(movieId: ID!): Movie
   GenresBySubstring(substring: String): [Genre] @cypher(statement: "MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g")
   Books: [Book]
+  CustomCameras: [Camera] @cypher(statement: "MATCH (c:Camera) RETURN c")
+  CustomCamera: Camera @cypher(statement: "MATCH (c:Camera) RETURN c")
+}
+
+type Mutation {
+  CustomCamera: Camera @cypher(statement: "CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro'}) RETURN newCamera")
+  CustomCameras: [Camera] @cypher(statement: "CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro', features: ['selfie', 'zoom']}) CREATE (oldCamera:Camera:OldCamera {id: apoc.create.uuid(), type: 'floating', smell: 'rusty' }) RETURN [newCamera, oldCamera]")
 }
 `;
 
@@ -146,15 +161,3 @@ export const resolvers = {
     }
   }
 };
-
-// Mutation: {
-//   CreateGenre(object, params, ctx, resolveInfo) {
-//     return neo4jgraphql(object, params, ctx, resolveInfo, true);
-//   },
-//   CreateMovie(object, params, ctx, resolveInfo) {
-//     return neo4jgraphql(object, params, ctx, resolveInfo, true);
-//   },
-//   AddMovieGenre(object, params, ctx, resolveInfo) {
-//     return neo4jgraphql(object, params, ctx, resolveInfo, true);
-//   }
-// }

--- a/src/augment/fields.js
+++ b/src/augment/fields.js
@@ -20,14 +20,17 @@ export const Neo4jSystemIDField = `_id`;
  * See: https://neo4j.com/docs/cypher-manual/current/syntax/values/#property-types
  */
 export const isPropertyTypeField = ({ kind, type }) =>
+  isScalarField({ kind, type }) ||
+  isTemporalField({ type }) ||
+  isSpatialField({ type }) ||
+  isNeo4jPropertyType({ type });
+
+export const isScalarField = ({ kind, type }) =>
   isIntegerField({ type }) ||
   isFloatField({ type }) ||
   isStringField({ kind, type }) ||
   isBooleanField({ type }) ||
-  isCustomScalarField({ kind }) ||
-  isTemporalField({ type }) ||
-  isSpatialField({ type }) ||
-  isNeo4jPropertyType({ type });
+  isCustomScalarField({ kind });
 
 export const isIntegerField = ({ type }) =>
   Neo4jDataType.PROPERTY[type] === 'Integer';

--- a/src/selections.js
+++ b/src/selections.js
@@ -8,7 +8,6 @@ import {
   getFilterParams,
   innerType,
   isGraphqlScalarType,
-  extractSelections,
   relationDirective,
   getRelationTypeDirective,
   decideNestedVariableName,
@@ -16,8 +15,8 @@ import {
   isNeo4jType,
   isNeo4jTypeField,
   getNeo4jTypeArguments,
-  neo4jTypePredicateClauses,
-  removeIgnoredFields
+  removeIgnoredFields,
+  getDerivedTypeNames
 } from './utils';
 import {
   customCypherField,
@@ -25,8 +24,20 @@ import {
   relationTypeFieldOnNodeType,
   nodeTypeFieldOnRelationType,
   neo4jType,
-  neo4jTypeField
+  neo4jTypeField,
+  derivedTypesParams
 } from './translate';
+import { Kind } from 'graphql';
+import {
+  isObjectTypeDefinition,
+  isInterfaceTypeDefinition,
+  isUnionTypeDefinition
+} from './augment/types/types';
+import {
+  unwrapNamedType,
+  TypeWrappers,
+  Neo4jSystemIDField
+} from './augment/fields';
 
 export function buildCypherSelection({
   initial = '',
@@ -54,19 +65,7 @@ export function buildCypherSelection({
     {}
   );
 
-  const [headSelection, ...tailSelections] = selections;
-
-  let tailParams = {
-    selections: tailSelections,
-    cypherParams,
-    variableName,
-    paramIndex,
-    schemaType,
-    resolveInfo,
-    parentSelectionInfo,
-    secondParentSelectionInfo
-  };
-
+  // TODO move recurse out of buildCypherSelection, refactoring paramIndex
   const recurse = args => {
     paramIndex =
       Object.keys(shallowFilterParams).length > 0 ? paramIndex + 1 : paramIndex;
@@ -89,174 +88,197 @@ export function buildCypherSelection({
     ];
   };
 
-  if (selections.find(({ kind }) => kind && kind === 'InlineFragment')) {
-    return selections
-      .filter(({ kind }) => kind && kind === 'InlineFragment')
-      .reduce((query, selection, index) => {
-        const fragmentSelections = selections
-          .filter(({ kind }) => kind && kind !== 'InlineFragment')
-          .concat(selection.selectionSet.selections);
-        const fragmentSchemaType = resolveInfo.schema.getType(
-          selection.typeCondition.name.value
-        );
-        let fragmentTailParams = {
-          selections: fragmentSelections,
-          variableName,
-          schemaType: fragmentSchemaType,
-          resolveInfo,
-          parentSelectionInfo,
-          secondParentSelectionInfo
-        };
-        const result = recurse({
-          initial: index === 0 ? query[0] : query[0] + ',',
-          ...fragmentTailParams
-        });
-        return result;
-      }, initial || ['']);
-  }
+  let selection = [];
+  let subSelection = [];
 
-  const fieldName = headSelection.name.value;
-  const commaIfTail = tailSelections.length > 0 ? ',' : '';
-  const isScalarSchemaType = isGraphqlScalarType(schemaType);
-  const schemaTypeField = !isScalarSchemaType
+  const [headSelection, ...tailSelections] = selections;
+  const fieldName =
+    headSelection && headSelection.name ? headSelection.name.value : '';
+  const typeMap = resolveInfo.schema.getTypeMap();
+  const schemaTypeName = schemaType.name;
+  const schemaTypeAstNode = typeMap[schemaType].astNode;
+  const safeVariableName = safeVar(variableName);
+
+  const usesFragments = isFragmentedSelection({ selections });
+  const isScalarType = isGraphqlScalarType(schemaType);
+  const schemaTypeField = !isScalarType
     ? schemaType.getFields()[fieldName]
     : {};
-  // Schema meta fields(__schema, __typename, etc)
-  if (!isScalarSchemaType && !schemaTypeField) {
-    return recurse({
-      initial: tailSelections.length
-        ? initial
-        : initial.substring(0, initial.lastIndexOf(',')),
-      ...tailParams
-    });
-  }
 
-  const fieldType =
-    schemaTypeField && schemaTypeField.type ? schemaTypeField.type : {};
-  const innerSchemaType = innerType(fieldType); // for target "type" aka label
-
-  const isInlineFragment =
-    innerSchemaType &&
-    innerSchemaType.astNode &&
-    innerSchemaType.astNode.kind === 'InterfaceTypeDefinition';
-  const { statement: customCypher } = cypherDirective(schemaType, fieldName);
-  const typeMap = resolveInfo.schema.getTypeMap();
-  const schemaTypeAstNode = typeMap[schemaType].astNode;
-
-  // Database meta fields(_id)
-  if (fieldName === '_id') {
-    return recurse({
-      initial: `${initial}${fieldName}: ID(${safeVar(
-        variableName
-      )})${commaIfTail}`,
-      ...tailParams
-    });
-  }
-  // Main control flow
-  if (isGraphqlScalarType(innerSchemaType)) {
-    if (customCypher) {
-      if (getRelationTypeDirective(schemaTypeAstNode)) {
-        variableName = `${variableName}_relation`;
-      }
-      return recurse({
-        initial: `${initial}${fieldName}: apoc.cypher.runFirstColumn("${customCypher}", {${cypherDirectiveArgs(
-          variableName,
-          headSelection,
-          cypherParams,
-          schemaType,
-          resolveInfo,
-          paramIndex
-        )}}, false)${commaIfTail}`,
-        ...tailParams
-      });
-    } else if (isNeo4jTypeField(schemaType, fieldName)) {
-      return recurse(
-        neo4jTypeField({
-          initial,
-          fieldName,
-          variableName,
-          commaIfTail,
-          tailParams,
-          parentSelectionInfo,
-          secondParentSelectionInfo
-        })
-      );
-    }
-    // graphql scalar type, no custom cypher statement
-    return recurse({
-      initial: `${initial} .${fieldName} ${commaIfTail}`,
-      ...tailParams
-    });
-  }
-  // We have a graphql object type
-  const innerSchemaTypeAstNode =
-    innerSchemaType && typeMap[innerSchemaType]
-      ? typeMap[innerSchemaType].astNode
-      : {};
-  const innerSchemaTypeRelation = getRelationTypeDirective(
-    innerSchemaTypeAstNode
-  );
-  const schemaTypeRelation = getRelationTypeDirective(schemaTypeAstNode);
-  const { name: relType, direction: relDirection } = relationDirective(
+  const isInterfaceType = isInterfaceTypeDefinition({
+    definition: schemaTypeAstNode
+  });
+  const isObjectType = isObjectTypeDefinition({
+    definition: schemaTypeAstNode
+  });
+  const isUnionType = isUnionTypeDefinition({
+    definition: schemaTypeAstNode
+  });
+  const isFragmentedInterfaceType = usesFragments && isInterfaceType;
+  const isFragmentedObjectType = usesFragments && isObjectType;
+  const { statement: customCypherStatement } = cypherDirective(
     schemaType,
     fieldName
   );
 
-  const nestedVariable = decideNestedVariableName({
-    schemaTypeRelation,
-    innerSchemaTypeRelation,
-    variableName,
-    fieldName,
-    parentSelectionInfo
-  });
-
-  const skipLimit = computeSkipLimit(headSelection, resolveInfo.variableValues);
-  const headSelectionSetSelections = headSelection.selectionSet
-    ? headSelection.selectionSet.selections
-    : [];
-
-  let subSelection = recurse({
-    initial: '',
-    selections: headSelectionSetSelections.filter(
-      ({ kind }) => kind !== 'FragmentSpread'
-    ),
-    variableName: nestedVariable,
-    schemaType: innerSchemaType,
-    resolveInfo,
+  let tailParams = {
+    selections: tailSelections,
     cypherParams,
-    parentSelectionInfo: {
-      fieldName,
+    variableName,
+    paramIndex,
+    schemaType,
+    resolveInfo,
+    shallowFilterParams,
+    parentSelectionInfo,
+    secondParentSelectionInfo
+  };
+
+  let translationConfig = undefined;
+
+  if (isFragmentedInterfaceType || isUnionType || isFragmentedObjectType) {
+    const [schemaTypeFields, composedTypeMap] = mergeSelectionFragments({
       schemaType,
-      variableName,
-      fieldType,
-      filterParams,
       selections,
-      paramIndex
-    },
-    secondParentSelectionInfo: parentSelectionInfo
-  });
-
-  // The following code will create all field selections per FragmentSpread.
-  // Fragments can have a different schemaType than the upper field definition due to interfaces.
-  subSelection = headSelectionSetSelections
-    .filter(({ kind }) => kind === 'FragmentSpread')
-    .reduce((acc, cur) => {
-      const fragmentSelections = extractSelections(
-        resolveInfo.fragments[cur.name.value].selectionSet.selections,
-        resolveInfo.fragments
+      isFragmentedObjectType,
+      resolveInfo
+    });
+    const hasOnlySchemaTypeFragments =
+      schemaTypeFields.length > 0 && Object.keys(composedTypeMap).length === 0;
+    if (hasOnlySchemaTypeFragments || isFragmentedObjectType) {
+      tailParams.selections = schemaTypeFields;
+      translationConfig = tailParams;
+    } else if (isFragmentedInterfaceType || isUnionType) {
+      const implementingTypes = getComposedTypes({
+        schemaTypeName,
+        schemaTypeAstNode,
+        isFragmentedInterfaceType,
+        isUnionType,
+        isFragmentedObjectType,
+        resolveInfo
+      });
+      // TODO Make this a new function once recurse is moved out of buildCypherSelection
+      // so that we don't have to start passing recurse as an argument
+      const [fragmentedQuery, queryParams] = implementingTypes.reduce(
+        ([listComprehensions, params], implementingType) => {
+          // Get merged selections of this implementing type
+          let mergedTypeSelections = composedTypeMap[implementingType];
+          if (!mergedTypeSelections) {
+            // If no fields of this implementing type were selected,
+            // use at least any interface fields selected generally
+            mergedTypeSelections = schemaTypeFields;
+          }
+          if (mergedTypeSelections.length) {
+            // If selections have been made for this type after merging
+            if (isFragmentedInterfaceType || isUnionType) {
+              schemaType = resolveInfo.schema.getType(implementingType);
+            }
+            // TODO Refactor when recurse is moved out buildCypherSelection
+            // Build the map projection for this implementing type
+            let [fragmentedQuery, queryParams] = recurse({
+              ...tailParams,
+              schemaType,
+              selections: mergedTypeSelections,
+              paramIndex
+            });
+            if (isFragmentedInterfaceType || isUnionType) {
+              // Build a more complex list comprehension for
+              // this type, to be aggregated together later
+              fragmentedQuery = buildComposedTypeListComprehension({
+                implementingType,
+                safeVariableName,
+                fragmentedQuery
+              });
+            }
+            listComprehensions.push(fragmentedQuery);
+            // Merge any cypher params built for field arguments
+            params = { ...params, ...queryParams };
+          }
+          return [listComprehensions, params];
+        },
+        [[], {}]
       );
+      const composedQuery = concatenateComposedTypeLists({
+        fragmentedQuery
+      });
+      selection = [composedQuery, queryParams];
+    }
+  } else {
+    const fieldType =
+      schemaTypeField && schemaTypeField.type ? schemaTypeField.type : {};
+    const innerSchemaType = innerType(fieldType); // for target "type" aka label
 
-      const fragmentSchemaType = resolveInfo.schema.getType(
-        resolveInfo.fragments[cur.name.value].typeCondition.name.value
+    // TODO Switch to using schemaTypeField.astNode instead of schemaTypeField
+    // so the field type could be extracted using unwrapNamedType. We could explicitly check
+    // the ast for list type wrappers (changing isArrayType calls in translate.js) and we
+    // could use in the branching logic here, the same astNode.kind based predicate functions
+    // used in the  augmentation code (ex: from isObjectType to isObjectTypeDefinition from ast.js)
+    const fieldAstNode = schemaTypeField ? schemaTypeField.astNode : {};
+    const fieldTypeWrappers = unwrapNamedType({ type: fieldAstNode });
+    const fieldTypeName = fieldTypeWrappers[TypeWrappers.NAME];
+    const innerSchemaTypeAstNode = typeMap[fieldTypeName]
+      ? typeMap[fieldTypeName].astNode
+      : {};
+
+    const commaIfTail = tailSelections.length > 0 ? ',' : '';
+
+    const isIntrospectionField = !isScalarType && !schemaTypeField;
+    const isScalarTypeField = isGraphqlScalarType(innerSchemaType);
+    const isObjectTypeField = isObjectTypeDefinition({
+      definition: innerSchemaTypeAstNode
+    });
+    const isInterfaceTypeField = isInterfaceTypeDefinition({
+      definition: innerSchemaTypeAstNode
+    });
+    if (isIntrospectionField) {
+      // Schema meta fields(__schema, __typename, etc)
+      translationConfig = {
+        ...tailParams,
+        initial: tailSelections.length
+          ? initial
+          : initial.substring(0, initial.lastIndexOf(','))
+      };
+    } else if (isScalarTypeField) {
+      translationConfig = translateScalarTypeField({
+        fieldName,
+        initial,
+        variableName,
+        commaIfTail,
+        tailParams,
+        customCypherStatement,
+        schemaType,
+        schemaTypeAstNode,
+        headSelection,
+        resolveInfo,
+        paramIndex,
+        cypherParams,
+        parentSelectionInfo,
+        secondParentSelectionInfo
+      });
+    } else if (isObjectType || isInterfaceType) {
+      const schemaTypeRelation = getRelationTypeDirective(schemaTypeAstNode);
+      const innerSchemaTypeRelation = getRelationTypeDirective(
+        innerSchemaTypeAstNode
       );
+      const nestedVariable = decideNestedVariableName({
+        schemaTypeRelation,
+        innerSchemaTypeRelation,
+        variableName,
+        fieldName,
+        parentSelectionInfo
+      });
+      const fieldSelectionSet =
+        headSelection && headSelection.selectionSet
+          ? headSelection.selectionSet.selections
+          : [];
 
-      return recurse({
-        initial: !acc[0] ? acc[0] : acc[0] + ',',
-        selections: fragmentSelections,
+      subSelection = recurse({
+        selections: fieldSelectionSet,
         variableName: nestedVariable,
-        schemaType: fragmentSchemaType,
+        paramIndex,
+        schemaType: innerSchemaType,
         resolveInfo,
         cypherParams,
+        shallowFilterParams,
         parentSelectionInfo: {
           fieldName,
           schemaType,
@@ -268,120 +290,366 @@ export function buildCypherSelection({
         },
         secondParentSelectionInfo: parentSelectionInfo
       });
-    }, subSelection);
 
-  let selection;
-  const fieldArgs =
-    !isScalarSchemaType && schemaTypeField && schemaTypeField.args
-      ? schemaTypeField.args.map(e => e.astNode)
-      : [];
-
-  const neo4jTypeArgs = getNeo4jTypeArguments(fieldArgs);
-  const queryParams = paramsToString(
-    innerFilterParams(filterParams, neo4jTypeArgs)
-  );
-  const fieldInfo = {
-    initial,
-    fieldName,
-    fieldType,
-    variableName,
-    nestedVariable,
-    queryParams,
-    filterParams,
-    neo4jTypeArgs,
-    subSelection,
-    skipLimit,
-    commaIfTail,
-    tailParams
-  };
-  if (customCypher) {
-    // Object type field with cypher directive
-    selection = recurse(
-      customCypherField({
-        ...fieldInfo,
-        cypherParams,
-        paramIndex,
-        schemaType,
-        schemaTypeRelation,
-        customCypher,
+      const fieldArgs =
+        !isScalarType && schemaTypeField && schemaTypeField.args
+          ? schemaTypeField.args.map(e => e.astNode)
+          : [];
+      const neo4jTypeArgs = getNeo4jTypeArguments(fieldArgs);
+      const queryParams = paramsToString(
+        innerFilterParams(filterParams, neo4jTypeArgs)
+      );
+      const skipLimit = computeSkipLimit(
         headSelection,
-        resolveInfo
-      })
-    );
-  } else if (isNeo4jType(innerSchemaType.name)) {
-    selection = recurse(
-      neo4jType({
+        resolveInfo.variableValues
+      );
+      const { name: relType, direction: relDirection } = relationDirective(
         schemaType,
-        schemaTypeRelation,
-        parentSelectionInfo,
-        ...fieldInfo
-      })
-    );
-  } else if (relType && relDirection) {
-    // Object type field with relation directive
-    const neo4jTypeClauses = neo4jTypePredicateClauses(
-      filterParams,
-      nestedVariable,
-      neo4jTypeArgs
-    );
-    // translate field, arguments and argument params
-    const translation = relationFieldOnNodeType({
-      ...fieldInfo,
-      schemaType,
-      selections,
-      selectionFilters,
-      relDirection,
-      relType,
-      isInlineFragment,
-      innerSchemaType,
-      neo4jTypeClauses,
-      resolveInfo,
-      paramIndex,
-      fieldArgs,
-      cypherParams
-    });
-    selection = recurse(translation.selection);
-    // set subSelection to update field argument params
-    subSelection = translation.subSelection;
-  } else if (schemaTypeRelation) {
-    // Object type field on relation type
-    // (from, to, renamed, relation mutation payloads...)
-    const translation = nodeTypeFieldOnRelationType({
-      fieldInfo,
-      schemaTypeRelation,
-      innerSchemaType,
-      isInlineFragment,
-      paramIndex,
-      schemaType,
-      filterParams,
-      neo4jTypeArgs,
-      parentSelectionInfo,
-      resolveInfo,
-      selectionFilters,
-      fieldArgs,
-      cypherParams
-    });
-    selection = recurse(translation.selection);
-    // set subSelection to update field argument params
-    subSelection = translation.subSelection;
-  } else if (innerSchemaTypeRelation) {
-    // Relation type field on node type (field payload types...)
-    const translation = relationTypeFieldOnNodeType({
-      ...fieldInfo,
-      innerSchemaTypeRelation,
-      schemaType,
-      innerSchemaType,
-      filterParams,
-      neo4jTypeArgs,
-      resolveInfo,
-      selectionFilters,
-      paramIndex,
-      fieldArgs,
-      cypherParams
-    });
-    selection = recurse(translation.selection);
-    // set subSelection to update field argument params
-    subSelection = translation.subSelection;
+        fieldName
+      );
+
+      const usesFragments = isFragmentedSelection({
+        selections: fieldSelectionSet
+      });
+      const isFragmentedObjectTypeField = isObjectTypeField && usesFragments;
+      const [schemaTypeFields, composedTypeMap] = mergeSelectionFragments({
+        schemaType: innerSchemaType,
+        selections: fieldSelectionSet,
+        isFragmentedObjectType: isFragmentedObjectTypeField,
+        resolveInfo
+      });
+      const fragmentTypeParams = derivedTypesParams({
+        isInterfaceType: isInterfaceTypeField,
+        schema: resolveInfo.schema,
+        interfaceName: innerSchemaType.name,
+        usesFragments
+      });
+      subSelection[1] = { ...subSelection[1], ...fragmentTypeParams };
+      if (customCypherStatement) {
+        // Object type field with cypher directive
+        translationConfig = customCypherField({
+          customCypherStatement,
+          cypherParams,
+          paramIndex,
+          schemaTypeRelation,
+          isInterfaceTypeField,
+          usesFragments,
+          schemaTypeFields,
+          composedTypeMap,
+          initial,
+          fieldName,
+          fieldType,
+          fieldTypeName,
+          nestedVariable,
+          variableName,
+          headSelection,
+          schemaType,
+          innerSchemaType,
+          resolveInfo,
+          subSelection,
+          skipLimit,
+          commaIfTail,
+          tailParams
+        });
+      } else if (isNeo4jType(fieldTypeName)) {
+        translationConfig = neo4jType({
+          initial,
+          fieldName,
+          subSelection,
+          commaIfTail,
+          tailParams,
+          variableName,
+          nestedVariable,
+          fieldType,
+          schemaType,
+          schemaTypeRelation,
+          parentSelectionInfo
+        });
+      } else if (relType && relDirection) {
+        // Object type field with relation directive
+        [translationConfig, subSelection] = relationFieldOnNodeType({
+          initial,
+          fieldName,
+          fieldType,
+          variableName,
+          relDirection,
+          relType,
+          nestedVariable,
+          schemaTypeFields,
+          composedTypeMap,
+          isInterfaceTypeField,
+          usesFragments,
+          innerSchemaType,
+          paramIndex,
+          fieldArgs,
+          filterParams,
+          selectionFilters,
+          neo4jTypeArgs,
+          selections,
+          schemaType,
+          subSelection,
+          skipLimit,
+          commaIfTail,
+          tailParams,
+          resolveInfo,
+          cypherParams
+        });
+      } else if (schemaTypeRelation) {
+        // Object type field on relation type
+        // (from, to, renamed, relation mutation payloads...)
+        [translationConfig, subSelection] = nodeTypeFieldOnRelationType({
+          initial,
+          fieldName,
+          fieldType,
+          variableName,
+          nestedVariable,
+          queryParams,
+          subSelection,
+          skipLimit,
+          commaIfTail,
+          tailParams,
+          filterParams,
+          neo4jTypeArgs,
+          schemaTypeRelation,
+          innerSchemaType,
+          schemaTypeFields,
+          composedTypeMap,
+          isInterfaceTypeField,
+          usesFragments,
+          paramIndex,
+          parentSelectionInfo,
+          resolveInfo,
+          selectionFilters,
+          fieldArgs,
+          cypherParams
+        });
+      } else if (innerSchemaTypeRelation) {
+        // Relation type field on node type (field payload types...)
+        // and set subSelection to update field argument params
+        [translationConfig, subSelection] = relationTypeFieldOnNodeType({
+          innerSchemaTypeRelation,
+          initial,
+          fieldName,
+          subSelection,
+          skipLimit,
+          commaIfTail,
+          tailParams,
+          fieldType,
+          variableName,
+          schemaType,
+          innerSchemaType,
+          nestedVariable,
+          queryParams,
+          filterParams,
+          neo4jTypeArgs,
+          resolveInfo,
+          selectionFilters,
+          paramIndex,
+          fieldArgs,
+          cypherParams
+        });
+      }
+    }
+  }
+  if (translationConfig) {
+    selection = recurse(translationConfig);
   }
   return [selection[0], { ...selection[1], ...subSelection[1] }];
 }
+
+const translateScalarTypeField = ({
+  fieldName,
+  initial,
+  variableName,
+  commaIfTail,
+  tailParams,
+  customCypherStatement,
+  schemaType,
+  schemaTypeAstNode,
+  headSelection,
+  resolveInfo,
+  paramIndex,
+  cypherParams,
+  parentSelectionInfo,
+  secondParentSelectionInfo
+}) => {
+  if (fieldName === Neo4jSystemIDField) {
+    return {
+      initial: `${initial}${fieldName}: ID(${safeVar(
+        variableName
+      )})${commaIfTail}`,
+      ...tailParams
+    };
+  } else {
+    if (customCypherStatement) {
+      if (getRelationTypeDirective(schemaTypeAstNode)) {
+        variableName = `${variableName}_relation`;
+      }
+      return {
+        initial: `${initial}${fieldName}: apoc.cypher.runFirstColumn("${customCypherStatement}", {${cypherDirectiveArgs(
+          variableName,
+          headSelection,
+          cypherParams,
+          schemaType,
+          resolveInfo,
+          paramIndex
+        )}}, false)${commaIfTail}`,
+        ...tailParams
+      };
+    } else if (isNeo4jTypeField(schemaType, fieldName)) {
+      return neo4jTypeField({
+        initial,
+        fieldName,
+        variableName,
+        commaIfTail,
+        tailParams,
+        parentSelectionInfo,
+        secondParentSelectionInfo
+      });
+    }
+    // graphql scalar type, no custom cypher statement
+    return {
+      initial: `${initial} .${fieldName} ${commaIfTail}`,
+      ...tailParams
+    };
+  }
+};
+
+export const mergeSelectionFragments = ({
+  schemaType,
+  selections,
+  isFragmentedObjectType,
+  resolveInfo
+}) => {
+  let schemaTypeFields = [];
+  const composedTypeMap = {};
+  const schemaTypeName = schemaType.name;
+  const fragmentDefinitions = resolveInfo.fragments;
+  selections.forEach(selection => {
+    let fieldKind = selection.kind;
+    if (fieldKind === Kind.FIELD) {
+      schemaTypeFields.push(selection);
+    } else if (
+      fieldKind === Kind.INLINE_FRAGMENT ||
+      fieldKind === Kind.FRAGMENT_SPREAD
+    ) {
+      let fragmentSelections = [];
+      let typeCondition = '';
+      if (fieldKind === Kind.FRAGMENT_SPREAD) {
+        const fragmentDefinition = fragmentDefinitions[selection.name.value];
+        fragmentSelections = fragmentDefinition.selectionSet.selections;
+        typeCondition = fragmentDefinition.typeCondition;
+      } else {
+        fragmentSelections = selection.selectionSet.selections;
+        typeCondition = selection.typeCondition;
+      }
+      const typeName = typeCondition ? typeCondition.name.value : '';
+      if (typeName) {
+        // For fragments on the same type containing the fragment or
+        // for inline fragments without type conditions
+        if (typeName === schemaTypeName) {
+          schemaTypeFields.push(...fragmentSelections);
+        } else {
+          const typeSelections = composedTypeMap[typeName];
+          // Initialize selection set array for this type
+          if (!typeSelections) {
+            composedTypeMap[typeName] = fragmentSelections;
+          } else {
+            // for aggregation of multiple fragments on the same type
+            composedTypeMap[typeName].push(...fragmentSelections);
+          }
+        }
+      } else {
+        // For inline untyped fragments on the same type, ex: ...{ title }
+        schemaTypeFields.push(...fragmentSelections);
+      }
+    }
+  });
+  if (isFragmentedObjectType) {
+    // Composed object queries still only use a single map projection
+    composedTypeMap[schemaTypeName] = schemaTypeFields;
+  }
+  Object.keys(composedTypeMap).forEach(typeName => {
+    composedTypeMap[typeName] = mergeFragmentedSelections({
+      selections: [...composedTypeMap[typeName], ...schemaTypeFields]
+    });
+  });
+  schemaTypeFields = mergeFragmentedSelections({
+    selections: schemaTypeFields
+  });
+  // When querying an interface type using fragments, queries are made
+  // more specific if there is not at least 1 interface field selected.
+  // So the __typename field is removed here to prevent interpreting it
+  // as a field for which a value could be obtained from matched data.
+  // Otherwisez all interface type nodes would always be returned even
+  // when only using fragments to select fields on implementing types
+  const typeNameFieldIndex = schemaTypeFields.findIndex(
+    field => field.name && field.name.value === '__typename'
+  );
+  if (typeNameFieldIndex !== -1) schemaTypeFields.splice(typeNameFieldIndex, 1);
+  return [schemaTypeFields, composedTypeMap];
+};
+
+const mergeFragmentedSelections = ({ selections = [] }) => {
+  const mergedSelections = selections.reduce((merged, selection) => {
+    const fieldName = selection.name.value;
+    if (!merged[fieldName]) {
+      // initialize entry for this composing type
+      merged[fieldName] = selection;
+    } else {
+      // FIXME Deeply merge selection sets of fragments on the same type
+    }
+    return merged;
+  }, {});
+  return Object.values(mergedSelections);
+};
+
+export const getComposedTypes = ({
+  schemaTypeName,
+  schemaTypeAstNode,
+  isFragmentedInterfaceType,
+  isUnionType,
+  isFragmentedObjectType,
+  resolveInfo
+}) => {
+  let implementingTypes = [];
+  if (isFragmentedInterfaceType) {
+    // Get an array of all types implementing this interface type
+    implementingTypes = getDerivedTypeNames(resolveInfo.schema, schemaTypeName);
+  } else if (isUnionType) {
+    implementingTypes = schemaTypeAstNode.types.reduce((types, type) => {
+      types.push(type.name.value);
+      return types;
+    }, []);
+  } else if (isFragmentedObjectType) {
+    implementingTypes.push(schemaTypeName);
+  }
+  return implementingTypes;
+};
+
+export const isFragmentedSelection = ({ selections }) => {
+  return selections.find(
+    selection =>
+      selection.kind === Kind.INLINE_FRAGMENT ||
+      selection.kind === Kind.FRAGMENT_SPREAD
+  );
+};
+
+const buildComposedTypeListComprehension = ({
+  implementingType,
+  safeVariableName,
+  fragmentedQuery
+}) => {
+  const fragmentTypeField = `FRAGMENT_TYPE: "${implementingType}"`;
+  const typeMapProjection = `${safeVariableName} { ${fragmentTypeField}${
+    // When __typename is the only field selected not within a fragment,
+    // fragmentedQuery is undefined, so that we only provide the FRAGMENT_TYPE
+    fragmentedQuery ? `, ${fragmentedQuery}` : ''
+  } }`;
+  const typeListComprehension = `${safeVariableName} IN [${safeVariableName}] WHERE [label IN labels(${safeVariableName}) WHERE label = "${implementingType}" | TRUE]`;
+  return `[${typeListComprehension} | ${typeMapProjection}]`;
+};
+
+// See: https://neo4j.com/docs/cypher-manual/current/syntax/operators/#syntax-concatenating-two-lists
+const concatenateComposedTypeLists = ({ fragmentedQuery }) =>
+  `head(${fragmentedQuery.join(` + `)})`;

--- a/test/helpers/cypherTestHelpers.js
+++ b/test/helpers/cypherTestHelpers.js
@@ -32,6 +32,8 @@ type Mutation {
     computedTemporal: DateTime @cypher(statement: "WITH datetime() AS now RETURN { year: now.year, month: now.month , day: now.day , hour: now.hour , minute: now.minute , second: now.second , millisecond: now.millisecond , microsecond: now.microsecond , nanosecond: now.nanosecond , timezone: now.timezone , formatted: toString(now) }")
     computedSpatial: Point @cypher(statement: "WITH point({ x: 10, y: 20, z: 15 }) AS instance RETURN { x: instance.x, y: instance.y, z: instance.z, crs: instance.crs }")
     customWithArguments(strArg: String, strInputArg: strInput): String @cypher(statement: "RETURN $strInputArg.strArg")
+    CustomCamera: Camera @cypher(statement: "CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro'}) RETURN newCamera")
+    CustomCameras: [Camera] @cypher(statement: "CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro', features: ['selfie', 'zoom']}) CREATE (oldCamera:Camera:OldCamera {id: apoc.create.uuid(), type: 'floating', smell: 'rusty' }) RETURN [newCamera, oldCamera]")
   }
 `;
 
@@ -59,6 +61,9 @@ type Mutation {
       GenresBySubstring: checkCypherQuery,
       Books: checkCypherQuery,
       State: checkCypherQuery,
+      Camera: checkCypherQuery,
+      CustomCameras: checkCypherQuery,
+      CustomCamera: checkCypherQuery,
       computedBoolean: checkCypherQuery,
       computedInt: checkCypherQuery,
       computedFloat: checkCypherQuery,
@@ -82,7 +87,9 @@ type Mutation {
       computedStringList: checkCypherMutation,
       computedTemporal: checkCypherMutation,
       computedSpatial: checkCypherMutation,
-      customWithArguments: checkCypherMutation
+      customWithArguments: checkCypherMutation,
+      CustomCamera: checkCypherMutation,
+      CustomCameras: checkCypherMutation
     }
   };
   let augmentedTypeDefs = augmentTypeDefs(testMovieSchema, { auth: true });
@@ -174,6 +181,9 @@ export function augmentedSchemaCypherTestRunner(
       SpatialNode: checkCypherQuery,
       State: checkCypherQuery,
       CasedType: checkCypherQuery,
+      Camera: checkCypherQuery,
+      CustomCameras: checkCypherQuery,
+      CustomCamera: checkCypherQuery,
       computedBoolean: checkCypherQuery,
       computedInt: checkCypherQuery,
       computedFloat: checkCypherQuery,
@@ -217,7 +227,9 @@ export function augmentedSchemaCypherTestRunner(
       computedStringList: checkCypherMutation,
       computedTemporal: checkCypherMutation,
       computedSpatial: checkCypherMutation,
-      customWithArguments: checkCypherMutation
+      customWithArguments: checkCypherMutation,
+      CustomCamera: checkCypherMutation,
+      CustomCameras: checkCypherMutation
     }
   };
 

--- a/test/helpers/tck/filterTck.md
+++ b/test/helpers/tck/filterTck.md
@@ -2420,5 +2420,5 @@ MATCH (`person`:`Person`) WHERE (`person`.name = $filter.name) RETURN `person` {
 ```
 
 ```cypher
-MATCH (`person`:`Person`) RETURN `person` { .name ,company: head([(`person`)-[:`WORKS_AT`]->(`person_company`:`Company`) WHERE (EXISTS((`person_company`)<-[:WORKS_AT]-(:Person)) AND ANY(`person` IN [(`person_company`)<-[:WORKS_AT]-(`_person`:Person) | `_person`] WHERE (`person`.name = $1_filter.employees_some.name))) | person_company { .name }]) } AS `person`
+MATCH (`person`:`Person`) RETURN `person` { .name ,company: head([(`person`)-[:`WORKS_AT`]->(`person_company`:`Company`) WHERE (EXISTS((`person_company`)<-[:WORKS_AT]-(:Person)) AND ANY(`person` IN [(`person_company`)<-[:WORKS_AT]-(`_person`:Person) | `_person`] WHERE (`person`.name = $1_filter.employees_some.name))) | `person_company` { .name }]) } AS `person`
 ```

--- a/test/helpers/tck/filterTck.md
+++ b/test/helpers/tck/filterTck.md
@@ -1276,7 +1276,7 @@ MATCH (`person`:`Person`) WHERE (`person`.name = $filter.name) AND (EXISTS((`per
 ```
 
 ```cypher
-MATCH (`company`:`Company`) RETURN `company` {employees: [(`company`)<-[:`WORKS_AT`]-(`company_employees`:`Person`) WHERE (`company_employees`.name = $1_filter.name) | company_employees { .name }] } AS `company`
+MATCH (`company`:`Company`) RETURN `company` {employees: [(`company`)<-[:`WORKS_AT`]-(`company_employees`:`Person`) WHERE (`company_employees`.name = $1_filter.name) | `company_employees` { .name }] } AS `company`
 ```
 
 ### ALL related nodes matching filter given in separate OR filters
@@ -1292,7 +1292,7 @@ MATCH (`company`:`Company`) RETURN `company` {employees: [(`company`)<-[:`WORKS_
 ```
 
 ```cypher
-MATCH (`company`:`Company`) RETURN `company` {employees: [(`company`)<-[:`WORKS_AT`]-(`company_employees`:`Person`) WHERE (ANY(_OR IN $1_filter.OR WHERE (_OR.name IS NULL OR `company_employees`.name = _OR.name))) | company_employees { .name }] } AS `company`
+MATCH (`company`:`Company`) RETURN `company` {employees: [(`company`)<-[:`WORKS_AT`]-(`company_employees`:`Person`) WHERE (ANY(_OR IN $1_filter.OR WHERE (_OR.name IS NULL OR `company_employees`.name = _OR.name))) | `company_employees` { .name }] } AS `company`
 ```
 
 ### ALL related nodes matching String field in given list
@@ -1944,7 +1944,7 @@ MATCH (`company`:`Company`) WHERE (EXISTS((`company`)<-[:WORKS_AT]-(:Person)) AN
 ```
 
 ```cypher
-MATCH (`company`:`Company`) WHERE (EXISTS((`company`)<-[:WORKS_AT]-(:Person)) AND ALL(`person` IN [(`company`)<-[:WORKS_AT]-(`_person`:Person) | `_person`] WHERE ((`person`.location = point($filter.employees.location))))) RETURN `company` { .name ,employees: [(`company`)<-[:`WORKS_AT`]-(`company_employees`:`Person`) | company_employees { .name ,location: { longitude: `company_employees`.location.longitude , latitude: `company_employees`.location.latitude , height: `company_employees`.location.height }}] } AS `company`
+MATCH (`company`:`Company`) WHERE (EXISTS((`company`)<-[:WORKS_AT]-(:Person)) AND ALL(`person` IN [(`company`)<-[:WORKS_AT]-(`_person`:Person) | `_person`] WHERE ((`person`.location = point($filter.employees.location))))) RETURN `company` { .name ,employees: [(`company`)<-[:`WORKS_AT`]-(`company_employees`:`Person`) | `company_employees` { .name ,location: { longitude: `company_employees`.location.longitude , latitude: `company_employees`.location.latitude , height: `company_employees`.location.height }}] } AS `company`
 ```
 
 ### Spatial field on related node equal to given year OR does NOT exist
@@ -2347,7 +2347,7 @@ MATCH (`person`:`Person`) WHERE (EXISTS((`person`)-[:WORKS_AT]->(:Company)) AND 
 ```
 
 ```cypher
-MATCH (`person`:`Person`) WHERE (`person`.name = $filter.name) AND (EXISTS((`person`)-[:WORKS_AT]->(:Company)) AND ALL(`company` IN [(`person`)-[:WORKS_AT]->(`_company`:Company) | `_company`] WHERE (`company`.name = $filter.company.name))) RETURN `person` { .name ,company: head([(`person`)-[:`WORKS_AT`]->(`person_company`:`Company`) WHERE (`person_company`.name = $1_filter.name) AND ((`person_company`.founded = datetime($1_filter.founded))) | person_company { .name }]) } AS `person`
+MATCH (`person`:`Person`) WHERE (`person`.name = $filter.name) AND (EXISTS((`person`)-[:WORKS_AT]->(:Company)) AND ALL(`company` IN [(`person`)-[:WORKS_AT]->(`_company`:Company) | `_company`] WHERE (`company`.name = $filter.company.name))) RETURN `person` { .name ,company: head([(`person`)-[:`WORKS_AT`]->(`person_company`:`Company`) WHERE (`person_company`.name = $1_filter.name) AND ((`person_company`.founded = datetime($1_filter.founded))) | `person_company` { .name }]) } AS `person`
 ```
 
 ### Nested filter on relationship type field

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -83,6 +83,38 @@ export const testSchema = /* GraphQL */ `
     name: String
   }
 
+  enum _PersonOrdering {
+    userId_asc
+    userId_desc
+    name_asc
+    name_desc
+  }
+
+  input _PersonFilter {
+    AND: [_PersonFilter!]
+    OR: [_PersonFilter!]
+    userId: ID
+    userId_not: ID
+    userId_in: [ID!]
+    userId_not_in: [ID!]
+    userId_contains: ID
+    userId_not_contains: ID
+    userId_starts_with: ID
+    userId_not_starts_with: ID
+    userId_ends_with: ID
+    userId_not_ends_with: ID
+    name: String
+    name_not: String
+    name_in: [String!]
+    name_not_in: [String!]
+    name_contains: String
+    name_not_contains: String
+    name_starts_with: String
+    name_not_starts_with: String
+    name_ends_with: String
+    name_not_ends_with: String
+  }
+
   type Actor implements Person {
     userId: ID!
     name: String
@@ -217,9 +249,18 @@ export const testSchema = /* GraphQL */ `
     customWithArguments(strArg: String, strInputArg: strInput): String
       @cypher(statement: "RETURN $strInputArg.strArg")
     CasedType: [CasedType]
+    Camera(
+      type: String
+      first: Int
+      offset: Int
+      orderBy: _CameraOrdering
+      filter: _CameraFilter
+    ): [Camera]
     InterfaceNoScalars(
       orderBy: _InterfaceNoScalarsOrdering
     ): [InterfaceNoScalars]
+    CustomCameras: [Camera] @cypher(statement: "MATCH (c:Camera) RETURN c")
+    CustomCamera: Camera @cypher(statement: "MATCH (c:Camera) RETURN c")
   }
 
   type Mutation {
@@ -242,6 +283,14 @@ export const testSchema = /* GraphQL */ `
     customWithArguments(strArg: String, strInputArg: strInput): String
       @cypher(statement: "RETURN $strInputArg.strArg")
     testPublish: Boolean @neo4j_ignore
+    CustomCamera: Camera
+      @cypher(
+        statement: "CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro'}) RETURN newCamera"
+      )
+    CustomCameras: [Camera]
+      @cypher(
+        statement: "CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro', features: ['selfie', 'zoom']}) CREATE (oldCamera:Camera:OldCamera {id: apoc.create.uuid(), type: 'floating', smell: 'rusty' }) RETURN [newCamera, oldCamera]"
+      )
   }
 
   type currentUserId {
@@ -304,6 +353,127 @@ export const testSchema = /* GraphQL */ `
 
   enum _InterfaceNoScalarsOrdering {
     movies_asc
+  }
+
+  input _CameraFilter {
+    AND: [_CameraFilter!]
+    OR: [_CameraFilter!]
+    id: ID
+    id_not: ID
+    id_in: [ID!]
+    id_not_in: [ID!]
+    id_contains: ID
+    id_not_contains: ID
+    id_starts_with: ID
+    id_not_starts_with: ID
+    id_ends_with: ID
+    id_not_ends_with: ID
+    type: String
+    type_not: String
+    type_in: [String!]
+    type_not_in: [String!]
+    type_contains: String
+    type_not_contains: String
+    type_starts_with: String
+    type_not_starts_with: String
+    type_ends_with: String
+    type_not_ends_with: String
+    make: String
+    make_not: String
+    make_in: [String!]
+    make_not_in: [String!]
+    make_contains: String
+    make_not_contains: String
+    make_starts_with: String
+    make_not_starts_with: String
+    make_ends_with: String
+    make_not_ends_with: String
+    weight: Int
+    weight_not: Int
+    weight_in: [Int!]
+    weight_not_in: [Int!]
+    weight_lt: Int
+    weight_lte: Int
+    weight_gt: Int
+    weight_gte: Int
+    operators: _PersonFilter
+    operators_not: _PersonFilter
+    operators_in: [_PersonFilter!]
+    operators_not_in: [_PersonFilter!]
+    operators_some: _PersonFilter
+    operators_none: _PersonFilter
+    operators_single: _PersonFilter
+    operators_every: _PersonFilter
+  }
+
+  interface Camera {
+    id: ID!
+    type: String
+    make: String
+    weight: Int
+    operators(
+      first: Int
+      offset: Int
+      orderBy: _PersonOrdering
+      filter: _PersonFilter
+    ): [Person] @relation(name: "cameras", direction: IN)
+    computedOperators(name: String): [Person]
+      @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
+  }
+
+  enum _CameraOrdering {
+    id_asc
+    id_desc
+    type_asc
+    type_desc
+    make_asc
+    make_desc
+    weight_asc
+    weight_desc
+  }
+
+  type OldCamera implements Camera {
+    id: ID!
+    type: String
+    make: String
+    weight: Int
+    smell: String
+    operators(
+      first: Int
+      offset: Int
+      orderBy: _PersonOrdering
+      filter: _PersonFilter
+    ): [Person] @relation(name: "cameras", direction: IN)
+    computedOperators(name: String): [Person]
+      @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
+  }
+
+  type NewCamera implements Camera {
+    id: ID!
+    type: String
+    make: String
+    weight: Int
+    features: [String]
+    operators(
+      first: Int
+      offset: Int
+      orderBy: _PersonOrdering
+      filter: _PersonFilter
+    ): [Person] @relation(name: "cameras", direction: IN)
+    computedOperators(name: String): [Person]
+      @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
+  }
+
+  type CameraMan implements Person {
+    userId: ID!
+    name: String
+    favoriteCamera: Camera @relation(name: "favoriteCamera", direction: "OUT")
+    heaviestCamera: [Camera]
+      @cypher(
+        statement: "MATCH (c: Camera)--(this) RETURN c ORDER BY c.weight DESC LIMIT 1"
+      )
+    cameras: [Camera!]! @relation(name: "cameras", direction: "OUT")
+    cameraBuddy: Person @relation(name: "cameraBuddy", direction: "OUT")
   }
 
   type SubscriptionC {

--- a/test/integration/integration.test.js
+++ b/test/integration/integration.test.js
@@ -764,7 +764,7 @@ test('query using inline fragment', async t => {
     });
 });
 
-test('should be able to query node by its interface type', async t => {
+test.serial('should be able to query node by its interface type', async t => {
   t.plan(1);
 
   let id = null;
@@ -826,318 +826,452 @@ test('should be able to query node by its interface type', async t => {
     });
 });
 
-test('should be able to query node by its interface type (with fragments)', async t => {
-  t.plan(1);
+test.serial(
+  'should be able to query node by its interface type (with fragments)',
+  async t => {
+    t.plan(1);
 
-  let id = null;
-  await client
-    .mutate({
-      mutation: gql`
-        mutation {
-          CreateUser(name: "John Petrucci") {
-            userId
+    let id = null;
+    await client
+      .mutate({
+        mutation: gql`
+          mutation {
+            CreateUser(name: "John Petrucci") {
+              userId
+            }
           }
-        }
-      `
-    })
-    .then(data => {
-      id = data.data.CreateUser.userId;
-    });
+        `
+      })
+      .then(data => {
+        id = data.data.CreateUser.userId;
+      });
 
-  let expected = {
-    data: {
-      Person: [
-        {
-          name: 'John Petrucci',
-          userId: id,
-          rated: [],
-          __typename: 'User'
-        }
-      ]
-    }
-  };
+    let expected = {
+      data: {
+        Person: [
+          {
+            name: 'John Petrucci',
+            userId: id,
+            rated: [],
+            __typename: 'User'
+          }
+        ]
+      }
+    };
 
-  await client
-    .query({
-      variables: { id },
-      query: gql`
-        query QueryByInterface($id: ID) {
-          Person(userId: $id) {
-            name
-            userId
-            ... on User {
-              rated {
-                timestamp
+    await client
+      .query({
+        variables: { id },
+        query: gql`
+          query QueryByInterface($id: ID) {
+            Person(userId: $id) {
+              name
+              userId
+              ... on User {
+                rated {
+                  timestamp
+                }
               }
             }
           }
-        }
-      `
-    })
-    .then(data => {
-      t.deepEqual(data.data, expected.data);
-    })
-    .catch(error => {
-      t.fail(error.message);
-    })
-    .finally(async () => {
-      await client.mutate({
-        variables: { id },
-        mutation: gql`
-          mutation Cleanup($id: ID!) {
-            DeleteUser(userId: $id) {
+        `
+      })
+      .then(data => {
+        t.deepEqual(data.data, expected.data);
+      })
+      .catch(error => {
+        t.fail(error.message);
+      })
+      .finally(async () => {
+        await client.mutate({
+          variables: { id },
+          mutation: gql`
+            mutation Cleanup($id: ID!) {
+              DeleteUser(userId: $id) {
+                userId
+              }
+            }
+          `
+        });
+      });
+  }
+);
+
+test.serial(
+  'should be able to query node relations(s) by interface type',
+  async t => {
+    t.plan(1);
+
+    await client.mutate({
+      mutation: gql`
+        mutation {
+          CreateOldCamera(id: "cam001", type: "macro", weight: 99) {
+            id
+          }
+          CreateNewCamera(
+            id: "cam002"
+            type: "floating"
+            features: ["selfie", "zoom"]
+          ) {
+            id
+          }
+          CreateCameraMan(userId: "man001", name: "Johnnie Zoom") {
+            userId
+          }
+          AddCameraManFavoriteCamera(
+            from: { userId: "man001" }
+            to: { id: "cam001" }
+          ) {
+            from {
               userId
             }
           }
-        `
-      });
+          a: AddCameraManCameras(
+            from: { userId: "man001" }
+            to: { id: "cam001" }
+          ) {
+            from {
+              userId
+            }
+          }
+          b: AddCameraManCameras(
+            from: { userId: "man001" }
+            to: { id: "cam002" }
+          ) {
+            from {
+              userId
+            }
+          }
+          c: CreateCameraMan(userId: "man002", name: "Bud Wise") {
+            userId
+          }
+          AddCameraManCameraBuddy(
+            from: { userId: "man001" }
+            to: { userId: "man002" }
+          ) {
+            from {
+              userId
+            }
+          }
+        }
+      `
     });
-});
 
-test('should be able to query node relations(s) by interface type', async t => {
-  t.plan(1);
-
-  await client.mutate({
-    mutation: gql`
-      mutation {
-        CreateOldCamera(id: "cam001", type: "macro", weight: 99) {
-          id
-        }
-        CreateNewCamera(
-          id: "cam002"
-          type: "floating"
-          features: ["selfie", "zoom"]
-        ) {
-          id
-        }
-        CreateCameraMan(userId: "man001", name: "Johnnie Zoom") {
-          userId
-        }
-        AddCameraManFavoriteCamera(
-          from: { userId: "man001" }
-          to: { id: "cam001" }
-        ) {
-          from {
-            userId
-          }
-        }
-        a: AddCameraManCameras(
-          from: { userId: "man001" }
-          to: { id: "cam001" }
-        ) {
-          from {
-            userId
-          }
-        }
-        b: AddCameraManCameras(
-          from: { userId: "man001" }
-          to: { id: "cam002" }
-        ) {
-          from {
-            userId
-          }
-        }
-        c: CreateCameraMan(userId: "man002", name: "Bud Wise") {
-          userId
-        }
-        AddCameraManCameraBuddy(
-          from: { userId: "man001" }
-          to: { userId: "man002" }
-        ) {
-          from {
-            userId
-          }
-        }
-      }
-    `
-  });
-
-  let expected = {
-    data: {
-      CameraMan: [
-        {
-          userId: 'man001',
-          favoriteCamera: {
-            id: 'cam001',
-            __typename: 'OldCamera'
-          },
-          cameras: [
-            {
-              id: 'cam002',
-              type: 'floating',
-              features: ['selfie', 'zoom'],
-              __typename: 'NewCamera'
-            },
-            {
+    let expected = {
+      data: {
+        CameraMan: [
+          {
+            userId: 'man001',
+            favoriteCamera: {
               id: 'cam001',
-              type: 'macro',
-              weight: 99,
               __typename: 'OldCamera'
-            }
-          ],
-          cameraBuddy: {
-            userId: 'man002',
+            },
+            cameras: [
+              {
+                id: 'cam002',
+                type: 'floating',
+                features: ['selfie', 'zoom'],
+                __typename: 'NewCamera'
+              },
+              {
+                id: 'cam001',
+                type: 'macro',
+                weight: 99,
+                __typename: 'OldCamera'
+              }
+            ],
+            cameraBuddy: {
+              userId: 'man002',
+              __typename: 'CameraMan'
+            },
             __typename: 'CameraMan'
-          },
-          __typename: 'CameraMan'
-        }
-      ]
-    }
-  };
-
-  await client
-    .query({
-      query: gql`
-        query {
-          CameraMan(userId: "man001") {
-            userId
-            favoriteCamera {
-              id
-            }
-            cameras {
-              id
-              type
-              ... on OldCamera {
-                weight
-              }
-              ... on NewCamera {
-                features
-              }
-            }
-            cameraBuddy {
-              userId
-            }
           }
-        }
-      `
-    })
-    .then(data => {
-      t.deepEqual(data.data, expected.data);
-    })
-    .catch(error => {
-      t.fail(error.message);
-    })
-    .finally(async () => {
-      await client.mutate({
-        mutation: gql`
-          mutation {
-            DeleteOldCamera(id: "cam001") {
-              id
-            }
-            DeleteNewCamera(id: "cam002") {
-              id
-            }
-            a: DeleteCameraMan(userId: "man001") {
-              userId
-            }
-            b: DeleteCameraMan(userId: "man002") {
-              userId
-            }
-          }
-        `
-      });
-    });
-});
-
-test('should be able to query custom cypher field returning interface type', async t => {
-  t.plan(1);
-
-  await client.mutate({
-    mutation: gql`
-      mutation {
-        CreateOldCamera(
-          id: "cam010"
-          type: "macro"
-          weight: 99
-          smell: "rancid"
-        ) {
-          id
-        }
-        CreateNewCamera(
-          id: "cam011"
-          type: "floating"
-          weight: 122
-          features: ["selfie", "zoom"]
-        ) {
-          id
-        }
-        CreateCameraMan(userId: "man010", name: "Johnnie Zoom") {
-          userId
-        }
-        a: AddCameraManCameras(
-          from: { userId: "man010" }
-          to: { id: "cam010" }
-        ) {
-          from {
-            userId
-          }
-        }
-        b: AddCameraManCameras(
-          from: { userId: "man010" }
-          to: { id: "cam011" }
-        ) {
-          from {
-            userId
-          }
-        }
+        ]
       }
-    `
-  });
+    };
 
-  let expected = {
-    data: {
-      CameraMan: [
-        {
-          userId: 'man010',
-          heaviestCamera: [
-            {
-              id: 'cam011',
-              __typename: 'NewCamera'
+    await client
+      .query({
+        query: gql`
+          query {
+            CameraMan(userId: "man001") {
+              userId
+              favoriteCamera {
+                id
+              }
+              cameras {
+                id
+                type
+                ... on OldCamera {
+                  weight
+                }
+                ... on NewCamera {
+                  features
+                }
+              }
+              cameraBuddy {
+                userId
+              }
             }
-          ],
-          __typename: 'CameraMan'
-        }
-      ]
-    }
-  };
+          }
+        `
+      })
+      .then(data => {
+        t.deepEqual(data.data, expected.data);
+      })
+      .catch(error => {
+        t.fail(error.message);
+      })
+      .finally(async () => {
+        await client.mutate({
+          mutation: gql`
+            mutation {
+              DeleteOldCamera(id: "cam001") {
+                id
+              }
+              DeleteNewCamera(id: "cam002") {
+                id
+              }
+              a: DeleteCameraMan(userId: "man001") {
+                userId
+              }
+              b: DeleteCameraMan(userId: "man002") {
+                userId
+              }
+            }
+          `
+        });
+      });
+  }
+);
 
-  await client
-    .query({
-      query: gql`
-        query {
-          CameraMan(userId: "man010") {
+test.serial(
+  'should be able to query custom cypher field returning interface type',
+  async t => {
+    t.plan(1);
+
+    await client.mutate({
+      mutation: gql`
+        mutation {
+          CreateOldCamera(
+            id: "cam010"
+            type: "macro"
+            weight: 99
+            smell: "rancid"
+          ) {
+            id
+          }
+          CreateNewCamera(
+            id: "cam011"
+            type: "floating"
+            weight: 122
+            features: ["selfie", "zoom"]
+          ) {
+            id
+          }
+          CreateCameraMan(userId: "man010", name: "Johnnie Zoom") {
             userId
-            heaviestCamera {
-              id
+          }
+          a: AddCameraManCameras(
+            from: { userId: "man010" }
+            to: { id: "cam010" }
+          ) {
+            from {
+              userId
+            }
+          }
+          b: AddCameraManCameras(
+            from: { userId: "man010" }
+            to: { id: "cam011" }
+          ) {
+            from {
+              userId
             }
           }
         }
       `
-    })
-    .then(data => {
-      t.deepEqual(data.data, expected.data);
-    })
-    .catch(error => {
-      t.fail(error.message);
-    })
-    .finally(async () => {
-      await client.mutate({
-        mutation: gql`
-          mutation {
-            DeleteOldCamera(id: "cam010") {
-              id
-            }
-            DeleteNewCamera(id: "cam011") {
-              id
-            }
-            DeleteCameraMan(userId: "man010") {
+    });
+
+    let expected = {
+      data: {
+        CameraMan: [
+          {
+            userId: 'man010',
+            heaviestCamera: [
+              {
+                id: 'cam011',
+                __typename: 'NewCamera'
+              }
+            ],
+            __typename: 'CameraMan'
+          }
+        ]
+      }
+    };
+
+    await client
+      .query({
+        query: gql`
+          query {
+            CameraMan(userId: "man010") {
               userId
+              heaviestCamera {
+                id
+              }
             }
           }
         `
+      })
+      .then(data => {
+        t.deepEqual(data.data, expected.data);
+      })
+      .catch(error => {
+        t.fail(error.message);
+      })
+      .finally(async () => {
+        await client.mutate({
+          mutation: gql`
+            mutation {
+              DeleteOldCamera(id: "cam010") {
+                id
+              }
+              DeleteNewCamera(id: "cam011") {
+                id
+              }
+              DeleteCameraMan(userId: "man010") {
+                userId
+              }
+            }
+          `
+        });
       });
+  }
+);
+
+test.serial(
+  'query interface type relationship field on interface type',
+  async t => {
+    t.plan(1);
+
+    await client.mutate({
+      mutation: gql`
+        mutation {
+          CreateOldCamera(id: "cam003", type: "macro", weight: 99) {
+            id
+          }
+          CreateNewCamera(
+            id: "cam004"
+            type: "floating"
+            features: ["selfie", "zoom"]
+          ) {
+            id
+          }
+          CreateCameraMan(userId: "man003", name: "Johnnie Zoom") {
+            userId
+          }
+          CreateUser(userId: "man004", name: "Johnnie Zoooom") {
+            userId
+          }
+          a: AddCameraOperators(
+            from: { userId: "man003" }
+            to: { id: "cam003" }
+          ) {
+            from {
+              userId
+            }
+          }
+          b: AddCameraOperators(
+            from: { userId: "man003" }
+            to: { id: "cam004" }
+          ) {
+            from {
+              userId
+            }
+          }
+          c: AddCameraOperators(
+            from: { userId: "man004" }
+            to: { id: "cam003" }
+          ) {
+            from {
+              userId
+            }
+          }
+        }
+      `
     });
-});
+
+    let expected = {
+      data: {
+        Camera: [
+          {
+            id: 'cam003',
+            type: 'macro',
+            operators: [
+              {
+                userId: 'man004',
+                __typename: 'User'
+              },
+              {
+                userId: 'man003',
+                name: 'Johnnie Zoom',
+                __typename: 'CameraMan'
+              }
+            ],
+            __typename: 'OldCamera'
+          }
+        ]
+      }
+    };
+
+    await client
+      .query({
+        query: gql`
+          query {
+            Camera {
+              ... on OldCamera {
+                id
+                type
+                operators {
+                  userId
+                  ...CameraManFragment
+                }
+              }
+            }
+          }
+          fragment CameraManFragment on CameraMan {
+            name
+          }
+        `
+      })
+      .then(data => {
+        t.deepEqual(data.data, expected.data);
+      })
+      .catch(error => {
+        t.fail(error.message);
+      })
+      .finally(async () => {
+        await client.mutate({
+          mutation: gql`
+            mutation {
+              DeleteOldCamera(id: "cam003") {
+                id
+              }
+              DeleteNewCamera(id: "cam004") {
+                id
+              }
+              DeleteUser(userId: "man004") {
+                userId
+              }
+              DeleteCameraMan(userId: "man003") {
+                userId
+              }
+            }
+          `
+        });
+      });
+  }
+);
+
 /*
  * Temporal type tests
  */

--- a/test/unit/augmentSchemaTest.test.js
+++ b/test/unit/augmentSchemaTest.test.js
@@ -132,12 +132,25 @@ test.cb('Test augmented schema', t => {
         orderBy: [_CasedTypeOrdering]
         filter: _CasedTypeFilter
       ): [CasedType]
+      Camera(
+        type: String
+        first: Int
+        offset: Int
+        orderBy: [_CameraOrdering]
+        filter: _CameraFilter
+      ): [Camera]
       InterfaceNoScalars(
         orderBy: _InterfaceNoScalarsOrdering
         first: Int
         offset: Int
         filter: _InterfaceNoScalarsFilter
       ): [InterfaceNoScalars]
+      CustomCameras(
+        first: Int
+        offset: Int
+        orderBy: [_CameraOrdering]
+      ): [Camera] @cypher(statement: "MATCH (c:Camera) RETURN c")
+      CustomCamera: Camera @cypher(statement: "MATCH (c:Camera) RETURN c")
       Genre(
         _id: String
         name: String
@@ -196,6 +209,39 @@ test.cb('Test augmented schema', t => {
         orderBy: [_SpatialNodeOrdering]
         filter: _SpatialNodeFilter
       ): [SpatialNode] @hasScope(scopes: ["SpatialNode: Read"])
+      OldCamera(
+        id: ID
+        type: String
+        make: String
+        weight: Int
+        smell: String
+        _id: String
+        first: Int
+        offset: Int
+        orderBy: [_OldCameraOrdering]
+        filter: _OldCameraFilter
+      ): [OldCamera] @hasScope(scopes: ["OldCamera: Read"])
+      NewCamera(
+        id: ID
+        type: String
+        make: String
+        weight: Int
+        features: String
+        _id: String
+        first: Int
+        offset: Int
+        orderBy: [_NewCameraOrdering]
+        filter: _NewCameraFilter
+      ): [NewCamera] @hasScope(scopes: ["NewCamera: Read"])
+      CameraMan(
+        userId: ID
+        name: String
+        _id: String
+        first: Int
+        offset: Int
+        orderBy: [_CameraManOrdering]
+        filter: _CameraManFilter
+      ): [CameraMan] @hasScope(scopes: ["CameraMan: Read"])
     }
 
     input _Neo4jDateTimeInput {
@@ -1294,6 +1340,346 @@ test.cb('Test augmented schema', t => {
       _id: String
     }
 
+    enum _CameraOrdering {
+      id_asc
+      id_desc
+      type_asc
+      type_desc
+      make_asc
+      make_desc
+      weight_asc
+      weight_desc
+    }
+
+    input _CameraFilter {
+      AND: [_CameraFilter!]
+      OR: [_CameraFilter!]
+      id: ID
+      id_not: ID
+      id_in: [ID!]
+      id_not_in: [ID!]
+      id_contains: ID
+      id_not_contains: ID
+      id_starts_with: ID
+      id_not_starts_with: ID
+      id_ends_with: ID
+      id_not_ends_with: ID
+      type: String
+      type_not: String
+      type_in: [String!]
+      type_not_in: [String!]
+      type_contains: String
+      type_not_contains: String
+      type_starts_with: String
+      type_not_starts_with: String
+      type_ends_with: String
+      type_not_ends_with: String
+      make: String
+      make_not: String
+      make_in: [String!]
+      make_not_in: [String!]
+      make_contains: String
+      make_not_contains: String
+      make_starts_with: String
+      make_not_starts_with: String
+      make_ends_with: String
+      make_not_ends_with: String
+      weight: Int
+      weight_not: Int
+      weight_in: [Int!]
+      weight_not_in: [Int!]
+      weight_lt: Int
+      weight_lte: Int
+      weight_gt: Int
+      weight_gte: Int
+      operators: _PersonFilter
+      operators_not: _PersonFilter
+      operators_in: [_PersonFilter!]
+      operators_not_in: [_PersonFilter!]
+      operators_some: _PersonFilter
+      operators_none: _PersonFilter
+      operators_single: _PersonFilter
+      operators_every: _PersonFilter
+    }
+
+    interface Camera {
+      id: ID!
+      type: String
+      make: String
+      weight: Int
+      operators(
+        first: Int
+        offset: Int
+        orderBy: [_PersonOrdering]
+        filter: _PersonFilter
+      ): [Person] @relation(name: "cameras", direction: IN)
+      computedOperators(
+        name: String
+        first: Int
+        offset: Int
+        orderBy: [_PersonOrdering]
+      ): [Person]
+        @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
+    }
+
+    enum _OldCameraOrdering {
+      id_asc
+      id_desc
+      type_asc
+      type_desc
+      make_asc
+      make_desc
+      weight_asc
+      weight_desc
+      smell_asc
+      smell_desc
+      _id_asc
+      _id_desc
+    }
+
+    input _OldCameraFilter {
+      AND: [_OldCameraFilter!]
+      OR: [_OldCameraFilter!]
+      id: ID
+      id_not: ID
+      id_in: [ID!]
+      id_not_in: [ID!]
+      id_contains: ID
+      id_not_contains: ID
+      id_starts_with: ID
+      id_not_starts_with: ID
+      id_ends_with: ID
+      id_not_ends_with: ID
+      type: String
+      type_not: String
+      type_in: [String!]
+      type_not_in: [String!]
+      type_contains: String
+      type_not_contains: String
+      type_starts_with: String
+      type_not_starts_with: String
+      type_ends_with: String
+      type_not_ends_with: String
+      make: String
+      make_not: String
+      make_in: [String!]
+      make_not_in: [String!]
+      make_contains: String
+      make_not_contains: String
+      make_starts_with: String
+      make_not_starts_with: String
+      make_ends_with: String
+      make_not_ends_with: String
+      weight: Int
+      weight_not: Int
+      weight_in: [Int!]
+      weight_not_in: [Int!]
+      weight_lt: Int
+      weight_lte: Int
+      weight_gt: Int
+      weight_gte: Int
+      smell: String
+      smell_not: String
+      smell_in: [String!]
+      smell_not_in: [String!]
+      smell_contains: String
+      smell_not_contains: String
+      smell_starts_with: String
+      smell_not_starts_with: String
+      smell_ends_with: String
+      smell_not_ends_with: String
+      operators: _PersonFilter
+      operators_not: _PersonFilter
+      operators_in: [_PersonFilter!]
+      operators_not_in: [_PersonFilter!]
+      operators_some: _PersonFilter
+      operators_none: _PersonFilter
+      operators_single: _PersonFilter
+      operators_every: _PersonFilter
+    }
+
+    type OldCamera implements Camera {
+      id: ID!
+      type: String
+      make: String
+      weight: Int
+      smell: String
+      operators(
+        first: Int
+        offset: Int
+        orderBy: [_PersonOrdering]
+        filter: _PersonFilter
+      ): [Person] @relation(name: "cameras", direction: IN)
+      computedOperators(
+        name: String
+        first: Int
+        offset: Int
+        orderBy: [_PersonOrdering]
+      ): [Person]
+        @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
+      _id: String
+    }
+
+    enum _NewCameraOrdering {
+      id_asc
+      id_desc
+      type_asc
+      type_desc
+      make_asc
+      make_desc
+      weight_asc
+      weight_desc
+      _id_asc
+      _id_desc
+    }
+
+    input _NewCameraFilter {
+      AND: [_NewCameraFilter!]
+      OR: [_NewCameraFilter!]
+      id: ID
+      id_not: ID
+      id_in: [ID!]
+      id_not_in: [ID!]
+      id_contains: ID
+      id_not_contains: ID
+      id_starts_with: ID
+      id_not_starts_with: ID
+      id_ends_with: ID
+      id_not_ends_with: ID
+      type: String
+      type_not: String
+      type_in: [String!]
+      type_not_in: [String!]
+      type_contains: String
+      type_not_contains: String
+      type_starts_with: String
+      type_not_starts_with: String
+      type_ends_with: String
+      type_not_ends_with: String
+      make: String
+      make_not: String
+      make_in: [String!]
+      make_not_in: [String!]
+      make_contains: String
+      make_not_contains: String
+      make_starts_with: String
+      make_not_starts_with: String
+      make_ends_with: String
+      make_not_ends_with: String
+      weight: Int
+      weight_not: Int
+      weight_in: [Int!]
+      weight_not_in: [Int!]
+      weight_lt: Int
+      weight_lte: Int
+      weight_gt: Int
+      weight_gte: Int
+      operators: _PersonFilter
+      operators_not: _PersonFilter
+      operators_in: [_PersonFilter!]
+      operators_not_in: [_PersonFilter!]
+      operators_some: _PersonFilter
+      operators_none: _PersonFilter
+      operators_single: _PersonFilter
+      operators_every: _PersonFilter
+    }
+
+    type NewCamera implements Camera {
+      id: ID!
+      type: String
+      make: String
+      weight: Int
+      features: [String]
+      operators(
+        first: Int
+        offset: Int
+        orderBy: [_PersonOrdering]
+        filter: _PersonFilter
+      ): [Person] @relation(name: "cameras", direction: IN)
+      computedOperators(
+        name: String
+        first: Int
+        offset: Int
+        orderBy: [_PersonOrdering]
+      ): [Person]
+        @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
+      _id: String
+    }
+
+    enum _CameraManOrdering {
+      userId_asc
+      userId_desc
+      name_asc
+      name_desc
+      _id_asc
+      _id_desc
+    }
+
+    input _CameraManFilter {
+      AND: [_CameraManFilter!]
+      OR: [_CameraManFilter!]
+      userId: ID
+      userId_not: ID
+      userId_in: [ID!]
+      userId_not_in: [ID!]
+      userId_contains: ID
+      userId_not_contains: ID
+      userId_starts_with: ID
+      userId_not_starts_with: ID
+      userId_ends_with: ID
+      userId_not_ends_with: ID
+      name: String
+      name_not: String
+      name_in: [String!]
+      name_not_in: [String!]
+      name_contains: String
+      name_not_contains: String
+      name_starts_with: String
+      name_not_starts_with: String
+      name_ends_with: String
+      name_not_ends_with: String
+      favoriteCamera: _CameraFilter
+      favoriteCamera_not: _CameraFilter
+      favoriteCamera_in: [_CameraFilter!]
+      favoriteCamera_not_in: [_CameraFilter!]
+      cameras: _CameraFilter
+      cameras_not: _CameraFilter
+      cameras_in: [_CameraFilter!]
+      cameras_not_in: [_CameraFilter!]
+      cameras_some: _CameraFilter
+      cameras_none: _CameraFilter
+      cameras_single: _CameraFilter
+      cameras_every: _CameraFilter
+      cameraBuddy: _PersonFilter
+      cameraBuddy_not: _PersonFilter
+      cameraBuddy_in: [_PersonFilter!]
+      cameraBuddy_not_in: [_PersonFilter!]
+    }
+
+    type CameraMan implements Person {
+      userId: ID!
+      name: String
+      favoriteCamera(filter: _CameraFilter): Camera
+        @relation(name: "favoriteCamera", direction: "OUT")
+      heaviestCamera(
+        first: Int
+        offset: Int
+        orderBy: [_CameraOrdering]
+      ): [Camera]
+        @cypher(
+          statement: "MATCH (c: Camera)--(this) RETURN c ORDER BY c.weight DESC LIMIT 1"
+        )
+      cameras(
+        first: Int
+        offset: Int
+        orderBy: [_CameraOrdering]
+        filter: _CameraFilter
+      ): [Camera!]! @relation(name: "cameras", direction: "OUT")
+      cameraBuddy(filter: _PersonFilter): Person
+        @relation(name: "cameraBuddy", direction: "OUT")
+      _id: String
+    }
+
     input _SpatialNodeFilter {
       AND: [_SpatialNodeFilter!]
       OR: [_SpatialNodeFilter!]
@@ -1344,6 +1730,14 @@ test.cb('Test augmented schema', t => {
       customWithArguments(strArg: String, strInputArg: strInput): String
         @cypher(statement: "RETURN $strInputArg.strArg")
       testPublish: Boolean @neo4j_ignore
+      CustomCamera: Camera
+        @cypher(
+          statement: "CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro'}) RETURN newCamera"
+        )
+      CustomCameras: [Camera]
+        @cypher(
+          statement: "CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro', features: ['selfie', 'zoom']}) CREATE (oldCamera:Camera:OldCamera {id: apoc.create.uuid(), type: 'floating', smell: 'rusty' }) RETURN [newCamera, oldCamera]"
+        )
       AddMovieGenres(
         from: _MovieInput!
         to: _GenreInput!
@@ -1746,6 +2140,192 @@ test.cb('Test augmented schema', t => {
         @hasScope(scopes: ["CasedType: Create"])
       DeleteCasedType(name: String!): CasedType
         @hasScope(scopes: ["CasedType: Delete"])
+      AddCameraOperators(
+        from: _PersonInput!
+        to: _CameraInput!
+      ): _AddCameraOperatorsPayload
+        @MutationMeta(relationship: "cameras", from: "Person", to: "Camera")
+        @hasScope(scopes: ["Person: Create", "Camera: Create"])
+      RemoveCameraOperators(
+        from: _PersonInput!
+        to: _CameraInput!
+      ): _RemoveCameraOperatorsPayload
+        @MutationMeta(relationship: "cameras", from: "Person", to: "Camera")
+        @hasScope(scopes: ["Person: Delete", "Camera: Delete"])
+      MergeCameraOperators(
+        from: _PersonInput!
+        to: _CameraInput!
+      ): _MergeCameraOperatorsPayload
+        @MutationMeta(relationship: "cameras", from: "Person", to: "Camera")
+        @hasScope(scopes: ["Person: Merge", "Camera: Merge"])
+      AddOldCameraOperators(
+        from: _PersonInput!
+        to: _OldCameraInput!
+      ): _AddOldCameraOperatorsPayload
+        @MutationMeta(relationship: "cameras", from: "Person", to: "OldCamera")
+        @hasScope(scopes: ["Person: Create", "OldCamera: Create"])
+      RemoveOldCameraOperators(
+        from: _PersonInput!
+        to: _OldCameraInput!
+      ): _RemoveOldCameraOperatorsPayload
+        @MutationMeta(relationship: "cameras", from: "Person", to: "OldCamera")
+        @hasScope(scopes: ["Person: Delete", "OldCamera: Delete"])
+      MergeOldCameraOperators(
+        from: _PersonInput!
+        to: _OldCameraInput!
+      ): _MergeOldCameraOperatorsPayload
+        @MutationMeta(relationship: "cameras", from: "Person", to: "OldCamera")
+        @hasScope(scopes: ["Person: Merge", "OldCamera: Merge"])
+      CreateOldCamera(
+        id: ID
+        type: String
+        make: String
+        weight: Int
+        smell: String
+      ): OldCamera @hasScope(scopes: ["OldCamera: Create"])
+      UpdateOldCamera(
+        id: ID!
+        type: String
+        make: String
+        weight: Int
+        smell: String
+      ): OldCamera @hasScope(scopes: ["OldCamera: Update"])
+      DeleteOldCamera(id: ID!): OldCamera
+        @hasScope(scopes: ["OldCamera: Delete"])
+      MergeOldCamera(
+        id: ID!
+        type: String
+        make: String
+        weight: Int
+        smell: String
+      ): OldCamera @hasScope(scopes: ["OldCamera: Merge"])
+      AddNewCameraOperators(
+        from: _PersonInput!
+        to: _NewCameraInput!
+      ): _AddNewCameraOperatorsPayload
+        @MutationMeta(relationship: "cameras", from: "Person", to: "NewCamera")
+        @hasScope(scopes: ["Person: Create", "NewCamera: Create"])
+      RemoveNewCameraOperators(
+        from: _PersonInput!
+        to: _NewCameraInput!
+      ): _RemoveNewCameraOperatorsPayload
+        @MutationMeta(relationship: "cameras", from: "Person", to: "NewCamera")
+        @hasScope(scopes: ["Person: Delete", "NewCamera: Delete"])
+      MergeNewCameraOperators(
+        from: _PersonInput!
+        to: _NewCameraInput!
+      ): _MergeNewCameraOperatorsPayload
+        @MutationMeta(relationship: "cameras", from: "Person", to: "NewCamera")
+        @hasScope(scopes: ["Person: Merge", "NewCamera: Merge"])
+      CreateNewCamera(
+        id: ID
+        type: String
+        make: String
+        weight: Int
+        features: [String]
+      ): NewCamera @hasScope(scopes: ["NewCamera: Create"])
+      UpdateNewCamera(
+        id: ID!
+        type: String
+        make: String
+        weight: Int
+        features: [String]
+      ): NewCamera @hasScope(scopes: ["NewCamera: Update"])
+      DeleteNewCamera(id: ID!): NewCamera
+        @hasScope(scopes: ["NewCamera: Delete"])
+      MergeNewCamera(
+        id: ID!
+        type: String
+        make: String
+        weight: Int
+        features: [String]
+      ): NewCamera @hasScope(scopes: ["NewCamera: Merge"])
+      AddCameraManFavoriteCamera(
+        from: _CameraManInput!
+        to: _CameraInput!
+      ): _AddCameraManFavoriteCameraPayload
+        @MutationMeta(
+          relationship: "favoriteCamera"
+          from: "CameraMan"
+          to: "Camera"
+        )
+        @hasScope(scopes: ["CameraMan: Create", "Camera: Create"])
+      RemoveCameraManFavoriteCamera(
+        from: _CameraManInput!
+        to: _CameraInput!
+      ): _RemoveCameraManFavoriteCameraPayload
+        @MutationMeta(
+          relationship: "favoriteCamera"
+          from: "CameraMan"
+          to: "Camera"
+        )
+        @hasScope(scopes: ["CameraMan: Delete", "Camera: Delete"])
+      MergeCameraManFavoriteCamera(
+        from: _CameraManInput!
+        to: _CameraInput!
+      ): _MergeCameraManFavoriteCameraPayload
+        @MutationMeta(
+          relationship: "favoriteCamera"
+          from: "CameraMan"
+          to: "Camera"
+        )
+        @hasScope(scopes: ["CameraMan: Merge", "Camera: Merge"])
+      AddCameraManCameras(
+        from: _CameraManInput!
+        to: _CameraInput!
+      ): _AddCameraManCamerasPayload
+        @MutationMeta(relationship: "cameras", from: "CameraMan", to: "Camera")
+        @hasScope(scopes: ["CameraMan: Create", "Camera: Create"])
+      RemoveCameraManCameras(
+        from: _CameraManInput!
+        to: _CameraInput!
+      ): _RemoveCameraManCamerasPayload
+        @MutationMeta(relationship: "cameras", from: "CameraMan", to: "Camera")
+        @hasScope(scopes: ["CameraMan: Delete", "Camera: Delete"])
+      MergeCameraManCameras(
+        from: _CameraManInput!
+        to: _CameraInput!
+      ): _MergeCameraManCamerasPayload
+        @MutationMeta(relationship: "cameras", from: "CameraMan", to: "Camera")
+        @hasScope(scopes: ["CameraMan: Merge", "Camera: Merge"])
+      AddCameraManCameraBuddy(
+        from: _CameraManInput!
+        to: _PersonInput!
+      ): _AddCameraManCameraBuddyPayload
+        @MutationMeta(
+          relationship: "cameraBuddy"
+          from: "CameraMan"
+          to: "Person"
+        )
+        @hasScope(scopes: ["CameraMan: Create", "Person: Create"])
+      RemoveCameraManCameraBuddy(
+        from: _CameraManInput!
+        to: _PersonInput!
+      ): _RemoveCameraManCameraBuddyPayload
+        @MutationMeta(
+          relationship: "cameraBuddy"
+          from: "CameraMan"
+          to: "Person"
+        )
+        @hasScope(scopes: ["CameraMan: Delete", "Person: Delete"])
+      MergeCameraManCameraBuddy(
+        from: _CameraManInput!
+        to: _PersonInput!
+      ): _MergeCameraManCameraBuddyPayload
+        @MutationMeta(
+          relationship: "cameraBuddy"
+          from: "CameraMan"
+          to: "Person"
+        )
+        @hasScope(scopes: ["CameraMan: Merge", "Person: Merge"])
+      CreateCameraMan(userId: ID, name: String): CameraMan
+        @hasScope(scopes: ["CameraMan: Create"])
+      UpdateCameraMan(userId: ID!, name: String): CameraMan
+        @hasScope(scopes: ["CameraMan: Update"])
+      DeleteCameraMan(userId: ID!): CameraMan
+        @hasScope(scopes: ["CameraMan: Delete"])
+      MergeCameraMan(userId: ID!, name: String): CameraMan
+        @hasScope(scopes: ["CameraMan: Merge"])
     }
 
     input _MovieInput {
@@ -2169,8 +2749,85 @@ test.cb('Test augmented schema', t => {
       to: State
     }
 
+    input _CameraManInput {
+      userId: ID!
+    }
+
+    input _CameraInput {
+      id: ID!
+    }
+
+    type _AddCameraOperatorsPayload
+      @relation(name: "cameras", from: "Person", to: "Camera") {
+      from: Person
+      to: Camera
+    }
+
+    type _RemoveCameraOperatorsPayload
+      @relation(name: "cameras", from: "Person", to: "Camera") {
+      from: Person
+      to: Camera
+    }
+
+    type _MergeCameraOperatorsPayload
+      @relation(name: "cameras", from: "Person", to: "Camera") {
+      from: Person
+      to: Camera
+    }
+
+    type _AddCameraManFavoriteCameraPayload
+      @relation(name: "favoriteCamera", from: "CameraMan", to: "Camera") {
+      from: CameraMan
+      to: Camera
+    }
+
+    type _RemoveCameraManFavoriteCameraPayload
+      @relation(name: "favoriteCamera", from: "CameraMan", to: "Camera") {
+      from: CameraMan
+      to: Camera
+    }
+    type _MergeCameraManFavoriteCameraPayload
+      @relation(name: "favoriteCamera", from: "CameraMan", to: "Camera") {
+      from: CameraMan
+      to: Camera
+    }
+    type _AddCameraManCamerasPayload
+      @relation(name: "cameras", from: "CameraMan", to: "Camera") {
+      from: CameraMan
+      to: Camera
+    }
+
+    type _RemoveCameraManCamerasPayload
+      @relation(name: "cameras", from: "CameraMan", to: "Camera") {
+      from: CameraMan
+      to: Camera
+    }
+
+    type _MergeCameraManCamerasPayload
+      @relation(name: "cameras", from: "CameraMan", to: "Camera") {
+      from: CameraMan
+      to: Camera
+    }
     input _PersonInput {
       userId: ID!
+    }
+
+    type _AddCameraManCameraBuddyPayload
+      @relation(name: "cameraBuddy", from: "CameraMan", to: "Person") {
+      from: CameraMan
+      to: Person
+    }
+
+    type _RemoveCameraManCameraBuddyPayload
+      @relation(name: "cameraBuddy", from: "CameraMan", to: "Person") {
+      from: CameraMan
+      to: Person
+    }
+
+    type _MergeCameraManCameraBuddyPayload
+      @relation(name: "cameraBuddy", from: "CameraMan", to: "Person") {
+      from: CameraMan
+      to: Person
     }
 
     type SubscriptionC {
@@ -2260,6 +2917,50 @@ test.cb('Test augmented schema', t => {
       reader
       user
       admin
+    }
+
+    input _OldCameraInput {
+      id: ID!
+    }
+
+    type _AddOldCameraOperatorsPayload
+      @relation(name: "cameras", from: "Person", to: "OldCamera") {
+      from: Person
+      to: OldCamera
+    }
+
+    type _RemoveOldCameraOperatorsPayload
+      @relation(name: "cameras", from: "Person", to: "OldCamera") {
+      from: Person
+      to: OldCamera
+    }
+
+    type _MergeOldCameraOperatorsPayload
+      @relation(name: "cameras", from: "Person", to: "OldCamera") {
+      from: Person
+      to: OldCamera
+    }
+
+    input _NewCameraInput {
+      id: ID!
+    }
+
+    type _AddNewCameraOperatorsPayload
+      @relation(name: "cameras", from: "Person", to: "NewCamera") {
+      from: Person
+      to: NewCamera
+    }
+
+    type _RemoveNewCameraOperatorsPayload
+      @relation(name: "cameras", from: "Person", to: "NewCamera") {
+      from: Person
+      to: NewCamera
+    }
+
+    type _MergeNewCameraOperatorsPayload
+      @relation(name: "cameras", from: "Person", to: "NewCamera") {
+      from: Person
+      to: NewCamera
     }
 
     type _Neo4jPoint {

--- a/test/unit/cypherTest.test.js
+++ b/test/unit/cypherTest.test.js
@@ -64,7 +64,7 @@ test('Cypher projection skip limit', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .name }] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $1_first}, true) | movie_similar { .title }][..3] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $1_first}, true) | movie_similar { .title }][..3] } AS \`movie\``;
 
   t.plan(3);
   return Promise.all([
@@ -151,7 +151,7 @@ test('Query single object relation', t => {
       }
     }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId:$movieId}) RETURN \`movie\` { .title ,filmedIn: head([(\`movie\`)-[:\`FILMED_IN\`]->(\`movie_filmedIn\`:\`State\`) | movie_filmedIn { .name }]) } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId:$movieId}) RETURN \`movie\` { .title ,filmedIn: head([(\`movie\`)-[:\`FILMED_IN\`]->(\`movie_filmedIn\`:\`State\`) | \`movie_filmedIn\` { .name }]) } AS \`movie\``;
 
   t.plan(3);
   return Promise.all([
@@ -178,7 +178,7 @@ test('Query single object and array of objects relations', t => {
         }
       }
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId:$movieId}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .name }] ,filmedIn: head([(\`movie\`)-[:\`FILMED_IN\`]->(\`movie_filmedIn\`:\`State\`) | movie_filmedIn { .name }]) } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId:$movieId}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] ,filmedIn: head([(\`movie\`)-[:\`FILMED_IN\`]->(\`movie_filmedIn\`:\`State\`) | \`movie_filmedIn\` { .name }]) } AS \`movie\``;
 
   t.plan(3);
   return Promise.all([
@@ -216,7 +216,7 @@ test('Deeply nested object query', t => {
     }
   }
 }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .name ,movies: [(\`movie_actors\`)-[:\`ACTED_IN\`]->(\`movie_actors_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | movie_actors_movies { .title ,actors: [(\`movie_actors_movies\`)<-[:\`ACTED_IN\`]-(\`movie_actors_movies_actors\`:\`Actor\`{name:$1_name}) | movie_actors_movies_actors { .name ,movies: [(\`movie_actors_movies_actors\`)-[:\`ACTED_IN\`]->(\`movie_actors_movies_actors_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | movie_actors_movies_actors_movies { .title , .year ,similar: [ movie_actors_movies_actors_movies_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie_actors_movies_actors_movies, cypherParams: $cypherParams, offset: 0, first: $2_first}, true) | movie_actors_movies_actors_movies_similar { .title , .year }][..3] }] }] }] }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name ,movies: [(\`movie_actors\`)-[:\`ACTED_IN\`]->(\`movie_actors_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`movie_actors_movies\` { .title ,actors: [(\`movie_actors_movies\`)<-[:\`ACTED_IN\`]-(\`movie_actors_movies_actors\`:\`Actor\`{name:$1_name}) | \`movie_actors_movies_actors\` { .name ,movies: [(\`movie_actors_movies_actors\`)-[:\`ACTED_IN\`]->(\`movie_actors_movies_actors_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`movie_actors_movies_actors_movies\` { .title , .year ,similar: [ movie_actors_movies_actors_movies_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie_actors_movies_actors_movies, cypherParams: $cypherParams, offset: 0, first: $2_first}, true) | movie_actors_movies_actors_movies_similar { .title , .year }][..3] }] }] }] }] } AS \`movie\``;
 
   t.plan(3);
   return Promise.all([
@@ -508,7 +508,7 @@ test('Cypher subquery filters', t => {
         }
       }
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`{name:$1_name}) | movie_actors { .name }] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $3_first}, true) | movie_similar { .title }][..3] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`{name:$1_name}) | \`movie_actors\` { .name }] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $3_first}, true) | movie_similar { .title }][..3] } AS \`movie\``;
 
   t.plan(3);
   return Promise.all([
@@ -535,7 +535,7 @@ test('cypher subquery preserves case through filters', t => {
       }
     }`,
     expectedCypherQuery =
-      'MATCH (`casedType`:`CasedType`) WHERE (EXISTS((`casedType`)-[:FILMED_IN]->(:State)) AND ALL(`state` IN [(`casedType`)-[:FILMED_IN]->(`_state`:State) | `_state`] WHERE (`state`.name = $filter.state.name))) RETURN `casedType` { .name ,state: head([(`casedType`)-[:`FILMED_IN`]->(`casedType_state`:`State`) | casedType_state { .name }]) } AS `casedType`';
+      'MATCH (`casedType`:`CasedType`) WHERE (EXISTS((`casedType`)-[:FILMED_IN]->(:State)) AND ALL(`state` IN [(`casedType`)-[:FILMED_IN]->(`_state`:State) | `_state`] WHERE (`state`.name = $filter.state.name))) RETURN `casedType` { .name ,state: head([(`casedType`)-[:`FILMED_IN`]->(`casedType_state`:`State`) | `casedType_state` { .name }]) } AS `casedType`';
 
   t.plan(1);
   return Promise.all([
@@ -556,7 +556,7 @@ test('Cypher subquery filters with paging', t => {
         }
       }
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`{name:$1_name}) | movie_actors { .name }][..3] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $3_first}, true) | movie_similar { .title }][..3] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`{name:$1_name}) | \`movie_actors\` { .name }][..3] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $3_first}, true) | movie_similar { .title }][..3] } AS \`movie\``;
 
   t.plan(3);
   return Promise.all([
@@ -584,7 +584,7 @@ test('Handle @cypher directive on Query Type', t => {
   }
 }
   `,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {offset:$offset, first:$first, substring:$substring, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`genre\` RETURN \`genre\` { .name ,movies: [(\`genre\`)<-[:\`IN_GENRE\`]-(\`genre_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | genre_movies { .title }][..3] } AS \`genre\``;
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {offset:$offset, first:$first, substring:$substring, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`genre\` RETURN \`genre\` { .name ,movies: [(\`genre\`)<-[:\`IN_GENRE\`]-(\`genre_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`genre_movies\` { .title }][..3] } AS \`genre\``;
 
   t.plan(3);
   return Promise.all([
@@ -654,7 +654,7 @@ test.cb('Create node mutation', t => {
   }`,
     expectedCypherQuery = `
     CREATE (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId:$params.movieId,title:$params.title,year:$params.year,plot:$params.plot,poster:$params.poster,imdbRating:$params.imdbRating})
-    RETURN \`movie\` {_id: ID(\`movie\`), .title ,genres: [(\`movie\`)-[:\`IN_GENRE\`]->(\`movie_genres\`:\`Genre\`) | movie_genres { .name }] } AS \`movie\`
+    RETURN \`movie\` {_id: ID(\`movie\`), .title ,genres: [(\`movie\`)-[:\`IN_GENRE\`]->(\`movie_genres\`:\`Genre\`) | \`movie_genres\` { .name }] } AS \`movie\`
   `;
 
   t.plan(2);
@@ -672,7 +672,7 @@ test.cb('Create node mutation', t => {
   });
 });
 
-test.cb('Merge node mutation', t => {
+test.cb('Merge node mutation (interface implemented)', t => {
   const graphQLQuery = `mutation {
     MergeUser(
       userId: "883c6b3e-3863-49a1-b190-1cee083c98b1",
@@ -760,7 +760,7 @@ test('Add relationship mutation', t => {
       MATCH (\`movie_from\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId: $from.movieId})
       MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
       CREATE (\`movie_from\`)-[\`in_genre_relation\`:\`IN_GENRE\`]->(\`genre_to\`)
-      RETURN \`in_genre_relation\` { from: \`movie_from\` { .movieId ,genres: [(\`movie_from\`)-[:\`IN_GENRE\`]->(\`movie_from_genres\`:\`Genre\`) | movie_from_genres {_id: ID(\`movie_from_genres\`), .name }] } ,to: \`genre_to\` { .name }  } AS \`_AddMovieGenresPayload\`;
+      RETURN \`in_genre_relation\` { from: \`movie_from\` { .movieId ,genres: [(\`movie_from\`)-[:\`IN_GENRE\`]->(\`movie_from_genres\`:\`Genre\`) | \`movie_from_genres\` {_id: ID(\`movie_from_genres\`), .name }] } ,to: \`genre_to\` { .name }  } AS \`_AddMovieGenresPayload\`;
     `;
 
   t.plan(1);
@@ -800,7 +800,7 @@ test('Merge relationship mutation', t => {
       MATCH (\`movie_from\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId: $from.movieId})
       MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
       MERGE (\`movie_from\`)-[\`in_genre_relation\`:\`IN_GENRE\`]->(\`genre_to\`)
-      RETURN \`in_genre_relation\` { from: \`movie_from\` { .movieId ,genres: [(\`movie_from\`)-[:\`IN_GENRE\`]->(\`movie_from_genres\`:\`Genre\`) | movie_from_genres {_id: ID(\`movie_from_genres\`), .name }] } ,to: \`genre_to\` { .name }  } AS \`_MergeMovieGenresPayload\`;
+      RETURN \`in_genre_relation\` { from: \`movie_from\` { .movieId ,genres: [(\`movie_from\`)-[:\`IN_GENRE\`]->(\`movie_from_genres\`:\`Genre\`) | \`movie_from_genres\` {_id: ID(\`movie_from_genres\`), .name }] } ,to: \`genre_to\` { .name }  } AS \`_MergeMovieGenresPayload\`;
     `;
 
   t.plan(1);
@@ -840,7 +840,7 @@ test('Add relationship mutation with GraphQL variables', t => {
       MATCH (\`movie_from\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId: $from.movieId})
       MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
       CREATE (\`movie_from\`)-[\`in_genre_relation\`:\`IN_GENRE\`]->(\`genre_to\`)
-      RETURN \`in_genre_relation\` { from: \`movie_from\` { .movieId ,genres: [(\`movie_from\`)-[:\`IN_GENRE\`]->(\`movie_from_genres\`:\`Genre\`) | movie_from_genres {_id: ID(\`movie_from_genres\`), .name }] } ,to: \`genre_to\` { .name }  } AS \`_AddMovieGenresPayload\`;
+      RETURN \`in_genre_relation\` { from: \`movie_from\` { .movieId ,genres: [(\`movie_from\`)-[:\`IN_GENRE\`]->(\`movie_from_genres\`:\`Genre\`) | \`movie_from_genres\` {_id: ID(\`movie_from_genres\`), .name }] } ,to: \`genre_to\` { .name }  } AS \`_AddMovieGenresPayload\`;
     `;
 
   t.plan(1);
@@ -1363,7 +1363,7 @@ test('Add interfaced relationship mutation', t => {
       MATCH (\`actor_from\`:\`Actor\` {userId: $from.userId})
       MATCH (\`person_to\`:\`Person\` {userId: $to.userId})
       CREATE (\`actor_from\`)-[\`knows_relation\`:\`KNOWS\`]->(\`person_to\`)
-      RETURN \`knows_relation\` { from: \`actor_from\` { .userId , .name } ,to: \`person_to\` {FRAGMENT_TYPE: head( [ label IN labels(person_to) WHERE label IN $Person_derivedTypes ] ), .userId , .name }  } AS \`_AddActorKnowsPayload\`;
+      RETURN \`knows_relation\` { from: \`actor_from\` { .userId , .name } ,to: \`person_to\` {FRAGMENT_TYPE: head( [ label IN labels(\`person_to\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }  } AS \`_AddActorKnowsPayload\`;
     `;
 
   t.plan(1);
@@ -1401,7 +1401,7 @@ test('Merge interfaced relationship mutation', t => {
       MATCH (\`actor_from\`:\`Actor\` {userId: $from.userId})
       MATCH (\`person_to\`:\`Person\` {userId: $to.userId})
       MERGE (\`actor_from\`)-[\`knows_relation\`:\`KNOWS\`]->(\`person_to\`)
-      RETURN \`knows_relation\` { from: \`actor_from\` { .userId , .name } ,to: \`person_to\` {FRAGMENT_TYPE: head( [ label IN labels(person_to) WHERE label IN $Person_derivedTypes ] ), .userId , .name }  } AS \`_MergeActorKnowsPayload\`;
+      RETURN \`knows_relation\` { from: \`actor_from\` { .userId , .name } ,to: \`person_to\` {FRAGMENT_TYPE: head( [ label IN labels(\`person_to\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }  } AS \`_MergeActorKnowsPayload\`;
     `;
 
   t.plan(1);
@@ -1441,7 +1441,7 @@ test('Remove interfaced relationship mutation', t => {
       OPTIONAL MATCH (\`actor_from\`)-[\`actor_fromperson_to\`:\`KNOWS\`]->(\`person_to\`)
       DELETE \`actor_fromperson_to\`
       WITH COUNT(*) AS scope, \`actor_from\` AS \`_actor_from\`, \`person_to\` AS \`_person_to\`
-      RETURN {from: \`_actor_from\` { .userId , .name } ,to: \`_person_to\` {FRAGMENT_TYPE: head( [ label IN labels(_person_to) WHERE label IN $Person_derivedTypes ] ), .userId , .name } } AS \`_RemoveActorKnowsPayload\`;
+      RETURN {from: \`_actor_from\` { .userId , .name } ,to: \`_person_to\` {FRAGMENT_TYPE: head( [ label IN labels(\`_person_to\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name } } AS \`_RemoveActorKnowsPayload\`;
     `;
 
   t.plan(1);
@@ -1665,7 +1665,7 @@ test('Return internal node id for _id field', t => {
   }
 }
 `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` {_id: ID(\`movie\`), .title , .year ,genres: [(\`movie\`)-[:\`IN_GENRE\`]->(\`movie_genres\`:\`Genre\`) | movie_genres {_id: ID(\`movie_genres\`), .name }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` {_id: ID(\`movie\`), .title , .year ,genres: [(\`movie\`)-[:\`IN_GENRE\`]->(\`movie_genres\`:\`Genre\`) | \`movie_genres\` {_id: ID(\`movie_genres\`), .name }] } AS \`movie\``;
 
   t.plan(3);
 
@@ -1701,7 +1701,7 @@ test('Treat enum as a scalar', t => {
   ]);
 });
 
-test('Handle query fragment', t => {
+test('Handle fragment spread on object type', t => {
   const graphQLQuery = `
 fragment myTitle on Movie {
   title
@@ -1716,7 +1716,7 @@ query getMovie {
     year
   }
 }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .name }] , .year } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] , .year } AS \`movie\``;
 
   t.plan(3);
   return Promise.all([
@@ -1730,7 +1730,33 @@ query getMovie {
   ]);
 });
 
-test('Handle multiple query fragments', t => {
+test('Handle inline fragment on object type', t => {
+  const graphQLQuery = `query getMovie {
+    Movie(title: "River Runs Through It, A") {
+      ... on Movie {
+        title
+        actors {
+          name
+        }
+      }
+      year
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] , .year } AS \`movie\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      cypherParams: CYPHER_PARAMS,
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('Handle multiple query fragments on object type', t => {
   const graphQLQuery = `
     fragment myTitle on Movie {
   title
@@ -1750,7 +1776,7 @@ query getMovie {
   }
 }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .name }] , .year } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] , .year } AS \`movie\``;
 
   t.plan(3);
   return Promise.all([
@@ -1764,7 +1790,37 @@ query getMovie {
   ]);
 });
 
-test('nested fragments', t => {
+test('query object type using inline fragment and fragment spread', t => {
+  const graphQLQuery = `fragment myTitle on Movie {
+    title
+  }
+  
+  query getMovie {
+    Movie(title: "River Runs Through It, A") {
+      ...myTitle
+      ... on Movie {
+        actors {
+          name
+        }
+      }
+      year
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] , .year } AS \`movie\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      cypherParams: CYPHER_PARAMS,
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('nested fragments on object type', t => {
   const graphQLQuery = `
     query movieItems {
       Movie(year:2010) {
@@ -1794,7 +1850,7 @@ test('nested fragments', t => {
   ]);
 });
 
-test('fragments on relations', t => {
+test('fragments on object type relations', t => {
   const graphQLQuery = `
     query movieItems {
       Movie(year:2010) {
@@ -1808,7 +1864,7 @@ test('fragments on relations', t => {
     fragment Foo on Actor {
       name
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .name }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] } AS \`movie\``;
 
   t.plan(3);
   return Promise.all([
@@ -1822,7 +1878,7 @@ test('fragments on relations', t => {
   ]);
 });
 
-test('nested fragments on relations', t => {
+test('nested fragments on object type relations', t => {
   const graphQLQuery = `
     query movieItems {
       Movie(year:2010) {
@@ -1841,7 +1897,7 @@ test('nested fragments on relations', t => {
     fragment Bar on Actor {
       name
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .userId , .name }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .userId , .name }] } AS \`movie\``;
 
   t.plan(3);
   return Promise.all([
@@ -1865,7 +1921,7 @@ test('orderBy test - descending, top level - augmented schema', t => {
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) WITH \`movie\` ORDER BY movie.title DESC RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .name }][..3] } AS \`movie\` LIMIT toInteger($first)`;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) WITH \`movie\` ORDER BY movie.title DESC RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }][..3] } AS \`movie\` LIMIT toInteger($first)`;
 
   t.plan(1);
 
@@ -2106,7 +2162,7 @@ test('query reflexive relation type with arguments', t => {
   );
 });
 
-test('query using inline fragment', t => {
+test('query using inline fragment on object type', t => {
   const graphQLQuery = `
   {
     Movie(title: "River Runs Through It, A") {
@@ -2137,8 +2193,7 @@ test('query using inline fragment', t => {
 });
 
 test('query interfaced relation using inline fragment', t => {
-  const graphQLQuery = `query 
-  {
+  const graphQLQuery = `query {
     Actor {
       name
       knows {
@@ -2154,9 +2209,8 @@ test('query interfaced relation using inline fragment', t => {
       title
       year
     }
-  } 
-  `,
-    expectedCypherQuery = `MATCH (\`actor\`:\`Actor\`) RETURN \`actor\` { .name ,knows: [(\`actor\`)-[:\`KNOWS\`]->(\`actor_knows\`:\`Person\`) | actor_knows {FRAGMENT_TYPE: head( [ label IN labels(actor_knows) WHERE label IN $Person_derivedTypes ] ),  .name ,favorites: [(\`actor_knows\`)-[:\`FAVORITED\`]->(\`actor_knows_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | actor_knows_favorites { .movieId , .title , .year }] }] } AS \`actor\``;
+  }`,
+    expectedCypherQuery = `MATCH (\`actor\`:\`Actor\`) RETURN \`actor\` { .name ,knows: [(\`actor\`)-[:\`KNOWS\`]->(\`actor_knows\`:\`Person\`) WHERE ("User" IN labels(\`actor_knows\`)) | head([\`actor_knows\` IN [\`actor_knows\`] WHERE [label IN labels(\`actor_knows\`) WHERE label = "User" | TRUE] | \`actor_knows\` { FRAGMENT_TYPE: "User",  .name ,favorites: [(\`actor_knows\`)-[:\`FAVORITED\`]->(\`actor_knows_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`actor_knows_favorites\` { .movieId , .title , .year }]  }])] } AS \`actor\``;
 
   t.plan(1);
 
@@ -2612,7 +2666,7 @@ test('Nested Query with temporal property arguments', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`temporalNode\`:\`TemporalNode\`) WHERE \`temporalNode\`.datetime.year = $datetime.year AND \`temporalNode\`.datetime.month = $datetime.month AND \`temporalNode\`.datetime.day = $datetime.day AND \`temporalNode\`.datetime.hour = $datetime.hour AND \`temporalNode\`.datetime.minute = $datetime.minute AND \`temporalNode\`.datetime.second = $datetime.second AND \`temporalNode\`.datetime.millisecond = $datetime.millisecond AND \`temporalNode\`.datetime.microsecond = $datetime.microsecond AND \`temporalNode\`.datetime.nanosecond = $datetime.nanosecond AND \`temporalNode\`.datetime.timezone = $datetime.timezone RETURN \`temporalNode\` {_id: ID(\`temporalNode\`),time: { hour: \`temporalNode\`.time.hour , minute: \`temporalNode\`.time.minute , second: \`temporalNode\`.time.second , millisecond: \`temporalNode\`.time.millisecond , microsecond: \`temporalNode\`.time.microsecond , nanosecond: \`temporalNode\`.time.nanosecond , timezone: \`temporalNode\`.time.timezone , formatted: toString(\`temporalNode\`.time) },date: { year: \`temporalNode\`.date.year , month: \`temporalNode\`.date.month , day: \`temporalNode\`.date.day , formatted: toString(\`temporalNode\`.date) },datetime: { year: \`temporalNode\`.datetime.year , month: \`temporalNode\`.datetime.month , day: \`temporalNode\`.datetime.day , hour: \`temporalNode\`.datetime.hour , minute: \`temporalNode\`.datetime.minute , second: \`temporalNode\`.datetime.second , millisecond: \`temporalNode\`.datetime.millisecond , microsecond: \`temporalNode\`.datetime.microsecond , nanosecond: \`temporalNode\`.datetime.nanosecond , timezone: \`temporalNode\`.datetime.timezone , formatted: toString(\`temporalNode\`.datetime) },localtime: { hour: \`temporalNode\`.localtime.hour , minute: \`temporalNode\`.localtime.minute , second: \`temporalNode\`.localtime.second , millisecond: \`temporalNode\`.localtime.millisecond , microsecond: \`temporalNode\`.localtime.microsecond , nanosecond: \`temporalNode\`.localtime.nanosecond , formatted: toString(\`temporalNode\`.localtime) },localdatetime: { year: \`temporalNode\`.localdatetime.year , month: \`temporalNode\`.localdatetime.month , day: \`temporalNode\`.localdatetime.day , hour: \`temporalNode\`.localdatetime.hour , minute: \`temporalNode\`.localdatetime.minute , second: \`temporalNode\`.localdatetime.second , millisecond: \`temporalNode\`.localdatetime.millisecond , microsecond: \`temporalNode\`.localdatetime.microsecond , nanosecond: \`temporalNode\`.localdatetime.nanosecond , formatted: toString(\`temporalNode\`.localdatetime) },temporalNodes: [(\`temporalNode\`)-[:\`TEMPORAL\`]->(\`temporalNode_temporalNodes\`:\`TemporalNode\`) WHERE temporalNode_temporalNodes.datetime.year = $1_datetime.year AND temporalNode_temporalNodes.datetime.month = $1_datetime.month AND temporalNode_temporalNodes.datetime.day = $1_datetime.day AND temporalNode_temporalNodes.datetime.hour = $1_datetime.hour AND temporalNode_temporalNodes.datetime.minute = $1_datetime.minute AND temporalNode_temporalNodes.datetime.second = $1_datetime.second AND temporalNode_temporalNodes.datetime.millisecond = $1_datetime.millisecond AND temporalNode_temporalNodes.datetime.microsecond = $1_datetime.microsecond AND temporalNode_temporalNodes.datetime.nanosecond = $1_datetime.nanosecond AND temporalNode_temporalNodes.datetime.timezone = $1_datetime.timezone AND temporalNode_temporalNodes.localdatetime = localdatetime($1_localdatetime.formatted) | temporalNode_temporalNodes {_id: ID(\`temporalNode_temporalNodes\`),time: { hour: \`temporalNode_temporalNodes\`.time.hour , minute: \`temporalNode_temporalNodes\`.time.minute , second: \`temporalNode_temporalNodes\`.time.second , millisecond: \`temporalNode_temporalNodes\`.time.millisecond , microsecond: \`temporalNode_temporalNodes\`.time.microsecond , nanosecond: \`temporalNode_temporalNodes\`.time.nanosecond , timezone: \`temporalNode_temporalNodes\`.time.timezone , formatted: toString(\`temporalNode_temporalNodes\`.time) },date: { year: \`temporalNode_temporalNodes\`.date.year , month: \`temporalNode_temporalNodes\`.date.month , day: \`temporalNode_temporalNodes\`.date.day , formatted: toString(\`temporalNode_temporalNodes\`.date) },datetime: { year: \`temporalNode_temporalNodes\`.datetime.year , month: \`temporalNode_temporalNodes\`.datetime.month , day: \`temporalNode_temporalNodes\`.datetime.day , hour: \`temporalNode_temporalNodes\`.datetime.hour , minute: \`temporalNode_temporalNodes\`.datetime.minute , second: \`temporalNode_temporalNodes\`.datetime.second , millisecond: \`temporalNode_temporalNodes\`.datetime.millisecond , microsecond: \`temporalNode_temporalNodes\`.datetime.microsecond , nanosecond: \`temporalNode_temporalNodes\`.datetime.nanosecond , timezone: \`temporalNode_temporalNodes\`.datetime.timezone , formatted: toString(\`temporalNode_temporalNodes\`.datetime) },localtime: { hour: \`temporalNode_temporalNodes\`.localtime.hour , minute: \`temporalNode_temporalNodes\`.localtime.minute , second: \`temporalNode_temporalNodes\`.localtime.second , millisecond: \`temporalNode_temporalNodes\`.localtime.millisecond , microsecond: \`temporalNode_temporalNodes\`.localtime.microsecond , nanosecond: \`temporalNode_temporalNodes\`.localtime.nanosecond , formatted: toString(\`temporalNode_temporalNodes\`.localtime) },localdatetime: { year: \`temporalNode_temporalNodes\`.localdatetime.year , month: \`temporalNode_temporalNodes\`.localdatetime.month , day: \`temporalNode_temporalNodes\`.localdatetime.day , hour: \`temporalNode_temporalNodes\`.localdatetime.hour , minute: \`temporalNode_temporalNodes\`.localdatetime.minute , second: \`temporalNode_temporalNodes\`.localdatetime.second , millisecond: \`temporalNode_temporalNodes\`.localdatetime.millisecond , microsecond: \`temporalNode_temporalNodes\`.localdatetime.microsecond , nanosecond: \`temporalNode_temporalNodes\`.localdatetime.nanosecond , formatted: toString(\`temporalNode_temporalNodes\`.localdatetime) }}] } AS \`temporalNode\``;
+    expectedCypherQuery = `MATCH (\`temporalNode\`:\`TemporalNode\`) WHERE \`temporalNode\`.datetime.year = $datetime.year AND \`temporalNode\`.datetime.month = $datetime.month AND \`temporalNode\`.datetime.day = $datetime.day AND \`temporalNode\`.datetime.hour = $datetime.hour AND \`temporalNode\`.datetime.minute = $datetime.minute AND \`temporalNode\`.datetime.second = $datetime.second AND \`temporalNode\`.datetime.millisecond = $datetime.millisecond AND \`temporalNode\`.datetime.microsecond = $datetime.microsecond AND \`temporalNode\`.datetime.nanosecond = $datetime.nanosecond AND \`temporalNode\`.datetime.timezone = $datetime.timezone RETURN \`temporalNode\` {_id: ID(\`temporalNode\`),time: { hour: \`temporalNode\`.time.hour , minute: \`temporalNode\`.time.minute , second: \`temporalNode\`.time.second , millisecond: \`temporalNode\`.time.millisecond , microsecond: \`temporalNode\`.time.microsecond , nanosecond: \`temporalNode\`.time.nanosecond , timezone: \`temporalNode\`.time.timezone , formatted: toString(\`temporalNode\`.time) },date: { year: \`temporalNode\`.date.year , month: \`temporalNode\`.date.month , day: \`temporalNode\`.date.day , formatted: toString(\`temporalNode\`.date) },datetime: { year: \`temporalNode\`.datetime.year , month: \`temporalNode\`.datetime.month , day: \`temporalNode\`.datetime.day , hour: \`temporalNode\`.datetime.hour , minute: \`temporalNode\`.datetime.minute , second: \`temporalNode\`.datetime.second , millisecond: \`temporalNode\`.datetime.millisecond , microsecond: \`temporalNode\`.datetime.microsecond , nanosecond: \`temporalNode\`.datetime.nanosecond , timezone: \`temporalNode\`.datetime.timezone , formatted: toString(\`temporalNode\`.datetime) },localtime: { hour: \`temporalNode\`.localtime.hour , minute: \`temporalNode\`.localtime.minute , second: \`temporalNode\`.localtime.second , millisecond: \`temporalNode\`.localtime.millisecond , microsecond: \`temporalNode\`.localtime.microsecond , nanosecond: \`temporalNode\`.localtime.nanosecond , formatted: toString(\`temporalNode\`.localtime) },localdatetime: { year: \`temporalNode\`.localdatetime.year , month: \`temporalNode\`.localdatetime.month , day: \`temporalNode\`.localdatetime.day , hour: \`temporalNode\`.localdatetime.hour , minute: \`temporalNode\`.localdatetime.minute , second: \`temporalNode\`.localdatetime.second , millisecond: \`temporalNode\`.localdatetime.millisecond , microsecond: \`temporalNode\`.localdatetime.microsecond , nanosecond: \`temporalNode\`.localdatetime.nanosecond , formatted: toString(\`temporalNode\`.localdatetime) },temporalNodes: [(\`temporalNode\`)-[:\`TEMPORAL\`]->(\`temporalNode_temporalNodes\`:\`TemporalNode\`) WHERE temporalNode_temporalNodes.datetime.year = $1_datetime.year AND temporalNode_temporalNodes.datetime.month = $1_datetime.month AND temporalNode_temporalNodes.datetime.day = $1_datetime.day AND temporalNode_temporalNodes.datetime.hour = $1_datetime.hour AND temporalNode_temporalNodes.datetime.minute = $1_datetime.minute AND temporalNode_temporalNodes.datetime.second = $1_datetime.second AND temporalNode_temporalNodes.datetime.millisecond = $1_datetime.millisecond AND temporalNode_temporalNodes.datetime.microsecond = $1_datetime.microsecond AND temporalNode_temporalNodes.datetime.nanosecond = $1_datetime.nanosecond AND temporalNode_temporalNodes.datetime.timezone = $1_datetime.timezone AND temporalNode_temporalNodes.localdatetime = localdatetime($1_localdatetime.formatted) | \`temporalNode_temporalNodes\` {_id: ID(\`temporalNode_temporalNodes\`),time: { hour: \`temporalNode_temporalNodes\`.time.hour , minute: \`temporalNode_temporalNodes\`.time.minute , second: \`temporalNode_temporalNodes\`.time.second , millisecond: \`temporalNode_temporalNodes\`.time.millisecond , microsecond: \`temporalNode_temporalNodes\`.time.microsecond , nanosecond: \`temporalNode_temporalNodes\`.time.nanosecond , timezone: \`temporalNode_temporalNodes\`.time.timezone , formatted: toString(\`temporalNode_temporalNodes\`.time) },date: { year: \`temporalNode_temporalNodes\`.date.year , month: \`temporalNode_temporalNodes\`.date.month , day: \`temporalNode_temporalNodes\`.date.day , formatted: toString(\`temporalNode_temporalNodes\`.date) },datetime: { year: \`temporalNode_temporalNodes\`.datetime.year , month: \`temporalNode_temporalNodes\`.datetime.month , day: \`temporalNode_temporalNodes\`.datetime.day , hour: \`temporalNode_temporalNodes\`.datetime.hour , minute: \`temporalNode_temporalNodes\`.datetime.minute , second: \`temporalNode_temporalNodes\`.datetime.second , millisecond: \`temporalNode_temporalNodes\`.datetime.millisecond , microsecond: \`temporalNode_temporalNodes\`.datetime.microsecond , nanosecond: \`temporalNode_temporalNodes\`.datetime.nanosecond , timezone: \`temporalNode_temporalNodes\`.datetime.timezone , formatted: toString(\`temporalNode_temporalNodes\`.datetime) },localtime: { hour: \`temporalNode_temporalNodes\`.localtime.hour , minute: \`temporalNode_temporalNodes\`.localtime.minute , second: \`temporalNode_temporalNodes\`.localtime.second , millisecond: \`temporalNode_temporalNodes\`.localtime.millisecond , microsecond: \`temporalNode_temporalNodes\`.localtime.microsecond , nanosecond: \`temporalNode_temporalNodes\`.localtime.nanosecond , formatted: toString(\`temporalNode_temporalNodes\`.localtime) },localdatetime: { year: \`temporalNode_temporalNodes\`.localdatetime.year , month: \`temporalNode_temporalNodes\`.localdatetime.month , day: \`temporalNode_temporalNodes\`.localdatetime.day , hour: \`temporalNode_temporalNodes\`.localdatetime.hour , minute: \`temporalNode_temporalNodes\`.localdatetime.minute , second: \`temporalNode_temporalNodes\`.localdatetime.second , millisecond: \`temporalNode_temporalNodes\`.localdatetime.millisecond , microsecond: \`temporalNode_temporalNodes\`.localdatetime.microsecond , nanosecond: \`temporalNode_temporalNodes\`.localdatetime.nanosecond , formatted: toString(\`temporalNode_temporalNodes\`.localdatetime) }}] } AS \`temporalNode\``;
 
   t.plan(1);
 
@@ -2642,7 +2696,7 @@ test('Nested Query with spatial property arguments', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`spatialNode\`:\`SpatialNode\`) WHERE \`spatialNode\`.point.longitude = $point.longitude RETURN \`spatialNode\` {point: { longitude: \`spatialNode\`.point.longitude , latitude: \`spatialNode\`.point.latitude , height: \`spatialNode\`.point.height },spatialNodes: [(\`spatialNode\`)-[:\`SPATIAL\`]->(\`spatialNode_spatialNodes\`:\`SpatialNode\`) WHERE spatialNode_spatialNodes.point.longitude = $1_point.longitude | spatialNode_spatialNodes {point: { longitude: \`spatialNode_spatialNodes\`.point.longitude , latitude: \`spatialNode_spatialNodes\`.point.latitude , height: \`spatialNode_spatialNodes\`.point.height }}] } AS \`spatialNode\``;
+    expectedCypherQuery = `MATCH (\`spatialNode\`:\`SpatialNode\`) WHERE \`spatialNode\`.point.longitude = $point.longitude RETURN \`spatialNode\` {point: { longitude: \`spatialNode\`.point.longitude , latitude: \`spatialNode\`.point.latitude , height: \`spatialNode\`.point.height },spatialNodes: [(\`spatialNode\`)-[:\`SPATIAL\`]->(\`spatialNode_spatialNodes\`:\`SpatialNode\`) WHERE spatialNode_spatialNodes.point.longitude = $1_point.longitude | \`spatialNode_spatialNodes\` {point: { longitude: \`spatialNode_spatialNodes\`.point.longitude , latitude: \`spatialNode_spatialNodes\`.point.latitude , height: \`spatialNode_spatialNodes\`.point.height }}] } AS \`spatialNode\``;
 
   t.plan(1);
 
@@ -4525,7 +4579,7 @@ test('Cypher array sub queries', t => {
         }
       }
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE \`movie\`.\`year\` IN $year RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`{names:$1_names}) WHERE \`movie_actors\`.\`names\` IN $1_names | movie_actors { .name }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE \`movie\`.\`year\` IN $year RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`{names:$1_names}) WHERE \`movie_actors\`.\`names\` IN $1_names | \`movie_actors\` { .name }] } AS \`movie\``;
 
   t.plan(3);
   return Promise.all([
@@ -4618,7 +4672,7 @@ test('Deeply nested orderBy', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WITH \`movie\` ORDER BY movie.title DESC RETURN \`movie\` { .title ,actors: apoc.coll.sortMulti([(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | movie_actors { .name ,movies: apoc.coll.sortMulti([(\`movie_actors\`)-[:\`ACTED_IN\`]->(\`movie_actors_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | movie_actors_movies { .title }], ['^title','title']) }], ['name']) } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WITH \`movie\` ORDER BY movie.title DESC RETURN \`movie\` { .title ,actors: apoc.coll.sortMulti([(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name ,movies: apoc.coll.sortMulti([(\`movie_actors\`)-[:\`ACTED_IN\`]->(\`movie_actors_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`movie_actors_movies\` { .title }], ['^title','title']) }], ['name']) } AS \`movie\``;
 
   t.plan(1);
   return Promise.all([
@@ -4741,7 +4795,7 @@ test('Deeply nested query using temporal orderBy', t => {
     }
   }`,
     expectedCypherQuery =
-      "MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC RETURN `temporalNode` {_id: ID(`temporalNode`),datetime: { year: `temporalNode`.datetime.year , month: `temporalNode`.datetime.month , day: `temporalNode`.datetime.day , hour: `temporalNode`.datetime.hour , minute: `temporalNode`.datetime.minute , second: `temporalNode`.datetime.second , millisecond: `temporalNode`.datetime.millisecond , microsecond: `temporalNode`.datetime.microsecond , nanosecond: `temporalNode`.datetime.nanosecond , timezone: `temporalNode`.datetime.timezone , formatted: toString(`temporalNode`.datetime) },temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | temporalNode_temporalNodes {_id: ID(`temporalNode_temporalNodes`),datetime: `temporalNode_temporalNodes`.datetime,time: `temporalNode_temporalNodes`.time,temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode_temporalNodes`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes_temporalNodes`:`TemporalNode`) | temporalNode_temporalNodes_temporalNodes {_id: ID(`temporalNode_temporalNodes_temporalNodes`),datetime: `temporalNode_temporalNodes_temporalNodes`.datetime,time: `temporalNode_temporalNodes_temporalNodes`.time}], ['datetime','time']) | sortedElement { .*,  datetime: {year: sortedElement.datetime.year,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}][1..3] }], ['^datetime']) | sortedElement { .*,  datetime: {year: sortedElement.datetime.year,month: sortedElement.datetime.month,day: sortedElement.datetime.day,hour: sortedElement.datetime.hour,minute: sortedElement.datetime.minute,second: sortedElement.datetime.second,millisecond: sortedElement.datetime.millisecond,microsecond: sortedElement.datetime.microsecond,nanosecond: sortedElement.datetime.nanosecond,timezone: sortedElement.datetime.timezone,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}] } AS `temporalNode`";
+      "MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC RETURN `temporalNode` {_id: ID(`temporalNode`),datetime: { year: `temporalNode`.datetime.year , month: `temporalNode`.datetime.month , day: `temporalNode`.datetime.day , hour: `temporalNode`.datetime.hour , minute: `temporalNode`.datetime.minute , second: `temporalNode`.datetime.second , millisecond: `temporalNode`.datetime.millisecond , microsecond: `temporalNode`.datetime.microsecond , nanosecond: `temporalNode`.datetime.nanosecond , timezone: `temporalNode`.datetime.timezone , formatted: toString(`temporalNode`.datetime) },temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes` {_id: ID(`temporalNode_temporalNodes`),datetime: `temporalNode_temporalNodes`.datetime,time: `temporalNode_temporalNodes`.time,temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode_temporalNodes`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes_temporalNodes` {_id: ID(`temporalNode_temporalNodes_temporalNodes`),datetime: `temporalNode_temporalNodes_temporalNodes`.datetime,time: `temporalNode_temporalNodes_temporalNodes`.time}], ['datetime','time']) | sortedElement { .*,  datetime: {year: sortedElement.datetime.year,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}][1..3] }], ['^datetime']) | sortedElement { .*,  datetime: {year: sortedElement.datetime.year,month: sortedElement.datetime.month,day: sortedElement.datetime.day,hour: sortedElement.datetime.hour,minute: sortedElement.datetime.minute,second: sortedElement.datetime.second,millisecond: sortedElement.datetime.millisecond,microsecond: sortedElement.datetime.microsecond,nanosecond: sortedElement.datetime.nanosecond,timezone: sortedElement.datetime.timezone,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}] } AS `temporalNode`";
 
   t.plan(1);
   return Promise.all([
@@ -4800,7 +4854,7 @@ test('Handle nested @cypher fields that use cypherParams', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user, cypherParams: $cypherParams, strArg: "Neo4j"}, false), .name ,friends: {to: [(\`user\`)-[\`user_to_relation\`:\`FRIEND_OF\`]->(\`user_to\`:\`User\`) | user_to_relation { .since ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_to_relation, cypherParams: $cypherParams}, false),User: user_to { .name ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_to, cypherParams: $cypherParams, strArg: "Neo4j"}, false)} }] ,from: [(\`user\`)<-[\`user_from_relation\`:\`FRIEND_OF\`]-(\`user_from\`:\`User\`) | user_from_relation { .since ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_from_relation, cypherParams: $cypherParams}, false)}] } ,rated: [(\`user\`)-[\`user_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_rated_relation { .rating ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_rated_relation, cypherParams: $cypherParams}, false)}] ,favorites: [(\`user\`)-[:\`FAVORITED\`]->(\`user_favorites\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_favorites { .movieId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_favorites, cypherParams: $cypherParams}, false)}] } AS \`user\``;
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user, cypherParams: $cypherParams, strArg: "Neo4j"}, false), .name ,friends: {to: [(\`user\`)-[\`user_to_relation\`:\`FRIEND_OF\`]->(\`user_to\`:\`User\`) | user_to_relation { .since ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_to_relation, cypherParams: $cypherParams}, false),User: user_to { .name ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_to, cypherParams: $cypherParams, strArg: "Neo4j"}, false)} }] ,from: [(\`user\`)<-[\`user_from_relation\`:\`FRIEND_OF\`]-(\`user_from\`:\`User\`) | user_from_relation { .since ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_from_relation, cypherParams: $cypherParams}, false)}] } ,rated: [(\`user\`)-[\`user_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_rated_relation { .rating ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_rated_relation, cypherParams: $cypherParams}, false)}] ,favorites: [(\`user\`)-[:\`FAVORITED\`]->(\`user_favorites\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`user_favorites\` { .movieId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_favorites, cypherParams: $cypherParams}, false)}] } AS \`user\``;
 
   t.plan(1);
   return Promise.all([
@@ -5291,10 +5345,917 @@ test('Handle order by field with underscores - nested field ', t => {
   }
   `,
     expectedCypherQuery =
-      'WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {offset:$offset, first:$first, substring:$substring, cypherParams: $cypherParams}, True) AS x UNWIND x AS `genre` RETURN `genre` {movies: apoc.coll.sortMulti([(`genre`)<-[:`IN_GENRE`]-(`genre_movies`:`Movie`:`u_user-id`:`newMovieLabel`) | genre_movies { .title }], [\'someprefix_title_with_underscores\']) } AS `genre`';
+      'WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {offset:$offset, first:$first, substring:$substring, cypherParams: $cypherParams}, True) AS x UNWIND x AS `genre` RETURN `genre` {movies: apoc.coll.sortMulti([(`genre`)<-[:`IN_GENRE`]-(`genre_movies`:`Movie`:`u_user-id`:`newMovieLabel`) | `genre_movies` { .title }], [\'someprefix_title_with_underscores\']) } AS `genre`';
 
   t.plan(1);
   return Promise.all([
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query only an interface field', t => {
+  const graphQLQuery = `query {
+    Camera {
+      id
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id } AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS,
+      Camera_derivedTypes: ['OldCamera', 'NewCamera']
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query only __typename field on interface type', t => {
+  const graphQLQuery = `query {
+    Camera {
+      __typename
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] )} AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS,
+      Camera_derivedTypes: ['OldCamera', 'NewCamera']
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query only interface fields', t => {
+  const graphQLQuery = `query {
+    Camera {
+      id
+      type
+      make
+      weight
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight } AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      Camera_derivedTypes: ['OldCamera', 'NewCamera']
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query only interface fields using untyped inline fragment', t => {
+  const graphQLQuery = `query {
+    Camera {
+      id
+      type
+      ... {
+        make
+        weight
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight } AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      Camera_derivedTypes: ['OldCamera', 'NewCamera']
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query only computed interface fields', t => {
+  const graphQLQuery = `query {
+    CustomCameras {
+      id
+      type
+      make
+      weight
+    }
+  }`,
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`camera\` RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight } AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      Camera_derivedTypes: ['OldCamera', 'NewCamera']
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interface type relationship field', t => {
+  const graphQLQuery = `query {
+    Camera {
+      id
+      type
+      make
+      weight
+      operators {
+        userId
+        name
+        __typename
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }] } AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      Person_derivedTypes: ['Actor', 'User', 'CameraMan'],
+      cypherParams: CYPHER_PARAMS,
+      Camera_derivedTypes: ['OldCamera', 'NewCamera']
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query only __typename field on interface type relationship field', t => {
+  const graphQLQuery = `query {
+    Camera {
+      id
+      operators {
+        __typename
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] )}] } AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      Person_derivedTypes: ['Actor', 'User', 'CameraMan'],
+      cypherParams: CYPHER_PARAMS,
+      Camera_derivedTypes: ['OldCamera', 'NewCamera']
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query computed interface type relationship field', t => {
+  const graphQLQuery = `query {
+    CustomCameras {
+      id
+      type
+      make
+      weight
+      computedOperators {
+        userId
+        name
+        __typename
+      }
+    }
+  }`,
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`camera\` RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,computedOperators: [ camera_computedOperators IN apoc.cypher.runFirstColumn("MATCH (this)<-[:cameras]-(p:Person) RETURN p", {this: camera, cypherParams: $cypherParams}, true) | camera_computedOperators {FRAGMENT_TYPE: head( [ label IN labels(camera_computedOperators) WHERE label IN $Person_derivedTypes ] ), .userId , .name }] } AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      Person_derivedTypes: ['Actor', 'User', 'CameraMan'],
+      cypherParams: CYPHER_PARAMS,
+      Camera_derivedTypes: ['OldCamera', 'NewCamera']
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query computed interface type relationship field using only an inline fragment', t => {
+  const graphQLQuery = `query {
+    CustomCameras {
+      id
+      type
+      make
+      weight
+      computedOperators {
+        ... on CameraMan {
+          userId
+          name
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`camera\` RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,computedOperators: [camera_computedOperators IN [ camera_computedOperators IN apoc.cypher.runFirstColumn("MATCH (this)<-[:cameras]-(p:Person) RETURN p", {this: camera, cypherParams: $cypherParams}, true) WHERE ("CameraMan" IN labels(camera_computedOperators)) | camera_computedOperators] | head([\`camera_computedOperators\` IN [\`camera_computedOperators\`] WHERE [label IN labels(\`camera_computedOperators\`) WHERE label = "CameraMan" | TRUE] | \`camera_computedOperators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }])] } AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      Camera_derivedTypes: ['OldCamera', 'NewCamera']
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query only fields on an implementing type using an inline fragment', t => {
+  const graphQLQuery = `query {
+    Camera {
+      ... on OldCamera {
+        id
+        type
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('pagination used on root and nested interface type field', t => {
+  const graphQLQuery = `query {
+    Camera(first: 2, offset: 1) {
+      id
+      type
+      make
+      weight
+      operators(first: 1, offset: 1) {
+        name
+        ... on CameraMan {
+          userId
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("Actor" IN labels(\`camera_operators\`) OR "User" IN labels(\`camera_operators\`) OR "CameraMan" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE [label IN labels(\`camera_operators\`) WHERE label = "Actor" | TRUE] | \`camera_operators\` { FRAGMENT_TYPE: "Actor",  .name  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE [label IN labels(\`camera_operators\`) WHERE label = "User" | TRUE] | \`camera_operators\` { FRAGMENT_TYPE: "User",  .name  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE [label IN labels(\`camera_operators\`) WHERE label = "CameraMan" | TRUE] | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }])][1..2] } AS \`camera\` SKIP toInteger($offset) LIMIT toInteger($first)`;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 1,
+      first: 2,
+      '1_first': 1,
+      '1_offset': 1,
+      cypherParams: CYPHER_PARAMS,
+      Camera_derivedTypes: ['OldCamera', 'NewCamera']
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('ordering used on root and nested interface type field', t => {
+  const graphQLQuery = `query {
+    Camera(orderBy: type_asc) {
+      id
+      type
+      make
+      weight
+      operators(orderBy: name_desc) {
+        name
+        ... on CameraMan {
+          userId
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WITH \`camera\` ORDER BY camera.type ASC RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,operators: apoc.coll.sortMulti([(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("Actor" IN labels(\`camera_operators\`) OR "User" IN labels(\`camera_operators\`) OR "CameraMan" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE [label IN labels(\`camera_operators\`) WHERE label = "Actor" | TRUE] | \`camera_operators\` { FRAGMENT_TYPE: "Actor",  .name  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE [label IN labels(\`camera_operators\`) WHERE label = "User" | TRUE] | \`camera_operators\` { FRAGMENT_TYPE: "User",  .name  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE [label IN labels(\`camera_operators\`) WHERE label = "CameraMan" | TRUE] | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }])], ['name']) } AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      '1_orderBy': 'name_desc',
+      cypherParams: CYPHER_PARAMS,
+      Camera_derivedTypes: ['OldCamera', 'NewCamera']
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('filtering used on root and nested interface type field with only fragments', t => {
+  const graphQLQuery = `query {
+    Camera(
+      filter: {
+        operators_not: null
+      }
+    ) {
+      ... on NewCamera {
+        operators(
+          filter: {
+            name_not: null
+          }
+        ) {
+          ... on CameraMan {
+            name
+          }
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`)) AND ($filter._operators_not_null = TRUE AND EXISTS((\`camera\`)<-[:cameras]-(:Person))) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "NewCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "NewCamera", operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("CameraMan" IN labels(\`camera_operators\`)) AND ($1_filter._name_not_null = TRUE AND EXISTS(\`camera_operators\`.name)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE [label IN labels(\`camera_operators\`) WHERE label = "CameraMan" | TRUE] | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .name  }])]  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      filter: {
+        _operators_not_null: true
+      },
+      '1_filter': {
+        _name_not_null: true
+      },
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('filtering used on root and nested interface using fragments and query variables', t => {
+  const graphQLQuery = `query getCameras($type: String, $operatorsFilter: _PersonFilter, $computedOperatorName: String) {
+    Camera(type: $type) {
+      id
+      type
+      ... on NewCamera {
+        operators(filter: $operatorsFilter) {
+          userId
+        }
+      }
+      ... on OldCamera {
+        operators(filter: $operatorsFilter) {
+          userId
+        }
+      }
+      operators(filter: $operatorsFilter) {
+        userId
+      }
+      computedOperators(name: $computedOperatorName) {
+        userId
+        name
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\` {type:$type}) WHERE ("OldCamera" IN labels(\`camera\`) OR "NewCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera", operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE (\`camera_operators\`.userId = $1_filter.userId) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId }] , .id , .type ,computedOperators: [ camera_computedOperators IN apoc.cypher.runFirstColumn("MATCH (this)<-[:cameras]-(p:Person) RETURN p", {this: camera, cypherParams: $cypherParams, name: $3_name}, true) | camera_computedOperators {FRAGMENT_TYPE: head( [ label IN labels(camera_computedOperators) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]  }] + [\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "NewCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "NewCamera", operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE (\`camera_operators\`.userId = $1_filter.userId) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId }] , .id , .type ,computedOperators: [ camera_computedOperators IN apoc.cypher.runFirstColumn("MATCH (this)<-[:cameras]-(p:Person) RETURN p", {this: camera, cypherParams: $cypherParams, name: $3_name}, true) | camera_computedOperators {FRAGMENT_TYPE: head( [ label IN labels(camera_computedOperators) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(
+      t,
+      graphQLQuery,
+      {
+        type: 'macro',
+        operatorsFilter: {
+          userId: 'man001'
+        },
+        computedOperatorName: 'Johnnie Zoom'
+      },
+      expectedCypherQuery,
+      {
+        offset: 0,
+        first: -1,
+        type: 'macro',
+        '1_filter': {
+          userId: 'man001'
+        },
+        '3_name': 'Johnnie Zoom',
+        Person_derivedTypes: ['Actor', 'User', 'CameraMan'],
+        cypherParams: CYPHER_PARAMS
+      }
+    ),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {
+        type: 'macro',
+        operatorsFilter: {
+          userId: 'man001'
+        },
+        computedOperatorName: 'Johnnie Zoom'
+      },
+      expectedCypherQuery
+    )
+  ]);
+});
+
+test('query only computed fields on an implementing type using an inline fragment', t => {
+  const graphQLQuery = `query {
+    CustomCameras {
+      ... on OldCamera {
+        id
+        type
+      }
+    }
+  }`,
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x WITH [\`camera\` IN x WHERE ("OldCamera" IN labels(\`camera\`)) | \`camera\`] AS x UNWIND x AS \`camera\` RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query computed interface fields using fragments on implementing types', t => {
+  const graphQLQuery = `query {
+    CustomCameras {
+      id
+      ... on OldCamera {
+        type
+      }
+      ...NewCameraFragment
+      __typename
+    }
+  }
+  
+  fragment NewCameraFragment on NewCamera {
+    type
+    weight
+  }`,
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x WITH [\`camera\` IN x WHERE ("OldCamera" IN labels(\`camera\`) OR "NewCamera" IN labels(\`camera\`)) | \`camera\`] AS x UNWIND x AS \`camera\` RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .type , .id  }] + [\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "NewCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .type , .weight , .id  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interface type relationship field using inline fragment on implementing type', t => {
+  const graphQLQuery = `query {
+    Camera {
+      ... on OldCamera {
+        id
+        type
+        operators {
+          userId
+          ... on CameraMan {
+            name
+          }
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("Actor" IN labels(\`camera_operators\`) OR "User" IN labels(\`camera_operators\`) OR "CameraMan" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE [label IN labels(\`camera_operators\`) WHERE label = "Actor" | TRUE] | \`camera_operators\` { FRAGMENT_TYPE: "Actor",  .userId  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE [label IN labels(\`camera_operators\`) WHERE label = "User" | TRUE] | \`camera_operators\` { FRAGMENT_TYPE: "User",  .userId  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE [label IN labels(\`camera_operators\`) WHERE label = "CameraMan" | TRUE] | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .name , .userId  }])]  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interface type relationship field using only inline fragment', t => {
+  const graphQLQuery = `query {
+    Camera {
+      ... on OldCamera {
+        id
+        type
+        operators {
+          ... on CameraMan {
+            userId
+            name
+          }
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("CameraMan" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE [label IN labels(\`camera_operators\`) WHERE label = "CameraMan" | TRUE] | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }])]  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interface __typename as only field not within fragments on implementing types', t => {
+  const graphQLQuery = `query {
+    Camera {
+      __typename
+      ... on OldCamera {
+        id
+        type
+        operators {
+          __typename
+          ... on CameraMan {
+            userId
+            name
+          }
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("CameraMan" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE [label IN labels(\`camera_operators\`) WHERE label = "CameraMan" | TRUE] | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }])]  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query same field on implementing type using inline fragment', t => {
+  const graphQLQuery = `query {
+    Camera {
+      id
+      ... on OldCamera {
+        id
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`) OR "NewCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id  }] + [\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "NewCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interface and implementing type using inline fragment', t => {
+  const graphQLQuery = `query {
+    Camera {
+      id
+      ... on OldCamera {
+        id
+        type
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`) OR "NewCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type  }] + [\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "NewCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interface type relationship fields within inline fragment', t => {
+  const graphQLQuery = `query {
+    Camera {
+      id
+      type
+      make
+      weight
+      ... on OldCamera {
+        operators {
+          userId
+          name
+          __typename
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`) OR "NewCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera", operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }] , .id , .type , .make , .weight  }] + [\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "NewCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id , .type , .make , .weight  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      Person_derivedTypes: ['Actor', 'User', 'CameraMan'],
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interface and implementing type using fragment spread', t => {
+  const graphQLQuery = `query {
+    Camera {
+      id
+      ...NewCameraFragment
+    }
+  }
+  
+  fragment NewCameraFragment on NewCamera {
+    id
+    type
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`) OR "NewCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id  }] + [\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "NewCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id , .type  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interface and implementing types using inline fragment and fragment spread', t => {
+  const graphQLQuery = `query {
+    Camera {
+      id
+      ...NewCameraFragment
+      make
+      ... on OldCamera {
+        smell
+      }
+    }
+  }
+  
+  fragment NewCameraFragment on NewCamera {
+    id
+    type
+    features
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`) OR "NewCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .smell , .id , .make  }] + [\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "NewCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id , .type , .features , .make  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interface type relationship field on implementing types using inline fragment and fragment spread', t => {
+  const graphQLQuery = `query {
+    Camera {
+      id
+      type
+      weight
+      ... on OldCamera {
+        id
+        operators {
+          userId
+          name
+        }
+      }
+      ...NewCameraFragment
+    }
+  }
+  
+  fragment NewCameraFragment on NewCamera {
+    id
+    operators {
+      userId
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`) OR "NewCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }] , .type , .weight  }] + [\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "NewCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId }] , .type , .weight  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      Person_derivedTypes: ['Actor', 'User', 'CameraMan'],
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interface type payload of @cypher mutation field', t => {
+  const graphQLQuery = `mutation {
+    CustomCamera {
+      id
+      type
+    }
+  }`,
+    expectedCypherQuery = `CALL apoc.cypher.doIt("CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro'}) RETURN newCamera", {first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
+    WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`camera\`
+    RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type } AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      Camera_derivedTypes: ['OldCamera', 'NewCamera']
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interface type list payload of @cypher mutation field using fragments', t => {
+  const graphQLQuery = `mutation {
+    CustomCameras {
+      id
+      ... on NewCamera {
+        features
+      }
+      ...OldCameraFragment
+      ...CameraFragment
+    }
+  }
+  fragment CameraFragment on Camera {
+    type
+  }
+  fragment OldCameraFragment on OldCamera {
+    smell
+  }`,
+    expectedCypherQuery = `CALL apoc.cypher.doIt("CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro', features: ['selfie', 'zoom']}) CREATE (oldCamera:Camera:OldCamera {id: apoc.create.uuid(), type: 'floating', smell: 'rusty' }) RETURN [newCamera, oldCamera]", {first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
+    UNWIND [\`camera\` IN apoc.map.values(value, [keys(value)[0]])[0]  WHERE ("OldCamera" IN labels(\`camera\`) OR "NewCamera" IN labels(\`camera\`)) | \`camera\`] AS \`camera\`
+    RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .smell , .id , .type  }] + [\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "NewCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .features , .id , .type  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interface type list payload of @cypher mutation field using only fragments', t => {
+  const graphQLQuery = `mutation {
+    CustomCameras {
+      ... on NewCamera {
+        features
+      }
+      ...OldCameraFragment
+    }
+  }
+  
+  fragment OldCameraFragment on OldCamera {
+    smell
+  }`,
+    expectedCypherQuery = `CALL apoc.cypher.doIt("CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro', features: ['selfie', 'zoom']}) CREATE (oldCamera:Camera:OldCamera {id: apoc.create.uuid(), type: 'floating', smell: 'rusty' }) RETURN [newCamera, oldCamera]", {first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
+    UNWIND [\`camera\` IN apoc.map.values(value, [keys(value)[0]])[0]  WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) | \`camera\`] AS \`camera\`
+    RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .smell  }] + [\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "NewCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .features  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    }),
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query interfaced relationship mutation payload using fragments', t => {
+  const graphQLQuery = `mutation someMutation {
+    AddActorKnows(from: { userId: "123" }, to: { userId: "456" }) {
+      from {
+        name
+      }
+      to {
+        name
+        ... on User {
+          userId
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `
+      MATCH (\`actor_from\`:\`Actor\` {userId: $from.userId})
+      MATCH (\`person_to\`:\`Person\` {userId: $to.userId})
+      CREATE (\`actor_from\`)-[\`knows_relation\`:\`KNOWS\`]->(\`person_to\`)
+      RETURN \`knows_relation\` { from: \`actor_from\` { .name } ,to: head([\`person_to\` IN [\`person_to\`] WHERE [label IN labels(\`person_to\`) WHERE label = "Actor" | TRUE] | \`person_to\` { FRAGMENT_TYPE: "Actor",  .name  }] + [\`person_to\` IN [\`person_to\`] WHERE [label IN labels(\`person_to\`) WHERE label = "User" | TRUE] | \`person_to\` { FRAGMENT_TYPE: "User",  .userId , .name  }] + [\`person_to\` IN [\`person_to\`] WHERE [label IN labels(\`person_to\`) WHERE label = "CameraMan" | TRUE] | \`person_to\` { FRAGMENT_TYPE: "CameraMan",  .name  }])  } AS \`_AddActorKnowsPayload\`;
+    `;
+
+  t.plan(1);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {
+      from: { userId: '123' },
+      to: { userId: '456' },
+      first: -1,
+      offset: 0
+    },
+    expectedCypherQuery,
+    {}
+  );
+});
+
+test('query interfaced relationship mutation payload using only fragments', t => {
+  const graphQLQuery = `mutation someMutation {
+    AddActorKnows(from: { userId: "123" }, to: { userId: "456" }) {
+      from {
+        name
+      }
+      to {
+        ... on User {
+          userId
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `
+      MATCH (\`actor_from\`:\`Actor\` {userId: $from.userId})
+      MATCH (\`person_to\`:\`Person\` {userId: $to.userId})
+      CREATE (\`actor_from\`)-[\`knows_relation\`:\`KNOWS\`]->(\`person_to\`)
+      RETURN \`knows_relation\` { from: \`actor_from\` { .name } ,to: head([\`person_to\` IN [\`person_to\`] WHERE [label IN labels(\`person_to\`) WHERE label = "User" | TRUE] | \`person_to\` { FRAGMENT_TYPE: "User",  .userId  }])  } AS \`_AddActorKnowsPayload\`;
+    `;
+
+  t.plan(1);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {
+      from: { userId: '123' },
+      to: { userId: '456' },
+      first: -1,
+      offset: 0
+    },
+    expectedCypherQuery,
+    {}
+  );
+});
+
+// FIXME Update we are merging the selection sets of multiple fragments on the same type
+// Currently, such selection sets are not deeply merged. This results in only the first
+// selection set for the 'operators' field being used; the 'userId' field selected for
+// 'operators' from within the NewCameraFragment fragment spread is not used.
+// See: mergeFragmentedSelections in selections.js
+test('query interface using multiple fragments on the same implementing type', t => {
+  const graphQLQuery = `query {
+    Camera {
+      weight
+      ... on NewCamera {
+        id
+        operators {
+          name
+        }
+      }
+      ...NewCameraFragment
+    }
+  }
+  
+  fragment NewCameraFragment on NewCamera {
+    type
+    operators {
+      userId
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`) OR "NewCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "OldCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .weight  }] + [\`camera\` IN [\`camera\`] WHERE [label IN labels(\`camera\`) WHERE label = "NewCamera" | TRUE] | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .name }] , .type , .weight  }]) AS \`camera\``;
+
+  t.plan(3);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      Person_derivedTypes: ['Actor', 'User', 'CameraMan']
+    }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
 });


### PR DESCRIPTION
This PR attempts general support for using inline fragments and fragment spreads when querying interface or object types. 

The translation strategy for interface types is extended to handle the complexity that arises from possibly using combinations of inline or spread fragments when querying an interface. 

For example, consider this reduced version of the types used in the tests added by this PR:
```graphql
interface Camera {
  id: ID!
  type: String
}

type OldCamera implements Camera {
  id: ID!
  type: String
  smell: String
}

type NewCamera implements Camera {
  id: ID!
  type: String
  features: [String]
}
```
A query for an interface type might select only fields on that interface. 
```graphql
query {
  Camera {
    id
    type
  }
}
```
In contrast, it might select only fields on types implementing the interface by using some combination of fragments. 
```graphql
query {
  Camera {
    ... on OldCamera {
      smell
    }
    ...NewCameraFragment
  }
}

fragment NewCameraFragment on NewCamera {
  features
}
```
Perhaps more likely, both fields on the interface type and the types implementing it could be selected.
```graphql
query {
  Camera {
    id
    ... on OldCamera {
      smell
    }
    ...NewCameraFragment
  }
}

fragment NewCameraFragment on NewCamera {
  features
}
```

### Tests
The following 31 translation tests have been added to `test/unit/cypherTest.test.js`:

###### query only an interface field
  ```graphql
  query {
    Camera {
      id
    }
  }
  ```
###### query only interface fields
  ```graphql
  query {
    Camera {
      id
      type
      make
      weight
    }
  }
  ```
###### query only interface fields using untyped inline fragment
  ```graphql
  query {
    Camera {
      id
      type
      ... {
        make
        weight
      }
    }
  }
  ```
###### query only fields on an implementing type using an inline fragment
  ```graphql
  query {
    Camera {
      ... on OldCamera {
        id
        type
      }
    }
  }
  ```
###### query same field on implementing type using inline fragment
  ```graphql
  query {
    Camera {
      id
      ... on OldCamera {
        id
      }
    }
  }
  ```
###### query interface and implementing type using inline fragment
  ```graphql
  query {
    Camera {
      id
      ... on OldCamera {
        id
        type
      }
    }
  }
  ```
###### query interface and implementing type using fragment spread
  ```graphql
  query {
    Camera {
      id
      ...NewCameraFragment
    }
  }
  
  fragment NewCameraFragment on NewCamera {
    id
    type
  }
  ```
###### query interface and implementing types using inline fragment and fragment spread
  ```graphql
  query {
    Camera {
      id
      ...NewCameraFragment
      make
      ... on OldCamera {
        smell
      }
    }
  }
  
  fragment NewCameraFragment on NewCamera {
    id
    type
    features
  }
  ```
###### query interface using multiple fragments on the same implementing type
  ```graphql
  query {
    Camera {
      weight
      ... on NewCamera {
        id
        operators {
          name
        }
      }
      ...NewCameraFragment
    }
  }
  
  fragment NewCameraFragment on NewCamera {
    type
    operators {
      userId
    }
  }
  ```
##### Computed query
  ###### query only computed interface fields
  ```graphql
  query {
    CustomCameras {
      id
      type
      make
      weight
    }
  }
  ```
  ###### query only computed fields on an implementing type using an inline fragment
  ```graphql
  query {
    CustomCameras {
      ... on OldCamera {
        id
        type
      }
    }
  }
  ```
  ###### query computed interface fields using fragments on implementing types
  ```graphql
  query {
    CustomCameras {
      id
      ... on OldCamera {
        type
      }
      ...NewCameraFragment
      __typename
    }
  }
  
  fragment NewCameraFragment on NewCamera {
    type
    weight
  }
  ```
##### Field arguments
  ###### pagination used on root and nested interface type field
  ```graphql
  query {
    Camera(first: 2, offset: 1) {
      id
      type
      make
      weight
      operators(first: 1, offset: 1) {
        name
        ... on CameraMan {
          userId
        }
      }
    }
  }
  ```
  ###### ordering used on root and nested interface type field
  ```graphql
  query {
    Camera(orderBy: type_asc) {
      id
      type
      make
      weight
      operators(orderBy: name_desc) {
        name
        ... on CameraMan {
          userId
        }
      }
    }
  }
  ```
  ###### filtering used on root and nested interface type field with only fragments
  ```graphql
  query {
    Camera(
      filter: {
        operators_not: null
      }
    ) {
      ... on NewCamera {
        operators(
          filter: {
            name_not: null
          }
        ) {
          ... on CameraMan {
            name
          }
        }
      }
    }
  }
  ```
  ###### filtering used on root and nested interface using fragments and query variables
  ```graphql
  query getCameras($type: String, $operatorsFilter: _PersonFilter, $computedOperatorName: String) {
    Camera(type: $type) {
      id
      type
      ... on NewCamera {
        operators(filter: $operatorsFilter) {
          userId
        }
      }
      ... on OldCamera {
        operators(filter: $operatorsFilter) {
          userId
        }
      }
      operators(filter: $operatorsFilter) {
        userId
      }
      computedOperators(name: $computedOperatorName) {
        userId
        name
      }
    }
  }
  ```
##### Computed mutation
  ###### query interface type payload of @cypher mutation field
  ```graphql
  mutation {
    CustomCamera {
      id
      type
    }
  }
  ```
  ###### query interface type list payload of @cypher mutation field using fragments
  ```graphql
  mutation {
    CustomCameras {
      id
      ... on NewCamera {
        features
      }
      ...OldCameraFragment
      ...CameraFragment
    }
  }
  fragment CameraFragment on Camera {
    type
  }
  fragment OldCameraFragment on OldCamera {
    smell
  }
  ```
  ###### query interface type list payload of @cypher mutation field using only fragments
  ```graphql
  mutation {
    CustomCameras {
      ... on NewCamera {
        features
      }
      ...OldCameraFragment
    }
  }
  
  fragment OldCameraFragment on OldCamera {
    smell
  }
  ```
  ###### query interface type relationship field
  ```graphql
  query {
    Camera {
      id
      type
      make
      weight
      operators {
        userId
        name
        __typename
      }
    }
  }
  ```
  ###### query interface type relationship field using only inline fragment
  ```graphql
  query {
    Camera {
      ... on OldCamera {
        id
        type
        operators {
          ... on CameraMan {
            userId
            name
          }
        }
      }
    }
  }
  ```
  ###### query interface type relationship field using inline fragment on implementing type
  ```graphql
  query {
    Camera {
      ... on OldCamera {
        id
        type
        operators {
          userId
          ... on CameraMan {
            name
          }
        }
      }
    }
  }
  ```
  ###### query interface type relationship fields within inline fragment
  ```graphql
  query {
    Camera {
      id
      type
      make
      weight
      ... on OldCamera {
        operators {
          userId
          name
          __typename
        }
      }
    }
  }
  ```
  ###### query interface type relationship field on implementing types using inline fragment and fragment spread
  ```graphql
  query {
    Camera {
      id
      type
      weight
      ... on OldCamera {
        id
        operators {
          userId
          name
        }
      }
      ...NewCameraFragment
    }
  }
  
  fragment NewCameraFragment on NewCamera {
    id
    operators {
      userId
    }
  }
  ```
##### Computed query
  ###### query computed interface type relationship field
  ```graphql
  query {
    CustomCameras {
      id
      type
      make
      weight
      computedOperators {
        userId
        name
        __typename
      }
    }
  }
  ```
  ###### query computed interface type relationship field using only an inline fragment
  ```graphql
  query {
    CustomCameras {
      id
      type
      make
      weight
      computedOperators {
        ... on CameraMan {
          userId
          name
        }
      }
    }
  }
  ```
##### Mutation
  ###### query interfaced relationship mutation payload using fragments
  ```graphql
  mutation someMutation {
    AddActorKnows(from: { userId: "123" }, to: { userId: "456" }) {
      from {
        name
      }
      to {
        name
        ... on User {
          userId
        }
      }
    }
  }
  ```
  ###### query interfaced relationship mutation payload using only fragments
  ```graphql
  mutation someMutation {
    AddActorKnows(from: { userId: "123" }, to: { userId: "456" }) {
      from {
        name
      }
      to {
        ... on User {
          userId
        }
      }
    }
  }
  ```
##### Introspection: __typename field
  ###### query only __typename field on interface type
  ```graphql
  query {
    Camera {
      __typename
    }
  }
  ```
  ###### query only __typename field on interface type relationship field
  ```graphql
  query {
    Camera {
      id
      operators {
        __typename
      }
    }
  }
  ```
  ###### query interface __typename as only field not within fragments on implementing types
  ```graphql
  query {
    Camera {
      __typename
      ... on OldCamera {
        id
        type
        operators {
          __typename
          ... on CameraMan {
            userId
            name
          }
        }
      }
    }
  }
  ```

### Limitations

* Querying interfaced relationship types using fragments are not yet supported
* Nested selection sets on the same relationship field in multiple fragments on an implementing type of an interface are not thoroughly merged. Only the first selection set for a relationship field within a fragment on an implementing type is used. See test: `query interface using multiple fragments on the same implementing type`