### PR TITLE
Change default resolveType to use User defined __resolveType when available

### DIFF
--- a/src/augment/resolvers.js
+++ b/src/augment/resolvers.js
@@ -110,7 +110,7 @@ export const augmentResolvers = ({
     resolvers[e] = {};
 
     resolvers[e]['__resolveType'] = (obj, context, info) => {
-      return obj['FRAGMENT_TYPE'];
+        return obj['__typeName'] ? obj['__typeName'] : obj['FRAGMENT_TYPE'];
     };
   });
 


### PR DESCRIPTION
Fixes: #414 
Aims to let user-defined resolvers for Interfaces and Queries work. 

For example users can define a union like:
```graphql
union SearchItem = Actor | Movie
```
And the resolver for this union:
```javascript
const resolver = {
    SearchItem: {
        __resolveType(obj) => {
            return "TypeName"
        }
    }
}
```
