### PR TITLE
Allow overriding of graphql-auth-directives 

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -36,14 +36,20 @@ export const addAuthDirectiveImplementations = (
   config
 ) => {
   if (shouldAddAuthDirective(config, 'isAuthenticated')) {
-    schemaDirectives['isAuthenticated'] = IsAuthenticatedDirective;
+    if (!schemaDirectives['isAuthenticated']) {
+      schemaDirectives['isAuthenticated'] = IsAuthenticatedDirective;
+    }
   }
   if (shouldAddAuthDirective(config, 'hasRole')) {
     getRoleType(typeMap); // ensure Role enum specified in typedefs
-    schemaDirectives['hasRole'] = HasRoleDirective;
+    if (!schemaDirectives['hasRole']) {
+      schemaDirectives['hasRole'] = HasRoleDirective;
+    }
   }
   if (shouldAddAuthDirective(config, 'hasScope')) {
-    schemaDirectives['hasScope'] = HasScopeDirective;
+    if (!schemaDirectives['hasScope']) {
+      schemaDirectives['hasScope'] = HasScopeDirective;
+    }
   }
   return schemaDirectives;
 };


### PR DESCRIPTION
Allow overriding of `graphql-auth-directives` whilst leveraging the schema augmentation funcitonality afforded by: `config.auth`.

With this feature, one can create a schema like so: 
```
export const schema = makeAugmentedSchema({
  resolvers,
  typeDefs,
  config: {
    auth: {
      hasScope: true,
    },
  },
  schemaDirectives: {
    hasScope: MyHasScopeDirective,
  },
});
```
This, among other things, allows the separation of the token decoding/authentication logic from the authorisation logic.