### PR TITLE
Relationship API bug fixes & updates

### DIFF
--- a/src/augment/ast.js
+++ b/src/augment/ast.js
@@ -209,7 +209,10 @@ export const buildFieldSelection = ({
   args = [],
   directives = [],
   name = {},
-  selectionSet = {}
+  selectionSet = {
+    kind: Kind.SELECTION_SET,
+    selections: []
+  }
 }) => {
   return {
     kind: Kind.FIELD,

--- a/src/augment/fields.js
+++ b/src/augment/fields.js
@@ -251,7 +251,6 @@ export const propertyFieldExists = ({
 }) => {
   const fields = definition.fields || [];
   return fields.find(field => {
-    const fieldName = field.name.value;
     const fieldType = field.type;
     const unwrappedType = unwrapNamedType({ type: fieldType });
     const outputType = unwrappedType.name;

--- a/src/augment/types/node/node.js
+++ b/src/augment/types/node/node.js
@@ -197,12 +197,13 @@ export const augmentNodeTypeFields = ({
   config
 }) => {
   let isIgnoredType = true;
+  let filterTypeName = `_${typeName}Filter`;
+  const fields = definition.fields;
   if (!isUnionType && !isUnionExtension) {
-    const fields = definition.fields;
     if (!isQueryType) {
       if (!nodeInputTypeMap[FilteringArgument.FILTER]) {
         nodeInputTypeMap[FilteringArgument.FILTER] = {
-          name: `_${typeName}Filter`,
+          name: filterTypeName,
           fields: []
         };
       }

--- a/src/augment/types/relationship/relationship.js
+++ b/src/augment/types/relationship/relationship.js
@@ -7,6 +7,7 @@ import {
   toSnakeCase
 } from '../../fields';
 import {
+  OrderingArgument,
   FilteringArgument,
   augmentInputTypePropertyFields
 } from '../../input-values';
@@ -82,6 +83,7 @@ export const augmentRelationshipTypeField = ({
         nodeInputTypeMap
       ] = augmentRelationshipQueryAPI({
         typeName,
+        definition,
         fieldArguments,
         fieldName,
         outputType,
@@ -151,13 +153,19 @@ const augmentRelationshipTypeFields = ({
     name: RelationshipDirectionField.TO
   });
   let relatedTypeFilterName = `_${typeName}${outputType}Filter`;
+  let relatedTypeOrderingName = `_${outputType}Ordering`;
   if (fromTypeName === toTypeName) {
     relatedTypeFilterName = `_${outputType}Filter`;
+    relatedTypeOrderingName = `_${outputType}Ordering`;
   }
   let relationshipInputTypeMap = {
     [FilteringArgument.FILTER]: {
       name: relatedTypeFilterName,
       fields: []
+    },
+    [OrderingArgument.ORDER_BY]: {
+      name: relatedTypeOrderingName,
+      values: []
     }
   };
   const propertyInputValues = [];

--- a/src/augment/types/types.js
+++ b/src/augment/types/types.js
@@ -87,7 +87,6 @@ export const Neo4jDataType = {
     [TemporalType.LOCALDATETIME]: 'Temporal',
     [SpatialType.POINT]: 'Spatial'
   },
-  // TODO probably revise and remove...
   STRUCTURAL: {
     [Kind.OBJECT_TYPE_DEFINITION]: Neo4jStructuralType,
     [Kind.INTERFACE_TYPE_DEFINITION]: Neo4jStructuralType,
@@ -689,9 +688,6 @@ const augmentOperationType = ({
           propertyInputValues,
           config
         });
-        // FIXME fieldArguments are modified through reference so
-        // this branch doesn't end up mattereing. A case of isIgnoredType
-        // being true may also be highly improbable, though it is posisble
         if (!isIgnoredType) {
           extension.fields = propertyOutputFields;
         }

--- a/src/selections.js
+++ b/src/selections.js
@@ -39,6 +39,7 @@ import {
   TypeWrappers,
   Neo4jSystemIDField
 } from './augment/fields';
+import { selectUnselectedOrderedFields } from './augment/input-values';
 
 export function buildCypherSelection({
   initial = '',
@@ -290,13 +291,23 @@ export function buildCypherSelection({
         fieldName,
         parentSelectionInfo
       });
+
       const fieldSelectionSet =
         headSelection && headSelection.selectionSet
           ? headSelection.selectionSet.selections
           : [];
 
+      const orderedFieldSelectionSet = selectUnselectedOrderedFields({
+        selectionFilters,
+        fieldSelectionSet
+      });
+
+      const fieldsForTranslation = orderedFieldSelectionSet.length
+        ? orderedFieldSelectionSet
+        : fieldSelectionSet;
+
       subSelection = recurse({
-        selections: fieldSelectionSet,
+        selections: fieldsForTranslation,
         variableName: nestedVariable,
         paramIndex,
         schemaType: innerSchemaType,
@@ -406,6 +417,7 @@ export function buildCypherSelection({
           initial,
           fieldName,
           fieldType,
+          fieldSelectionSet,
           variableName,
           relDirection,
           relType,
@@ -422,7 +434,7 @@ export function buildCypherSelection({
           filterParams,
           selectionFilters,
           neo4jTypeArgs,
-          selections,
+          fieldsForTranslation,
           schemaType,
           subSelection,
           skipLimit,
@@ -436,6 +448,7 @@ export function buildCypherSelection({
         // (from, to, renamed, relation mutation payloads...)
         [translationConfig, subSelection] = nodeTypeFieldOnRelationType({
           initial,
+          schemaType,
           fieldName,
           fieldType,
           variableName,
@@ -449,6 +462,8 @@ export function buildCypherSelection({
           neo4jTypeArgs,
           schemaTypeRelation,
           innerSchemaType,
+          fieldSelectionSet,
+          fieldsForTranslation,
           schemaTypeFields,
           derivedTypeMap,
           isObjectTypeField,
@@ -469,12 +484,14 @@ export function buildCypherSelection({
           innerSchemaTypeRelation,
           initial,
           fieldName,
+          fieldSelectionSet,
           subSelection,
           skipLimit,
           commaIfTail,
           tailParams,
           fieldType,
           variableName,
+          fieldsForTranslation,
           schemaType,
           innerSchemaType,
           nestedVariable,

--- a/test/helpers/cypherTestHelpers.js
+++ b/test/helpers/cypherTestHelpers.js
@@ -165,8 +165,10 @@ export function augmentedSchemaCypherTestRunner(
 
   const resolvers = {
     QueryA: {
+      Person: checkCypherQuery,
       Actor: checkCypherQuery,
       User: checkCypherQuery,
+      Genre: checkCypherQuery,
       Movie: checkCypherQuery,
       MoviesByYear: checkCypherQuery,
       MoviesByYears: checkCypherQuery,
@@ -188,6 +190,7 @@ export function augmentedSchemaCypherTestRunner(
       State: checkCypherQuery,
       CasedType: checkCypherQuery,
       Camera: checkCypherQuery,
+      NewCamera: checkCypherQuery,
       CustomCameras: checkCypherQuery,
       CustomCamera: checkCypherQuery,
       computedBoolean: checkCypherQuery,
@@ -240,7 +243,12 @@ export function augmentedSchemaCypherTestRunner(
       CustomCamera: checkCypherMutation,
       CustomCameras: checkCypherMutation,
       CreateNewCamera: checkCypherMutation,
-      computedMovieSearch: checkCypherMutation
+      computedMovieSearch: checkCypherMutation,
+      AddActorInterfacedRelationshipType: checkCypherMutation,
+      RemoveActorInterfacedRelationshipType: checkCypherMutation,
+      MergeActorInterfacedRelationshipType: checkCypherMutation,
+      UpdateActorInterfacedRelationshipType: checkCypherMutation,
+      MergeGenreInterfacedRelationshipType: checkCypherMutation
     }
   };
 

--- a/test/helpers/tck/parser.js
+++ b/test/helpers/tck/parser.js
@@ -82,7 +82,6 @@ const extractTestBlocks = data => {
 const buildTestDeclarations = (tck, extractionLimit) => {
   const schema = makeTestDataSchema(tck);
   const testData = buildTestData(schema, tck);
-  //! refactor to involve forEach and a counter that is compared against extractionLimit
   return testData
     .reduce((acc, test) => {
       // escape " so that we can wrap the cypher in "s

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -81,6 +81,7 @@ export const testSchema = `
       @cypher(
         statement: "MATCH (m:Movie)-[:IN_GENRE]->(this) RETURN m ORDER BY m.imdbRating DESC LIMIT 1"
       )
+    interfacedRelationshipType: [InterfacedRelationshipType]
   }
 
   type State {
@@ -91,6 +92,21 @@ export const testSchema = `
   interface Person {
     userId: ID!
     name: String
+    interfacedRelationshipType: [InterfacedRelationshipType]
+    reflexiveInterfacedRelationshipType: [ReflexiveInterfacedRelationshipType]    
+  }
+
+  type ReflexiveInterfacedRelationshipType @relation(name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE") {
+    from: Person!
+    boolean: Boolean
+    to: Person!
+  }
+
+  type InterfacedRelationshipType @relation(name: "INTERFACED_RELATIONSHIP_TYPE") {
+    from: Person!
+    string: String!
+    boolean: Boolean
+    to: Genre!
   }
 
   extend interface Person {
@@ -127,6 +143,104 @@ export const testSchema = `
     name_not_starts_with: String
     name_ends_with: String
     name_not_ends_with: String
+    interfacedRelationshipType: _PersonInterfacedRelationshipTypeFilter
+    interfacedRelationshipType_not: _PersonInterfacedRelationshipTypeFilter
+    interfacedRelationshipType_in: [_PersonInterfacedRelationshipTypeFilter!]
+    interfacedRelationshipType_not_in: [_PersonInterfacedRelationshipTypeFilter!]
+    interfacedRelationshipType_some: _PersonInterfacedRelationshipTypeFilter
+    interfacedRelationshipType_none: _PersonInterfacedRelationshipTypeFilter
+    interfacedRelationshipType_single: _PersonInterfacedRelationshipTypeFilter
+    interfacedRelationshipType_every: _PersonInterfacedRelationshipTypeFilter
+    reflexiveInterfacedRelationshipType: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+    reflexiveInterfacedRelationshipType_not: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+    reflexiveInterfacedRelationshipType_in: [_ReflexiveInterfacedRelationshipTypeDirectionsFilter!]
+    reflexiveInterfacedRelationshipType_not_in: [_ReflexiveInterfacedRelationshipTypeDirectionsFilter!]
+    reflexiveInterfacedRelationshipType_some: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+    reflexiveInterfacedRelationshipType_none: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+    reflexiveInterfacedRelationshipType_single: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+    reflexiveInterfacedRelationshipType_every: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+    extensionScalar: String
+    extensionScalar_not: String
+    extensionScalar_in: [String!]
+    extensionScalar_not_in: [String!]
+    extensionScalar_contains: String
+    extensionScalar_not_contains: String
+    extensionScalar_starts_with: String
+    extensionScalar_not_starts_with: String
+    extensionScalar_ends_with: String
+    extensionScalar_not_ends_with: String
+  }
+  
+  input _PersonInterfacedRelationshipTypeFilter {
+    AND: [_PersonInterfacedRelationshipTypeFilter!]
+    OR: [_PersonInterfacedRelationshipTypeFilter!]
+    string: String
+    string_not: String
+    string_in: [String!]
+    string_not_in: [String!]
+    string_contains: String
+    string_not_contains: String
+    string_starts_with: String
+    string_not_starts_with: String
+    string_ends_with: String
+    string_not_ends_with: String
+    boolean: Boolean
+    boolean_not: Boolean
+    Genre: _GenreFilter
+  }
+  
+  input _GenreFilter {
+    AND: [_GenreFilter!]
+    OR: [_GenreFilter!]
+    name: String
+    name_not: String
+    name_in: [String!]
+    name_not_in: [String!]
+    name_contains: String
+    name_not_contains: String
+    name_starts_with: String
+    name_not_starts_with: String
+    name_ends_with: String
+    name_not_ends_with: String
+    interfacedRelationshipType: _GenreInterfacedRelationshipTypeFilter
+    interfacedRelationshipType_not: _GenreInterfacedRelationshipTypeFilter
+    interfacedRelationshipType_in: [_GenreInterfacedRelationshipTypeFilter!]
+    interfacedRelationshipType_not_in: [_GenreInterfacedRelationshipTypeFilter!]
+    interfacedRelationshipType_some: _GenreInterfacedRelationshipTypeFilter
+    interfacedRelationshipType_none: _GenreInterfacedRelationshipTypeFilter
+    interfacedRelationshipType_single: _GenreInterfacedRelationshipTypeFilter
+    interfacedRelationshipType_every: _GenreInterfacedRelationshipTypeFilter
+  }
+
+  input _GenreInterfacedRelationshipTypeFilter {
+    AND: [_GenreInterfacedRelationshipTypeFilter!]
+    OR: [_GenreInterfacedRelationshipTypeFilter!]
+    string: String
+    string_not: String
+    string_in: [String!]
+    string_not_in: [String!]
+    string_contains: String
+    string_not_contains: String
+    string_starts_with: String
+    string_not_starts_with: String
+    string_ends_with: String
+    string_not_ends_with: String
+    boolean: Boolean
+    boolean_not: Boolean
+    Person: _PersonFilter
+  }
+  
+  input _ReflexiveInterfacedRelationshipTypeDirectionsFilter {
+    from: _ReflexiveInterfacedRelationshipTypeFilter
+    to: _ReflexiveInterfacedRelationshipTypeFilter
+  }
+  
+  input _ReflexiveInterfacedRelationshipTypeFilter {
+    AND: [_ReflexiveInterfacedRelationshipTypeFilter!]
+    OR: [_ReflexiveInterfacedRelationshipTypeFilter!]
+    boolean: Boolean
+    boolean_not: Boolean
+    Person: _PersonFilter
   }
 
   type Actor {
@@ -135,6 +249,8 @@ export const testSchema = `
     movies: [Movie] @relation(name: "ACTED_IN", direction: "OUT")
     knows: [Person] @relation(name: "KNOWS", direction: "OUT")
     extensionScalar: String
+    interfacedRelationshipType: [InterfacedRelationshipType]
+    reflexiveInterfacedRelationshipType: [ReflexiveInterfacedRelationshipType]    
   }
 
   extend type Actor implements Person
@@ -142,6 +258,8 @@ export const testSchema = `
   type User implements Person {
     userId: ID!
     name: String
+    interfacedRelationshipType: [InterfacedRelationshipType]
+    reflexiveInterfacedRelationshipType: [ReflexiveInterfacedRelationshipType]
     currentUserId(strArg: String = "Neo4j", strInputArg: strInput): String
       @cypher(
         statement: "RETURN $cypherParams.currentUserId AS cypherParamsUserId"
@@ -459,6 +577,7 @@ export const testSchema = `
     ): [Person] @relation(name: "cameras", direction: IN)
     computedOperators(name: String): [Person]
       @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
+    reflexiveInterfaceRelationship: [Camera] @relation(name: "REFLEXIVE_INTERFACE_RELATIONSHIP", direction: OUT)
   }
 
   enum _CameraOrdering {
@@ -486,6 +605,7 @@ export const testSchema = `
     ): [Person] @relation(name: "cameras", direction: IN)
     computedOperators(name: String): [Person]
       @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
+    reflexiveInterfaceRelationship: [Camera] @relation(name: "REFLEXIVE_INTERFACE_RELATIONSHIP", direction: OUT)
   }
 
   type NewCamera implements Camera {
@@ -502,6 +622,7 @@ export const testSchema = `
     ): [Person] @relation(name: "cameras", direction: IN)
     computedOperators(name: String): [Person]
       @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
+    reflexiveInterfaceRelationship: [Camera] @relation(name: "REFLEXIVE_INTERFACE_RELATIONSHIP", direction: OUT)      
   }
 
   union MovieSearch = Movie | Genre | Book
@@ -519,6 +640,8 @@ export const testSchema = `
     cameras: [Camera!]! @relation(name: "cameras", direction: "OUT")
     cameraBuddy: Person @relation(name: "cameraBuddy", direction: "OUT")
     extensionScalar: String
+    interfacedRelationshipType: [InterfacedRelationshipType]
+    reflexiveInterfacedRelationshipType: [ReflexiveInterfacedRelationshipType]
   }
 
   type SubscriptionC {

--- a/test/unit/augmentSchemaTest.test.js
+++ b/test/unit/augmentSchemaTest.test.js
@@ -464,14 +464,83 @@ test.cb('Test augmented schema', t => {
       name_not_starts_with: String
       name_ends_with: String
       name_not_ends_with: String
-      movies: _MovieFilter
-      movies_not: _MovieFilter
-      movies_in: [_MovieFilter!]
-      movies_not_in: [_MovieFilter!]
-      movies_some: _MovieFilter
-      movies_none: _MovieFilter
-      movies_single: _MovieFilter
-      movies_every: _MovieFilter
+      interfacedRelationshipType: _GenreInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_not: _GenreInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_in: [_GenreInterfacedRelationshipTypeFilter!]
+      interfacedRelationshipType_not_in: [_GenreInterfacedRelationshipTypeFilter!]
+      interfacedRelationshipType_some: _GenreInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_none: _GenreInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_single: _GenreInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_every: _GenreInterfacedRelationshipTypeFilter
+    }
+
+    input _GenreInterfacedRelationshipTypeFilter {
+      AND: [_GenreInterfacedRelationshipTypeFilter!]
+      OR: [_GenreInterfacedRelationshipTypeFilter!]
+      string: String
+      string_not: String
+      string_in: [String!]
+      string_not_in: [String!]
+      string_contains: String
+      string_not_contains: String
+      string_starts_with: String
+      string_not_starts_with: String
+      string_ends_with: String
+      string_not_ends_with: String
+      boolean: Boolean
+      boolean_not: Boolean
+      Person: _PersonFilter
+    }
+
+    input _InterfacedRelationshipTypeInput {
+      string: String!
+      boolean: Boolean
+    }
+
+    type _AddGenreInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _RemoveGenreInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+    }
+
+    type _UpdateGenreInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _MergeGenreInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
     }
 
     input _ActorFilter {
@@ -523,6 +592,22 @@ test.cb('Test augmented schema', t => {
       extensionScalar_not_starts_with: String
       extensionScalar_ends_with: String
       extensionScalar_not_ends_with: String
+      interfacedRelationshipType: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_not: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_in: [_PersonInterfacedRelationshipTypeFilter!]
+      interfacedRelationshipType_not_in: [_PersonInterfacedRelationshipTypeFilter!]
+      interfacedRelationshipType_some: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_none: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_single: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_every: _PersonInterfacedRelationshipTypeFilter
+      reflexiveInterfacedRelationshipType: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_not: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_in: [_ReflexiveInterfacedRelationshipTypeDirectionsFilter!]
+      reflexiveInterfacedRelationshipType_not_in: [_ReflexiveInterfacedRelationshipTypeDirectionsFilter!]
+      reflexiveInterfacedRelationshipType_some: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_none: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_single: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_every: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
     }
 
     input _StateFilter {
@@ -601,6 +686,23 @@ test.cb('Test augmented schema', t => {
       User: _UserFilter
     }
 
+    enum _MovieRatedOrdering {
+      currentUserId_asc
+      currentUserId_desc
+      rating_asc
+      rating_desc
+      time_asc
+      time_desc
+      date_asc
+      date_desc
+      datetime_asc
+      datetime_desc
+      localtime_asc
+      localtime_desc
+      localdatetime_asc
+      localdatetime_desc
+    }
+
     input _Neo4jTimeInput {
       hour: Int
       minute: Int
@@ -665,6 +767,22 @@ test.cb('Test augmented schema', t => {
       name_not_starts_with: String
       name_ends_with: String
       name_not_ends_with: String
+      interfacedRelationshipType: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_not: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_in: [_PersonInterfacedRelationshipTypeFilter!]
+      interfacedRelationshipType_not_in: [_PersonInterfacedRelationshipTypeFilter!]
+      interfacedRelationshipType_some: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_none: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_single: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_every: _PersonInterfacedRelationshipTypeFilter
+      reflexiveInterfacedRelationshipType: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_not: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_in: [_ReflexiveInterfacedRelationshipTypeDirectionsFilter!]
+      reflexiveInterfacedRelationshipType_not_in: [_ReflexiveInterfacedRelationshipTypeDirectionsFilter!]
+      reflexiveInterfacedRelationshipType_some: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_none: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_single: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_every: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
       rated: _UserRatedFilter
       rated_not: _UserRatedFilter
       rated_in: [_UserRatedFilter!]
@@ -900,6 +1018,9 @@ test.cb('Test augmented schema', t => {
         localtime: _Neo4jLocalTimeInput
         localdatetime: _Neo4jLocalDateTimeInput
         location: _Neo4jPointInput
+        first: Int
+        offset: Int
+        orderBy: [_RatedOrdering]
         filter: _MovieRatedFilter
       ): [_MovieRatings]
       years: [Int]
@@ -965,6 +1086,48 @@ test.cb('Test augmented schema', t => {
         @cypher(
           statement: "MATCH (m:Movie)-[:IN_GENRE]->(this) RETURN m ORDER BY m.imdbRating DESC LIMIT 1"
         )
+      interfacedRelationshipType(
+        first: Int
+        offset: Int
+        orderBy: [_InterfacedRelationshipTypeOrdering]
+        filter: _GenreInterfacedRelationshipTypeFilter
+      ): [_GenreInterfacedRelationshipType]
+    }
+
+    type _GenreInterfacedRelationshipType
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      string: String!
+      boolean: Boolean
+      Person: Person
+    }
+
+    enum _InterfacedRelationshipTypeOrdering {
+      string_asc
+      string_desc
+      boolean_asc
+      boolean_desc
+    }
+
+    input _GenreInterfacedRelationshipTypeFilter {
+      AND: [_GenreInterfacedRelationshipTypeFilter!]
+      OR: [_GenreInterfacedRelationshipTypeFilter!]
+      string: String
+      string_not: String
+      string_in: [String!]
+      string_not_in: [String!]
+      string_contains: String
+      string_not_contains: String
+      string_starts_with: String
+      string_not_starts_with: String
+      string_ends_with: String
+      string_not_ends_with: String
+      boolean: Boolean
+      boolean_not: Boolean
+      Person: _PersonFilter
     }
 
     enum _ActorOrdering {
@@ -994,6 +1157,13 @@ test.cb('Test augmented schema', t => {
         filter: _PersonFilter
       ): [Person] @relation(name: "KNOWS", direction: "OUT")
       extensionScalar: String
+      interfacedRelationshipType(
+        first: Int
+        offset: Int
+        orderBy: [_InterfacedRelationshipTypeOrdering]
+        filter: _PersonInterfacedRelationshipTypeFilter
+      ): [_PersonInterfacedRelationshipType]
+      reflexiveInterfacedRelationshipType: _PersonReflexiveInterfacedRelationshipTypeDirections
       _id: String
     }
 
@@ -1002,6 +1172,28 @@ test.cb('Test augmented schema', t => {
     interface Person {
       userId: ID!
       name: String
+      interfacedRelationshipType(
+        first: Int
+        offset: Int
+        orderBy: [_InterfacedRelationshipTypeOrdering]
+        filter: _PersonInterfacedRelationshipTypeFilter
+      ): [_PersonInterfacedRelationshipType]
+      reflexiveInterfacedRelationshipType: _PersonReflexiveInterfacedRelationshipTypeDirections
+    }
+
+    type ReflexiveInterfacedRelationshipType
+      @relation(name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE") {
+      from: Person!
+      boolean: Boolean
+      to: Person!
+    }
+
+    type InterfacedRelationshipType
+      @relation(name: "INTERFACED_RELATIONSHIP_TYPE") {
+      from: Person!
+      string: String!
+      boolean: Boolean
+      to: Genre!
     }
 
     extend interface Person {
@@ -1012,6 +1204,35 @@ test.cb('Test augmented schema', t => {
       customField: String @neo4j_ignore
       name: String!
       _id: String
+    }
+
+    type _PersonInterfacedRelationshipType
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      string: String!
+      boolean: Boolean
+      Genre: Genre
+    }
+
+    input _PersonInterfacedRelationshipTypeFilter {
+      AND: [_PersonInterfacedRelationshipTypeFilter!]
+      OR: [_PersonInterfacedRelationshipTypeFilter!]
+      string: String
+      string_not: String
+      string_in: [String!]
+      string_not_in: [String!]
+      string_contains: String
+      string_not_contains: String
+      string_starts_with: String
+      string_not_starts_with: String
+      string_ends_with: String
+      string_not_ends_with: String
+      boolean: Boolean
+      boolean_not: Boolean
+      Genre: _GenreFilter
     }
 
     type _MovieRatings @relation(name: "RATED", from: "User", to: "Movie") {
@@ -1075,6 +1296,13 @@ test.cb('Test augmented schema', t => {
     type User implements Person {
       userId: ID!
       name: String
+      interfacedRelationshipType(
+        first: Int
+        offset: Int
+        orderBy: [_InterfacedRelationshipTypeOrdering]
+        filter: _PersonInterfacedRelationshipTypeFilter
+      ): [_PersonInterfacedRelationshipType]
+      reflexiveInterfacedRelationshipType: _PersonReflexiveInterfacedRelationshipTypeDirections
       currentUserId(strArg: String = "Neo4j", strInputArg: strInput): String
         @cypher(
           statement: "RETURN $cypherParams.currentUserId AS cypherParamsUserId"
@@ -1087,6 +1315,9 @@ test.cb('Test augmented schema', t => {
         localtime: _Neo4jLocalTimeInput
         localdatetime: _Neo4jLocalDateTimeInput
         location: _Neo4jPointInput
+        first: Int
+        offset: Int
+        orderBy: [_RatedOrdering]
         filter: _UserRatedFilter
       ): [_UserRated]
       friends: _UserFriendsDirections
@@ -1109,6 +1340,95 @@ test.cb('Test augmented schema', t => {
 
     extend input strInput {
       extensionArg: String
+    }
+
+    type _AddUserInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _RemoveUserInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+    }
+
+    type _UpdateUserInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _MergeUserInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _AddUserReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+      boolean: Boolean
+    }
+
+    type _RemoveUserReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+    }
+
+    type _UpdateUserReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+      boolean: Boolean
+    }
+
+    type _MergeUserReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+      boolean: Boolean
     }
 
     type _UserRated @relation(name: "RATED", from: "User", to: "Movie") {
@@ -1138,6 +1458,9 @@ test.cb('Test augmented schema', t => {
         localtime: _Neo4jLocalTimeInput
         localdatetime: _Neo4jLocalDateTimeInput
         location: _Neo4jPointInput
+        first: Int
+        offset: Int
+        orderBy: [_FriendOfOrdering]
         filter: _FriendOfFilter
       ): [_UserFriends]
       to(
@@ -1148,6 +1471,9 @@ test.cb('Test augmented schema', t => {
         localtime: _Neo4jLocalTimeInput
         localdatetime: _Neo4jLocalDateTimeInput
         location: _Neo4jPointInput
+        first: Int
+        offset: Int
+        orderBy: [_FriendOfOrdering]
         filter: _FriendOfFilter
       ): [_UserFriends]
     }
@@ -1299,6 +1625,32 @@ test.cb('Test augmented schema', t => {
       name_not_starts_with: String
       name_ends_with: String
       name_not_ends_with: String
+      interfacedRelationshipType: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_not: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_in: [_PersonInterfacedRelationshipTypeFilter!]
+      interfacedRelationshipType_not_in: [_PersonInterfacedRelationshipTypeFilter!]
+      interfacedRelationshipType_some: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_none: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_single: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_every: _PersonInterfacedRelationshipTypeFilter
+      reflexiveInterfacedRelationshipType: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_not: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_in: [_ReflexiveInterfacedRelationshipTypeDirectionsFilter!]
+      reflexiveInterfacedRelationshipType_not_in: [_ReflexiveInterfacedRelationshipTypeDirectionsFilter!]
+      reflexiveInterfacedRelationshipType_some: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_none: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_single: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_every: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      extensionScalar: String
+      extensionScalar_not: String
+      extensionScalar_in: [String!]
+      extensionScalar_not_in: [String!]
+      extensionScalar_contains: String
+      extensionScalar_not_contains: String
+      extensionScalar_starts_with: String
+      extensionScalar_not_starts_with: String
+      extensionScalar_ends_with: String
+      extensionScalar_not_ends_with: String
     }
 
     enum _TemporalNodeOrdering {
@@ -1507,6 +1859,13 @@ test.cb('Test augmented schema', t => {
         orderBy: [_PersonOrdering]
       ): [Person]
         @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
+      reflexiveInterfaceRelationship(
+        first: Int
+        offset: Int
+        orderBy: [_CameraOrdering]
+        filter: _CameraFilter
+      ): [Camera]
+        @relation(name: "REFLEXIVE_INTERFACE_RELATIONSHIP", direction: OUT)
     }
 
     enum _OldCameraOrdering {
@@ -1583,6 +1942,14 @@ test.cb('Test augmented schema', t => {
       operators_none: _PersonFilter
       operators_single: _PersonFilter
       operators_every: _PersonFilter
+      reflexiveInterfaceRelationship: _CameraFilter
+      reflexiveInterfaceRelationship_not: _CameraFilter
+      reflexiveInterfaceRelationship_in: [_CameraFilter!]
+      reflexiveInterfaceRelationship_not_in: [_CameraFilter!]
+      reflexiveInterfaceRelationship_some: _CameraFilter
+      reflexiveInterfaceRelationship_none: _CameraFilter
+      reflexiveInterfaceRelationship_single: _CameraFilter
+      reflexiveInterfaceRelationship_every: _CameraFilter
     }
 
     type OldCamera implements Camera {
@@ -1604,6 +1971,13 @@ test.cb('Test augmented schema', t => {
         orderBy: [_PersonOrdering]
       ): [Person]
         @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
+      reflexiveInterfaceRelationship(
+        first: Int
+        offset: Int
+        orderBy: [_CameraOrdering]
+        filter: _CameraFilter
+      ): [Camera]
+        @relation(name: "REFLEXIVE_INTERFACE_RELATIONSHIP", direction: OUT)
       _id: String
     }
 
@@ -1669,6 +2043,14 @@ test.cb('Test augmented schema', t => {
       operators_none: _PersonFilter
       operators_single: _PersonFilter
       operators_every: _PersonFilter
+      reflexiveInterfaceRelationship: _CameraFilter
+      reflexiveInterfaceRelationship_not: _CameraFilter
+      reflexiveInterfaceRelationship_in: [_CameraFilter!]
+      reflexiveInterfaceRelationship_not_in: [_CameraFilter!]
+      reflexiveInterfaceRelationship_some: _CameraFilter
+      reflexiveInterfaceRelationship_none: _CameraFilter
+      reflexiveInterfaceRelationship_single: _CameraFilter
+      reflexiveInterfaceRelationship_every: _CameraFilter
     }
 
     type NewCamera implements Camera {
@@ -1690,6 +2072,13 @@ test.cb('Test augmented schema', t => {
         orderBy: [_PersonOrdering]
       ): [Person]
         @cypher(statement: "MATCH (this)<-[:cameras]-(p:Person) RETURN p")
+      reflexiveInterfaceRelationship(
+        first: Int
+        offset: Int
+        orderBy: [_CameraOrdering]
+        filter: _CameraFilter
+      ): [Camera]
+        @relation(name: "REFLEXIVE_INTERFACE_RELATIONSHIP", direction: OUT)
       _id: String
     }
 
@@ -1753,6 +2142,22 @@ test.cb('Test augmented schema', t => {
       extensionScalar_not_starts_with: String
       extensionScalar_ends_with: String
       extensionScalar_not_ends_with: String
+      interfacedRelationshipType: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_not: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_in: [_PersonInterfacedRelationshipTypeFilter!]
+      interfacedRelationshipType_not_in: [_PersonInterfacedRelationshipTypeFilter!]
+      interfacedRelationshipType_some: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_none: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_single: _PersonInterfacedRelationshipTypeFilter
+      interfacedRelationshipType_every: _PersonInterfacedRelationshipTypeFilter
+      reflexiveInterfacedRelationshipType: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_not: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_in: [_ReflexiveInterfacedRelationshipTypeDirectionsFilter!]
+      reflexiveInterfacedRelationshipType_not_in: [_ReflexiveInterfacedRelationshipTypeDirectionsFilter!]
+      reflexiveInterfacedRelationshipType_some: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_none: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_single: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
+      reflexiveInterfacedRelationshipType_every: _ReflexiveInterfacedRelationshipTypeDirectionsFilter
     }
 
     union MovieSearch = Movie | Genre | Book
@@ -1781,6 +2186,13 @@ test.cb('Test augmented schema', t => {
       cameraBuddy(filter: _PersonFilter): Person
         @relation(name: "cameraBuddy", direction: "OUT")
       extensionScalar: String
+      interfacedRelationshipType(
+        first: Int
+        offset: Int
+        orderBy: [_InterfacedRelationshipTypeOrdering]
+        filter: _PersonInterfacedRelationshipTypeFilter
+      ): [_PersonInterfacedRelationshipType]
+      reflexiveInterfacedRelationshipType: _PersonReflexiveInterfacedRelationshipTypeDirections
       _id: String
     }
 
@@ -2008,10 +2420,139 @@ test.cb('Test augmented schema', t => {
       ): _MergeGenreMoviesPayload
         @MutationMeta(relationship: "IN_GENRE", from: "Movie", to: "Genre")
         @hasScope(scopes: ["Movie: Merge", "Genre: Merge"])
+      AddGenreInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _AddGenreInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Create", "Genre: Create"])
+      RemoveGenreInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+      ): _RemoveGenreInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Delete", "Genre: Delete"])
+      UpdateGenreInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _UpdateGenreInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Update", "Genre: Update"])
+      MergeGenreInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _MergeGenreInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Merge", "Genre: Merge"])
       CreateGenre(name: String): Genre @hasScope(scopes: ["Genre: Create"])
       DeleteGenre(name: String!): Genre @hasScope(scopes: ["Genre: Delete"])
       CreateState(name: String!): State @hasScope(scopes: ["State: Create"])
       DeleteState(name: String!): State @hasScope(scopes: ["State: Delete"])
+      AddPersonInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _AddPersonInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Create", "Genre: Create"])
+      RemovePersonInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+      ): _RemovePersonInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Delete", "Genre: Delete"])
+      UpdatePersonInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _UpdatePersonInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Update", "Genre: Update"])
+      MergePersonInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _MergePersonInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Merge", "Genre: Merge"])
+      AddPersonReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+        data: _ReflexiveInterfacedRelationshipTypeInput!
+      ): _AddPersonReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Create", "Person: Create"])
+      RemovePersonReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+      ): _RemovePersonReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Delete", "Person: Delete"])
+      UpdatePersonReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+        data: _ReflexiveInterfacedRelationshipTypeInput!
+      ): _UpdatePersonReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Update", "Person: Update"])
+      MergePersonReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+        data: _ReflexiveInterfacedRelationshipTypeInput!
+      ): _MergePersonReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Merge", "Person: Merge"])
       AddActorMovies(
         from: _ActorInput!
         to: _MovieInput!
@@ -2048,6 +2589,92 @@ test.cb('Test augmented schema', t => {
       ): _MergeActorKnowsPayload
         @MutationMeta(relationship: "KNOWS", from: "Actor", to: "Person")
         @hasScope(scopes: ["Actor: Merge", "Person: Merge"])
+      AddActorInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _AddActorInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Create", "Genre: Create"])
+      RemoveActorInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+      ): _RemoveActorInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Delete", "Genre: Delete"])
+      UpdateActorInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _UpdateActorInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Update", "Genre: Update"])
+      MergeActorInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _MergeActorInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Merge", "Genre: Merge"])
+      AddActorReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+        data: _ReflexiveInterfacedRelationshipTypeInput!
+      ): _AddActorReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Create", "Person: Create"])
+      RemoveActorReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+      ): _RemoveActorReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Delete", "Person: Delete"])
+      UpdateActorReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+        data: _ReflexiveInterfacedRelationshipTypeInput!
+      ): _UpdateActorReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Update", "Person: Update"])
+      MergeActorReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+        data: _ReflexiveInterfacedRelationshipTypeInput!
+      ): _MergeActorReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Merge", "Person: Merge"])
       CreateActor(userId: ID, name: String, extensionScalar: String): Actor
         @hasScope(scopes: ["Actor: Create"])
       UpdateActor(userId: ID!, name: String, extensionScalar: String): Actor
@@ -2055,6 +2682,92 @@ test.cb('Test augmented schema', t => {
       DeleteActor(userId: ID!): Actor @hasScope(scopes: ["Actor: Delete"])
       MergeActor(userId: ID!, name: String, extensionScalar: String): Actor
         @hasScope(scopes: ["Actor: Merge"])
+      AddUserInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _AddUserInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Create", "Genre: Create"])
+      RemoveUserInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+      ): _RemoveUserInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Delete", "Genre: Delete"])
+      UpdateUserInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _UpdateUserInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Update", "Genre: Update"])
+      MergeUserInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _MergeUserInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Merge", "Genre: Merge"])
+      AddUserReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+        data: _ReflexiveInterfacedRelationshipTypeInput!
+      ): _AddUserReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Create", "Person: Create"])
+      RemoveUserReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+      ): _RemoveUserReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Delete", "Person: Delete"])
+      UpdateUserReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+        data: _ReflexiveInterfacedRelationshipTypeInput!
+      ): _UpdateUserReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Update", "Person: Update"])
+      MergeUserReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+        data: _ReflexiveInterfacedRelationshipTypeInput!
+      ): _MergeUserReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Merge", "Person: Merge"])
       AddUserRated(
         from: _UserInput!
         to: _MovieInput!
@@ -2277,6 +2990,36 @@ test.cb('Test augmented schema', t => {
       ): _MergeCameraOperatorsPayload
         @MutationMeta(relationship: "cameras", from: "Person", to: "Camera")
         @hasScope(scopes: ["Person: Merge", "Camera: Merge"])
+      AddCameraReflexiveInterfaceRelationship(
+        from: _CameraInput!
+        to: _CameraInput!
+      ): _AddCameraReflexiveInterfaceRelationshipPayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+          from: "Camera"
+          to: "Camera"
+        )
+        @hasScope(scopes: ["Camera: Create", "Camera: Create"])
+      RemoveCameraReflexiveInterfaceRelationship(
+        from: _CameraInput!
+        to: _CameraInput!
+      ): _RemoveCameraReflexiveInterfaceRelationshipPayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+          from: "Camera"
+          to: "Camera"
+        )
+        @hasScope(scopes: ["Camera: Delete", "Camera: Delete"])
+      MergeCameraReflexiveInterfaceRelationship(
+        from: _CameraInput!
+        to: _CameraInput!
+      ): _MergeCameraReflexiveInterfaceRelationshipPayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+          from: "Camera"
+          to: "Camera"
+        )
+        @hasScope(scopes: ["Camera: Merge", "Camera: Merge"])
       AddOldCameraOperators(
         from: _PersonInput!
         to: _OldCameraInput!
@@ -2295,6 +3038,36 @@ test.cb('Test augmented schema', t => {
       ): _MergeOldCameraOperatorsPayload
         @MutationMeta(relationship: "cameras", from: "Person", to: "OldCamera")
         @hasScope(scopes: ["Person: Merge", "OldCamera: Merge"])
+      AddOldCameraReflexiveInterfaceRelationship(
+        from: _OldCameraInput!
+        to: _CameraInput!
+      ): _AddOldCameraReflexiveInterfaceRelationshipPayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+          from: "OldCamera"
+          to: "Camera"
+        )
+        @hasScope(scopes: ["OldCamera: Create", "Camera: Create"])
+      RemoveOldCameraReflexiveInterfaceRelationship(
+        from: _OldCameraInput!
+        to: _CameraInput!
+      ): _RemoveOldCameraReflexiveInterfaceRelationshipPayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+          from: "OldCamera"
+          to: "Camera"
+        )
+        @hasScope(scopes: ["OldCamera: Delete", "Camera: Delete"])
+      MergeOldCameraReflexiveInterfaceRelationship(
+        from: _OldCameraInput!
+        to: _CameraInput!
+      ): _MergeOldCameraReflexiveInterfaceRelationshipPayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+          from: "OldCamera"
+          to: "Camera"
+        )
+        @hasScope(scopes: ["OldCamera: Merge", "Camera: Merge"])
       CreateOldCamera(
         id: ID
         type: String
@@ -2336,6 +3109,36 @@ test.cb('Test augmented schema', t => {
       ): _MergeNewCameraOperatorsPayload
         @MutationMeta(relationship: "cameras", from: "Person", to: "NewCamera")
         @hasScope(scopes: ["Person: Merge", "NewCamera: Merge"])
+      AddNewCameraReflexiveInterfaceRelationship(
+        from: _NewCameraInput!
+        to: _CameraInput!
+      ): _AddNewCameraReflexiveInterfaceRelationshipPayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+          from: "NewCamera"
+          to: "Camera"
+        )
+        @hasScope(scopes: ["NewCamera: Create", "Camera: Create"])
+      RemoveNewCameraReflexiveInterfaceRelationship(
+        from: _NewCameraInput!
+        to: _CameraInput!
+      ): _RemoveNewCameraReflexiveInterfaceRelationshipPayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+          from: "NewCamera"
+          to: "Camera"
+        )
+        @hasScope(scopes: ["NewCamera: Delete", "Camera: Delete"])
+      MergeNewCameraReflexiveInterfaceRelationship(
+        from: _NewCameraInput!
+        to: _CameraInput!
+      ): _MergeNewCameraReflexiveInterfaceRelationshipPayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+          from: "NewCamera"
+          to: "Camera"
+        )
+        @hasScope(scopes: ["NewCamera: Merge", "Camera: Merge"])
       CreateNewCamera(
         id: ID
         type: String
@@ -2437,6 +3240,92 @@ test.cb('Test augmented schema', t => {
           to: "Person"
         )
         @hasScope(scopes: ["CameraMan: Merge", "Person: Merge"])
+      AddCameraManInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _AddCameraManInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Create", "Genre: Create"])
+      RemoveCameraManInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+      ): _RemoveCameraManInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Delete", "Genre: Delete"])
+      UpdateCameraManInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _UpdateCameraManInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Update", "Genre: Update"])
+      MergeCameraManInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _GenreInput!
+        data: _InterfacedRelationshipTypeInput!
+      ): _MergeCameraManInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Genre"
+        )
+        @hasScope(scopes: ["Person: Merge", "Genre: Merge"])
+      AddCameraManReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+        data: _ReflexiveInterfacedRelationshipTypeInput!
+      ): _AddCameraManReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Create", "Person: Create"])
+      RemoveCameraManReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+      ): _RemoveCameraManReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Delete", "Person: Delete"])
+      UpdateCameraManReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+        data: _ReflexiveInterfacedRelationshipTypeInput!
+      ): _UpdateCameraManReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Update", "Person: Update"])
+      MergeCameraManReflexiveInterfacedRelationshipType(
+        from: _PersonInput!
+        to: _PersonInput!
+        data: _ReflexiveInterfacedRelationshipTypeInput!
+      ): _MergeCameraManReflexiveInterfacedRelationshipTypePayload
+        @MutationMeta(
+          relationship: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+          from: "Person"
+          to: "Person"
+        )
+        @hasScope(scopes: ["Person: Merge", "Person: Merge"])
       CreateCameraMan(
         userId: ID
         name: String
@@ -2681,10 +3570,116 @@ test.cb('Test augmented schema', t => {
       to: Person
     }
 
+    type _AddActorInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _RemoveActorInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+    }
+
+    type _UpdateActorInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _MergeActorInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _AddActorReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+      boolean: Boolean
+    }
+
+    type _RemoveActorReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+    }
+
+    type _UpdateActorReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+      boolean: Boolean
+    }
+
+    type _MergeActorReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+      boolean: Boolean
+    }
+
     type _RemoveActorKnowsPayload
       @relation(name: "KNOWS", from: "Actor", to: "Person") {
       from: Actor
       to: Person
+    }
+
+    enum _RatedOrdering {
+      currentUserId_asc
+      currentUserId_desc
+      rating_asc
+      rating_desc
+      time_asc
+      time_desc
+      date_asc
+      date_desc
+      datetime_asc
+      datetime_desc
+      localtime_asc
+      localtime_desc
+      localdatetime_asc
+      localdatetime_desc
     }
 
     type _AddUserRatedPayload
@@ -2748,6 +3743,23 @@ test.cb('Test augmented schema', t => {
       localdatetime: _Neo4jLocalDateTime
       datetimes: [_Neo4jDateTime]
       location: _Neo4jPoint
+    }
+
+    enum _FriendOfOrdering {
+      currentUserId_asc
+      currentUserId_desc
+      since_asc
+      since_desc
+      time_asc
+      time_desc
+      date_asc
+      date_desc
+      datetime_asc
+      datetime_desc
+      localtime_asc
+      localtime_desc
+      localdatetime_asc
+      localdatetime_desc
     }
 
     input _FriendOfInput {
@@ -2905,6 +3917,95 @@ test.cb('Test augmented schema', t => {
       to: State
     }
 
+    type _AddCameraManInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _RemoveCameraManInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+    }
+
+    type _UpdateCameraManInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _MergeCameraManInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _AddCameraManReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+      boolean: Boolean
+    }
+
+    type _RemoveCameraManReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+    }
+
+    type _UpdateCameraManReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+      boolean: Boolean
+    }
+
+    type _MergeCameraManReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+      boolean: Boolean
+    }
+
     input _CameraManInput {
       userId: ID!
     }
@@ -2928,6 +4029,36 @@ test.cb('Test augmented schema', t => {
     type _MergeCameraOperatorsPayload
       @relation(name: "cameras", from: "Person", to: "Camera") {
       from: Person
+      to: Camera
+    }
+
+    type _AddCameraReflexiveInterfaceRelationshipPayload
+      @relation(
+        name: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+        from: "Camera"
+        to: "Camera"
+      ) {
+      from: Camera
+      to: Camera
+    }
+
+    type _RemoveCameraReflexiveInterfaceRelationshipPayload
+      @relation(
+        name: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+        from: "Camera"
+        to: "Camera"
+      ) {
+      from: Camera
+      to: Camera
+    }
+
+    type _MergeCameraReflexiveInterfaceRelationshipPayload
+      @relation(
+        name: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+        from: "Camera"
+        to: "Camera"
+      ) {
+      from: Camera
       to: Camera
     }
 
@@ -2964,6 +4095,154 @@ test.cb('Test augmented schema', t => {
       from: CameraMan
       to: Camera
     }
+
+    enum InterfacedRelationshipTypeOrdering {
+      string_asc
+      string_desc
+      boolean_asc
+      boolean_desc
+    }
+
+    type _AddPersonInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _RemovePersonInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+    }
+
+    type _UpdatePersonInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+
+    type _MergePersonInterfacedRelationshipTypePayload
+      @relation(
+        name: "INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Genre"
+      ) {
+      from: Person
+      to: Genre
+      string: String!
+      boolean: Boolean
+    }
+    type _PersonReflexiveInterfacedRelationshipTypeDirections
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from(
+        first: Int
+        offset: Int
+        orderBy: [_ReflexiveInterfacedRelationshipTypeOrdering]
+        filter: _ReflexiveInterfacedRelationshipTypeFilter
+      ): [_PersonReflexiveInterfacedRelationshipType]
+      to(
+        first: Int
+        offset: Int
+        orderBy: [_ReflexiveInterfacedRelationshipTypeOrdering]
+        filter: _ReflexiveInterfacedRelationshipTypeFilter
+      ): [_PersonReflexiveInterfacedRelationshipType]
+    }
+
+    type _PersonReflexiveInterfacedRelationshipType
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      boolean: Boolean
+      Person: Person
+    }
+
+    input _ReflexiveInterfacedRelationshipTypeDirectionsFilter {
+      from: _ReflexiveInterfacedRelationshipTypeFilter
+      to: _ReflexiveInterfacedRelationshipTypeFilter
+    }
+
+    enum _ReflexiveInterfacedRelationshipTypeOrdering {
+      boolean_asc
+      boolean_desc
+    }
+
+    input _ReflexiveInterfacedRelationshipTypeFilter {
+      AND: [_ReflexiveInterfacedRelationshipTypeFilter!]
+      OR: [_ReflexiveInterfacedRelationshipTypeFilter!]
+      boolean: Boolean
+      boolean_not: Boolean
+      Person: _PersonFilter
+    }
+
+    input _ReflexiveInterfacedRelationshipTypeInput {
+      boolean: Boolean
+    }
+
+    type _AddPersonReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+      boolean: Boolean
+    }
+
+    type _RemovePersonReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+    }
+
+    type _UpdatePersonReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+      boolean: Boolean
+    }
+
+    type _MergePersonReflexiveInterfacedRelationshipTypePayload
+      @relation(
+        name: "REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE"
+        from: "Person"
+        to: "Person"
+      ) {
+      from: Person
+      to: Person
+      boolean: Boolean
+    }
+
     input _PersonInput {
       userId: ID!
     }
@@ -3099,6 +4378,36 @@ test.cb('Test augmented schema', t => {
       to: OldCamera
     }
 
+    type _AddOldCameraReflexiveInterfaceRelationshipPayload
+      @relation(
+        name: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+        from: "OldCamera"
+        to: "Camera"
+      ) {
+      from: OldCamera
+      to: Camera
+    }
+
+    type _RemoveOldCameraReflexiveInterfaceRelationshipPayload
+      @relation(
+        name: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+        from: "OldCamera"
+        to: "Camera"
+      ) {
+      from: OldCamera
+      to: Camera
+    }
+
+    type _MergeOldCameraReflexiveInterfaceRelationshipPayload
+      @relation(
+        name: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+        from: "OldCamera"
+        to: "Camera"
+      ) {
+      from: OldCamera
+      to: Camera
+    }
+
     input _NewCameraInput {
       id: ID!
     }
@@ -3119,6 +4428,36 @@ test.cb('Test augmented schema', t => {
       @relation(name: "cameras", from: "Person", to: "NewCamera") {
       from: Person
       to: NewCamera
+    }
+
+    type _AddNewCameraReflexiveInterfaceRelationshipPayload
+      @relation(
+        name: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+        from: "NewCamera"
+        to: "Camera"
+      ) {
+      from: NewCamera
+      to: Camera
+    }
+
+    type _RemoveNewCameraReflexiveInterfaceRelationshipPayload
+      @relation(
+        name: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+        from: "NewCamera"
+        to: "Camera"
+      ) {
+      from: NewCamera
+      to: Camera
+    }
+
+    type _MergeNewCameraReflexiveInterfaceRelationshipPayload
+      @relation(
+        name: "REFLEXIVE_INTERFACE_RELATIONSHIP"
+        from: "NewCamera"
+        to: "Camera"
+      ) {
+      from: NewCamera
+      to: Camera
     }
 
     type _Neo4jPoint {

--- a/test/unit/cypherTest.test.js
+++ b/test/unit/cypherTest.test.js
@@ -1381,6 +1381,56 @@ test('Add interfaced relationship mutation', t => {
   );
 });
 
+test('Add interfaced relationship type mutation', t => {
+  const graphQLQuery = `mutation {
+    AddActorInterfacedRelationshipType(
+      from: { userId: "744c23c8-2042-402d-b482-28d089f976f9" }
+      to: { name: "Wildlife Documentary" }
+      data: { string: "data" }
+    ) {
+      from {
+        userId
+        interfacedRelationshipType {
+          string
+          Genre {
+            name
+          }
+        }
+      }
+      string
+    }
+  }`,
+    expectedCypherQuery = `
+      MATCH (\`person_from\`:\`Person\` {userId: $from.userId})
+      MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
+      CREATE (\`person_from\`)-[\`interfaced_relationship_type_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\` {string:$data.string}]->(\`genre_to\`)
+      RETURN \`interfaced_relationship_type_relation\` { from: \`person_from\` {FRAGMENT_TYPE: head( [ label IN labels(\`person_from\`) WHERE label IN $Person_derivedTypes ] ), .userId ,interfacedRelationshipType: [(\`person_from\`)-[\`person_from_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_from_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_from_interfacedRelationshipType_relation\`]->(\`person_from_interfacedRelationshipType_Genre\`:\`Genre\`) | person_from_interfacedRelationshipType_Genre { .name }]) }] } , .string  } AS \`_AddActorInterfacedRelationshipTypePayload\`;
+    `;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      from: {
+        userId: '744c23c8-2042-402d-b482-28d089f976f9'
+      },
+      to: {
+        name: 'Wildlife Documentary'
+      },
+      data: {
+        string: 'data'
+      },
+      first: -1,
+      offset: 0,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    }
+  );
+});
+
 test('Merge interfaced relationship mutation', t => {
   const graphQLQuery = `mutation someMutation {
     MergeActorKnows(
@@ -1413,6 +1463,167 @@ test('Merge interfaced relationship mutation', t => {
       to: { userId: '456' },
       first: -1,
       offset: 0
+    },
+    expectedCypherQuery,
+    {}
+  );
+});
+
+test('Merge interfaced relationship type mutation', t => {
+  const graphQLQuery = `mutation {
+    MergeActorInterfacedRelationshipType(
+      from: { userId: "744c23c8-2042-402d-b482-28d089f976f9" }
+      to: { name: "Wildlife Documentary" }
+      data: { string: "data" }
+    ) {
+      from {
+        userId
+        interfacedRelationshipType {
+          string
+          Genre {
+            name
+          }
+        }
+      }
+      string
+    }
+  }`,
+    expectedCypherQuery = `
+      MATCH (\`person_from\`:\`Person\` {userId: $from.userId})
+      MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
+      MERGE (\`person_from\`)-[\`interfaced_relationship_type_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(\`genre_to\`)
+      SET \`interfaced_relationship_type_relation\` += {string:$data.string} 
+      RETURN \`interfaced_relationship_type_relation\` { from: \`person_from\` {FRAGMENT_TYPE: head( [ label IN labels(\`person_from\`) WHERE label IN $Person_derivedTypes ] ), .userId ,interfacedRelationshipType: [(\`person_from\`)-[\`person_from_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_from_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_from_interfacedRelationshipType_relation\`]->(\`person_from_interfacedRelationshipType_Genre\`:\`Genre\`) | person_from_interfacedRelationshipType_Genre { .name }]) }] } , .string  } AS \`_MergeActorInterfacedRelationshipTypePayload\`;
+    `;
+
+  t.plan(1);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {
+      from: {
+        userId: '744c23c8-2042-402d-b482-28d089f976f9'
+      },
+      to: {
+        name: 'Wildlife Documentary'
+      },
+      data: {
+        string: 'data'
+      },
+      first: -1,
+      offset: 0,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    },
+    expectedCypherQuery,
+    {}
+  );
+});
+
+test('Update interfaced relationship type mutation', t => {
+  const graphQLQuery = `mutation {
+    UpdateActorInterfacedRelationshipType(
+      from: { userId: "744c23c8-2042-402d-b482-28d089f976f9" }
+      to: { name: "Wildlife Documentary" }
+      data: { string: "value" }
+    ) {
+      from {
+        userId
+        interfacedRelationshipType {
+          string
+          Genre {
+            name
+          }
+        }
+      }
+      string
+    }
+  }`,
+    expectedCypherQuery = `
+      MATCH (\`person_from\`:\`Person\` {userId: $from.userId})
+      MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
+      MATCH (\`person_from\`)-[\`interfaced_relationship_type_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(\`genre_to\`)
+      SET \`interfaced_relationship_type_relation\` += {string:$data.string} 
+      RETURN \`interfaced_relationship_type_relation\` { from: \`person_from\` {FRAGMENT_TYPE: head( [ label IN labels(\`person_from\`) WHERE label IN $Person_derivedTypes ] ), .userId ,interfacedRelationshipType: [(\`person_from\`)-[\`person_from_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_from_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_from_interfacedRelationshipType_relation\`]->(\`person_from_interfacedRelationshipType_Genre\`:\`Genre\`) | person_from_interfacedRelationshipType_Genre { .name }]) }] } , .string  } AS \`_UpdateActorInterfacedRelationshipTypePayload\`;
+    `;
+
+  t.plan(1);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {
+      from: {
+        userId: '744c23c8-2042-402d-b482-28d089f976f9'
+      },
+      to: {
+        name: 'Wildlife Documentary'
+      },
+      data: {
+        string: 'value'
+      },
+      first: -1,
+      offset: 0,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    },
+    expectedCypherQuery,
+    {}
+  );
+});
+
+test('Merge interfaced relationship type mutation (additional operation)', t => {
+  const graphQLQuery = `mutation {
+    MergeGenreInterfacedRelationshipType(
+      from: { userId: "744c23c8-2042-402d-b482-28d089f976f9" }
+      to: { name: "Wildlife Documentary" }
+      data: { string: "data" }
+    ) {
+      from {
+        userId
+        name
+        interfacedRelationshipType {
+          string
+          Genre {
+            name
+          }
+        }
+      }
+      to {
+        name
+        interfacedRelationshipType {
+          string
+          Person {
+            userId
+            name
+          }
+        }
+      }
+      string
+    }
+  }`,
+    expectedCypherQuery = `
+      MATCH (\`person_from\`:\`Person\` {userId: $from.userId})
+      MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
+      MERGE (\`person_from\`)-[\`interfaced_relationship_type_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(\`genre_to\`)
+      SET \`interfaced_relationship_type_relation\` += {string:$data.string} 
+      RETURN \`interfaced_relationship_type_relation\` { from: \`person_from\` {FRAGMENT_TYPE: head( [ label IN labels(\`person_from\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: [(\`person_from\`)-[\`person_from_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_from_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_from_interfacedRelationshipType_relation\`]->(\`person_from_interfacedRelationshipType_Genre\`:\`Genre\`) | person_from_interfacedRelationshipType_Genre { .name }]) }] } ,to: \`genre_to\` { .name ,interfacedRelationshipType: [(\`genre_to\`)<-[\`genre_to_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_to_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_to_interfacedRelationshipType_relation\`]-(\`genre_to_interfacedRelationshipType_Person\`:\`Person\`) | genre_to_interfacedRelationshipType_Person {FRAGMENT_TYPE: head( [ label IN labels(genre_to_interfacedRelationshipType_Person) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]) }] } , .string  } AS \`_MergeGenreInterfacedRelationshipTypePayload\`;
+    `;
+
+  t.plan(1);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {
+      from: {
+        userId: '744c23c8-2042-402d-b482-28d089f976f9'
+      },
+      to: {
+        name: 'Wildlife Documentary'
+      },
+      data: {
+        string: 'data'
+      },
+      first: -1,
+      offset: 0,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
     },
     expectedCypherQuery,
     {}
@@ -1453,6 +1664,52 @@ test('Remove interfaced relationship mutation', t => {
       to: { userId: '456' },
       first: -1,
       offset: 0
+    },
+    expectedCypherQuery,
+    {}
+  );
+});
+
+test('Remove interfaced relationship type mutation', t => {
+  const graphQLQuery = `mutation {
+    RemoveActorInterfacedRelationshipType(
+      from: { userId: "744c23c8-2042-402d-b482-28d089f976f9" }
+      to: { name: "Wildlife Documentary" }
+    ) {
+      from {
+        userId
+        interfacedRelationshipType {
+          string
+          Genre {
+            name
+          }
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `
+      MATCH (\`person_from\`:\`Person\` {userId: $from.userId})
+      MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
+      OPTIONAL MATCH (\`person_from\`)-[\`person_fromgenre_to\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(\`genre_to\`)
+      DELETE \`person_fromgenre_to\`
+      WITH COUNT(*) AS scope, \`person_from\` AS \`_person_from\`, \`genre_to\` AS \`_genre_to\`
+      RETURN {from: \`_person_from\` {FRAGMENT_TYPE: head( [ label IN labels(\`_person_from\`) WHERE label IN $Person_derivedTypes ] ), .userId ,interfacedRelationshipType: [(\`_person_from\`)-[\`_person_from_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | _person_from_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`_person_from_interfacedRelationshipType_relation\`]->(\`_person_from_interfacedRelationshipType_Genre\`:\`Genre\`) | _person_from_interfacedRelationshipType_Genre { .name }]) }] } } AS \`_RemoveActorInterfacedRelationshipTypePayload\`;
+    `;
+
+  t.plan(1);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {
+      from: {
+        userId: '744c23c8-2042-402d-b482-28d089f976f9'
+      },
+      to: {
+        name: 'Wildlife Documentary'
+      },
+      first: -1,
+      offset: 0,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
     },
     expectedCypherQuery,
     {}
@@ -1964,6 +2221,39 @@ test('query for relationship properties', t => {
   );
 });
 
+test('query for relationship properties using orderBy argument', t => {
+  const graphQLQuery = `query {
+    Movie(title: "River Runs Through It, A") {
+      title
+      ratings(orderBy: [datetime_asc]) {
+        rating
+        User {
+          userId
+          name
+        }
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\` {title:$title}) RETURN \`movie\` { .title ,ratings: [sortedElement IN apoc.coll.sortMulti([(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,User: head([(:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`)<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .userId , .name }]) ,datetime: \`movie_ratings_relation\`.datetime}], ['^datetime']) | sortedElement { .* }] } AS \`movie\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      title: 'River Runs Through It, A',
+      '1_orderBy': ['datetime_asc'],
+      cypherParams: CYPHER_PARAMS
+    }
+  );
+});
+
 test('query reflexive relation nested in non-reflexive relation', t => {
   const graphQLQuery = `query {
     Movie {
@@ -2193,11 +2483,11 @@ test('query using inline fragment on object type - including cypherParams', t =>
   );
 });
 
-test('query interfaced relation using inline fragment', t => {
+test('query interfaced relation using inline fragment and pagination', t => {
   const graphQLQuery = `query {
     Actor {
       name
-      knows {
+      knows(first: 0, offset: 1) {
         ...userFavorites
       }
     }
@@ -2211,7 +2501,7 @@ test('query interfaced relation using inline fragment', t => {
       year
     }
   }`,
-    expectedCypherQuery = `MATCH (\`actor\`:\`Actor\`) RETURN \`actor\` { .name ,knows: [(\`actor\`)-[:\`KNOWS\`]->(\`actor_knows\`:\`Person\`) WHERE ("User" IN labels(\`actor_knows\`)) | head([\`actor_knows\` IN [\`actor_knows\`] WHERE "User" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "User",  .name ,favorites: [(\`actor_knows\`)-[:\`FAVORITED\`]->(\`actor_knows_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`actor_knows_favorites\` { .movieId , .title , .year }]  }])] } AS \`actor\``;
+    expectedCypherQuery = `MATCH (\`actor\`:\`Actor\`) RETURN \`actor\` { .name ,knows: [(\`actor\`)-[:\`KNOWS\`]->(\`actor_knows\`:\`Person\`) WHERE ("User" IN labels(\`actor_knows\`)) | head([\`actor_knows\` IN [\`actor_knows\`] WHERE "User" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "User",  .name ,favorites: [(\`actor_knows\`)-[:\`FAVORITED\`]->(\`actor_knows_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`actor_knows_favorites\` { .movieId , .title , .year }]  }])][1..1] } AS \`actor\``;
 
   t.plan(1);
 
@@ -2221,6 +2511,606 @@ test('query interfaced relation using inline fragment', t => {
     {},
     expectedCypherQuery,
     {}
+  );
+});
+
+test('order interfaced relation using inline fragment', t => {
+  const graphQLQuery = `query {
+    Actor {
+      name
+      knows(orderBy: userId_asc) {
+        name
+        ... on User {
+          userId
+          favorites {
+            movieId
+            title
+            year
+          }          
+        }
+      }
+    }
+  }
+`,
+    expectedCypherQuery = `MATCH (\`actor\`:\`Actor\`) RETURN \`actor\` { .name ,knows: apoc.coll.sortMulti([(\`actor\`)-[:\`KNOWS\`]->(\`actor_knows\`:\`Person\`) WHERE ("Actor" IN labels(\`actor_knows\`) OR "CameraMan" IN labels(\`actor_knows\`) OR "User" IN labels(\`actor_knows\`)) | head([\`actor_knows\` IN [\`actor_knows\`] WHERE "Actor" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "Actor",  .name , .userId  }] + [\`actor_knows\` IN [\`actor_knows\`] WHERE "CameraMan" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "CameraMan",  .name , .userId  }] + [\`actor_knows\` IN [\`actor_knows\`] WHERE "User" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "User",  .userId ,favorites: [(\`actor_knows\`)-[:\`FAVORITED\`]->(\`actor_knows_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`actor_knows_favorites\` { .movieId , .title , .year }] , .name  }])], ['^userId']) } AS \`actor\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      '1_orderBy': 'userId_asc',
+      cypherParams: CYPHER_PARAMS
+    }
+  );
+});
+
+test('query interfaced relationship type using inline fragment and pagination', t => {
+  const graphQLQuery = `query {
+    Person {
+      name
+      ... on Actor {
+        userId
+        interfacedRelationshipType(first: 0, offset: 1) {
+          string
+          Genre {
+            name
+          }
+          __typename
+        }
+      }
+      __typename
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE ("Actor" IN labels(\`person\`) OR "CameraMan" IN labels(\`person\`) OR "User" IN labels(\`person\`)) RETURN head([\`person\` IN [\`person\`] WHERE "Actor" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "Actor",  .userId ,interfacedRelationshipType: [(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }][1..1] , .name  }] + [\`person\` IN [\`person\`] WHERE "CameraMan" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "CameraMan",  .name  }] + [\`person\` IN [\`person\`] WHERE "User" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "User",  .name  }]) AS \`person\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    }
+  );
+});
+test('order interfaced relationship type using inline fragment', t => {
+  const graphQLQuery = `query {
+    Person {
+      name
+      ... on Actor {
+        userId
+        interfacedRelationshipType(orderBy: [string_desc]) {
+          string
+          Genre {
+            name
+          }
+          __typename
+        }
+      }
+      __typename
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE ("Actor" IN labels(\`person\`) OR "CameraMan" IN labels(\`person\`) OR "User" IN labels(\`person\`)) RETURN head([\`person\` IN [\`person\`] WHERE "Actor" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "Actor",  .userId ,interfacedRelationshipType: apoc.coll.sortMulti([(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }], ['string']) , .name  }] + [\`person\` IN [\`person\`] WHERE "CameraMan" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "CameraMan",  .name  }] + [\`person\` IN [\`person\`] WHERE "User" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "User",  .name  }]) AS \`person\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      '1_orderBy': ['string_desc'],
+      cypherParams: CYPHER_PARAMS
+    }
+  );
+});
+
+test('query interfaced relationship type field for outgoing object type nodes', t => {
+  const graphQLQuery = `query {
+    Person {
+      userId
+      name
+      interfacedRelationshipType {
+        string
+        Genre {
+          name
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: [(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }] } AS \`person\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    }
+  );
+});
+
+test('order interfaced relationship type field for outgoing object type nodes', t => {
+  const graphQLQuery = `query {
+    Person {
+      userId
+      name
+      interfacedRelationshipType(orderBy: [string_asc]) {
+        string
+        Genre {
+          name
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: apoc.coll.sortMulti([(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }], ['^string']) } AS \`person\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      '1_orderBy': ['string_asc'],
+      cypherParams: CYPHER_PARAMS,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    }
+  );
+});
+
+test('fliter interfaced relationship type field for outgoing object type nodes', t => {
+  const graphQLQuery = `query {
+    Person(filter: {
+      interfacedRelationshipType: {
+        Genre: {
+          name: "Action"
+        }
+      }
+    }) {
+      userId
+      name
+      interfacedRelationshipType(filter: {
+        string: "data"
+      }) {
+        string
+        Genre {
+          name        
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE (EXISTS((\`person\`)-[:INTERFACED_RELATIONSHIP_TYPE]->(:Genre)) AND ALL(\`person_filter_genre\` IN [(\`person\`)-[\`_person_filter_genre\`:INTERFACED_RELATIONSHIP_TYPE]->(:Genre) | \`_person_filter_genre\`] WHERE (ALL(\`genre\` IN [(\`person\`)-[\`person_filter_genre\`]->(\`_genre\`:Genre) | \`_genre\`] WHERE (\`genre\`.name = $filter.interfacedRelationshipType.Genre.name))))) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: [(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) WHERE (\`person_interfacedRelationshipType_relation\`.string = $1_filter.string) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }] } AS \`person\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      filter: {
+        interfacedRelationshipType: {
+          Genre: {
+            name: 'Action'
+          }
+        }
+      },
+      '1_filter': {
+        string: 'data'
+      },
+      cypherParams: CYPHER_PARAMS,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    }
+  );
+});
+
+test('query interfaced relationship type field for incoming interface type nodes', t => {
+  const graphQLQuery = `query {
+    Genre {
+      name
+      interfacedRelationshipType {
+        string
+        Person {
+          userId
+          name
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) | genre_interfacedRelationshipType_Person {FRAGMENT_TYPE: head( [ label IN labels(genre_interfacedRelationshipType_Person) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]) }] } AS \`genre\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
+      cypherParams: CYPHER_PARAMS
+    }
+  );
+});
+
+test('order interfaced relationship type field for incoming interface type nodes', t => {
+  const graphQLQuery = `query {
+    Genre {
+      name
+      interfacedRelationshipType(orderBy: string_desc) {
+        string
+        Person {
+          userId
+          name
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: apoc.coll.sortMulti([(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) | genre_interfacedRelationshipType_Person {FRAGMENT_TYPE: head( [ label IN labels(genre_interfacedRelationshipType_Person) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]) }], ['string']) } AS \`genre\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      '1_orderBy': 'string_desc',
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
+      cypherParams: CYPHER_PARAMS
+    }
+  );
+});
+
+test('fliter interfaced relationship type field for incoming interface type nodes', t => {
+  const graphQLQuery = `query {
+    Genre(filter: {
+      interfacedRelationshipType: {
+        Person: {
+          userId: "45add9f4-e6c7-4ded-b951-59e3947240fe"
+        }
+      }
+    }) {
+      name
+      interfacedRelationshipType(filter: {
+        string: "data",
+        Person: {
+          name_in: ["Michael"]
+        }
+      }) {
+        string
+        Person {
+          userId
+          name
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) WHERE (EXISTS((\`genre\`)<-[:INTERFACED_RELATIONSHIP_TYPE]-(:Person)) AND ALL(\`genre_filter_person\` IN [(\`genre\`)<-[\`_genre_filter_person\`:INTERFACED_RELATIONSHIP_TYPE]-(:Person) | \`_genre_filter_person\`] WHERE (ALL(\`person\` IN [(\`genre\`)<-[\`genre_filter_person\`]-(\`_person\`:Person) | \`_person\`] WHERE (\`person\`.userId = $filter.interfacedRelationshipType.Person.userId))))) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) WHERE (\`genre_interfacedRelationshipType_relation\`.string = $1_filter.string) AND (ALL(\`genre_filter_person\` IN [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`_person\`:Person) | \`_person\`] WHERE (\`genre_filter_person\`.name IN $1_filter.Person.name_in))) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) | genre_interfacedRelationshipType_Person {FRAGMENT_TYPE: head( [ label IN labels(genre_interfacedRelationshipType_Person) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]) }] } AS \`genre\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      filter: {
+        interfacedRelationshipType: {
+          Person: {
+            userId: '45add9f4-e6c7-4ded-b951-59e3947240fe'
+          }
+        }
+      },
+      '1_filter': {
+        string: 'data',
+        Person: {
+          name_in: ['Michael']
+        }
+      },
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
+      cypherParams: CYPHER_PARAMS
+    }
+  );
+});
+
+test('query incoming interface type nodes using fragments in relationship type field', t => {
+  const graphQLQuery = `query {
+    Genre {
+      name
+      interfacedRelationshipType {
+        string          
+        Person {
+          ... on User {
+            name
+          }
+          ...UserFragment
+          __typename
+        }
+      }
+    }
+  }
+
+  fragment UserFragment on User {
+    userId
+  }`,
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) WHERE ("User" IN labels(genre_interfacedRelationshipType_Person)) | head([\`genre_interfacedRelationshipType_Person\` IN [\`genre_interfacedRelationshipType_Person\`] WHERE "User" IN labels(\`genre_interfacedRelationshipType_Person\`) | \`genre_interfacedRelationshipType_Person\` { FRAGMENT_TYPE: "User",  .name , .userId  }])]) }] } AS \`genre\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    }
+  );
+});
+
+test('order incoming interface type nodes using fragments in relationship type field', t => {
+  const graphQLQuery = `query {
+    Genre {
+      name
+      interfacedRelationshipType(orderBy: string_asc) {
+        string          
+        Person {
+          ... on User {
+            name
+          }
+          ...UserFragment
+          __typename
+        }
+      }
+    }
+  }
+
+  fragment UserFragment on User {
+    userId
+  }`,
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: apoc.coll.sortMulti([(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) WHERE ("User" IN labels(genre_interfacedRelationshipType_Person)) | head([\`genre_interfacedRelationshipType_Person\` IN [\`genre_interfacedRelationshipType_Person\`] WHERE "User" IN labels(\`genre_interfacedRelationshipType_Person\`) | \`genre_interfacedRelationshipType_Person\` { FRAGMENT_TYPE: "User",  .name , .userId  }])]) }], ['^string']) } AS \`genre\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      '1_orderBy': 'string_asc',
+      cypherParams: CYPHER_PARAMS
+    }
+  );
+});
+
+test('filter incoming interface type nodes using only fragments in relationship type field', t => {
+  const graphQLQuery = `query {
+    Genre {
+      name
+      interfacedRelationshipType(filter: { Person: { name_not_in: ["John"] } }) {
+        string
+        Person {
+          ... on User {
+            userId
+          }
+        }
+      }
+      __typename
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) WHERE (ALL(\`genre_filter_person\` IN [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`_person\`:Person) | \`_person\`] WHERE (NOT \`genre_filter_person\`.name IN $1_filter.Person.name_not_in))) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) WHERE ("User" IN labels(genre_interfacedRelationshipType_Person)) | head([\`genre_interfacedRelationshipType_Person\` IN [\`genre_interfacedRelationshipType_Person\`] WHERE "User" IN labels(\`genre_interfacedRelationshipType_Person\`) | \`genre_interfacedRelationshipType_Person\` { FRAGMENT_TYPE: "User",  .userId  }])]) }] } AS \`genre\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      '1_filter': {
+        Person: {
+          name_not_in: ['John']
+        }
+      },
+      cypherParams: CYPHER_PARAMS
+    }
+  );
+});
+
+test('query reflexive interfaced relationship type field using fragments', t => {
+  const graphQLQuery = `query {
+    Person {
+      userId
+      name
+      reflexiveInterfacedRelationshipType {
+        from {
+          boolean
+          Person {
+            ...UserFragment
+            __typename
+          }
+        }
+        to {
+          boolean
+          Person {
+            userId
+            ... on Actor {
+              name
+            }
+            __typename
+          }
+        }      
+      }
+    }
+  }	
+  
+  fragment UserFragment on User {
+    name
+    userId
+  }`,
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,reflexiveInterfacedRelationshipType: {from: [(\`person\`)<-[\`person_from_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]-(\`person_from\`:\`Person\`) | person_from_relation { .boolean ,Person: head([\`person_from\` IN [\`person_from\`] WHERE "User" IN labels(\`person_from\`) | \`person_from\` { FRAGMENT_TYPE: "User",  .name , .userId  }]) }] ,to: [(\`person\`)-[\`person_to_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]->(\`person_to\`:\`Person\`) | person_to_relation { .boolean ,Person: head([\`person_to\` IN [\`person_to\`] WHERE "Actor" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "Actor",  .name , .userId  }] + [\`person_to\` IN [\`person_to\`] WHERE "CameraMan" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "CameraMan",  .userId  }] + [\`person_to\` IN [\`person_to\`] WHERE "User" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "User",  .userId  }]) }] } } AS \`person\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    }
+  );
+});
+
+test('order incoming and outgoing nodes of reflexive interfaced relationship type field', t => {
+  const graphQLQuery = `query {
+    Person {
+      userId
+      name
+      reflexiveInterfacedRelationshipType {
+        from(orderBy: boolean_desc) {
+          boolean
+        }
+        to(orderBy: boolean_asc) {
+          boolean
+        }
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,reflexiveInterfacedRelationshipType: {from: apoc.coll.sortMulti([(\`person\`)<-[\`person_from_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]-(\`person_from\`:\`Person\`) | person_from_relation { .boolean }], ['boolean']) ,to: apoc.coll.sortMulti([(\`person\`)-[\`person_to_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]->(\`person_to\`:\`Person\`) | person_to_relation { .boolean }], ['^boolean']) } } AS \`person\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      '1_orderBy': 'boolean_desc',
+      '3_orderBy': 'boolean_asc',
+      cypherParams: CYPHER_PARAMS,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    }
+  );
+});
+
+test('filter reflexive interfaced relationship type field', t => {
+  const graphQLQuery = `query {
+    Person(filter: {
+      name_in: ["Michael"]
+      reflexiveInterfacedRelationshipType: {
+        to: {
+          Person: {
+            name_in: ["John"]
+          }
+        }
+      }
+    }) {
+      userId
+      name
+      reflexiveInterfacedRelationshipType {
+        to(first: 1, offset: 0, filter: {
+          boolean: true
+        }) {
+          boolean
+          Person {
+            userId
+            name          
+            interfacedRelationshipType(first: 1) {
+              string
+              Genre {
+                name
+              }
+              __typename
+            }
+            __typename
+          }
+        }
+      }
+    }
+  }`,
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE (\`person\`.name IN $filter.name_in) AND ((EXISTS((\`person\`)-[:REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE]->(:Person)) AND ALL(\`person_filter_person\` IN [(\`person\`)-[\`_person_filter_person\`:REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE]->(:Person) | \`_person_filter_person\`] WHERE (ALL(\`person\` IN [(\`person\`)-[\`person_filter_person\`]->(\`_person\`:Person) | \`_person\`] WHERE (\`person\`.name IN $filter.reflexiveInterfacedRelationshipType.to.Person.name_in)))))) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,reflexiveInterfacedRelationshipType: {to: [(\`person\`)-[\`person_to_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]->(\`person_to\`:\`Person\`) WHERE (\`person_to_relation\`.boolean = $1_filter.boolean) | person_to_relation { .boolean ,Person: person_to {FRAGMENT_TYPE: head( [ label IN labels(person_to) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: [(\`person_to\`)-[\`person_to_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_to_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_to_interfacedRelationshipType_relation\`]->(\`person_to_interfacedRelationshipType_Genre\`:\`Genre\`) | person_to_interfacedRelationshipType_Genre { .name }]) }][..1] } }][0..1] } } AS \`person\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      filter: {
+        name_in: ['Michael'],
+        reflexiveInterfacedRelationshipType: {
+          to: {
+            Person: {
+              name_in: ['John']
+            }
+          }
+        }
+      },
+      '1_filter': {
+        boolean: true
+      },
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
+      cypherParams: CYPHER_PARAMS
+    }
   );
 });
 
@@ -4796,7 +5686,63 @@ test('Deeply nested query using temporal orderBy', t => {
     }
   }`,
     expectedCypherQuery =
-      "MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC RETURN `temporalNode` {_id: ID(`temporalNode`),datetime: { year: `temporalNode`.datetime.year , month: `temporalNode`.datetime.month , day: `temporalNode`.datetime.day , hour: `temporalNode`.datetime.hour , minute: `temporalNode`.datetime.minute , second: `temporalNode`.datetime.second , millisecond: `temporalNode`.datetime.millisecond , microsecond: `temporalNode`.datetime.microsecond , nanosecond: `temporalNode`.datetime.nanosecond , timezone: `temporalNode`.datetime.timezone , formatted: toString(`temporalNode`.datetime) },temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes` {_id: ID(`temporalNode_temporalNodes`),datetime: `temporalNode_temporalNodes`.datetime,time: `temporalNode_temporalNodes`.time,temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode_temporalNodes`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes_temporalNodes` {_id: ID(`temporalNode_temporalNodes_temporalNodes`),datetime: `temporalNode_temporalNodes_temporalNodes`.datetime,time: `temporalNode_temporalNodes_temporalNodes`.time}], ['datetime','time']) | sortedElement { .*,  datetime: {year: sortedElement.datetime.year,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}][1..3] }], ['^datetime']) | sortedElement { .*,  datetime: {year: sortedElement.datetime.year,month: sortedElement.datetime.month,day: sortedElement.datetime.day,hour: sortedElement.datetime.hour,minute: sortedElement.datetime.minute,second: sortedElement.datetime.second,millisecond: sortedElement.datetime.millisecond,microsecond: sortedElement.datetime.microsecond,nanosecond: sortedElement.datetime.nanosecond,timezone: sortedElement.datetime.timezone,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}] } AS `temporalNode`";
+      "MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC RETURN `temporalNode` {_id: ID(`temporalNode`),datetime: { year: `temporalNode`.datetime.year , month: `temporalNode`.datetime.month , day: `temporalNode`.datetime.day , hour: `temporalNode`.datetime.hour , minute: `temporalNode`.datetime.minute , second: `temporalNode`.datetime.second , millisecond: `temporalNode`.datetime.millisecond , microsecond: `temporalNode`.datetime.microsecond , nanosecond: `temporalNode`.datetime.nanosecond , timezone: `temporalNode`.datetime.timezone , formatted: toString(`temporalNode`.datetime) },temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes` {_id: ID(`temporalNode_temporalNodes`),datetime: `temporalNode_temporalNodes`.datetime,time: `temporalNode_temporalNodes`.time,temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode_temporalNodes`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes_temporalNodes` {_id: ID(`temporalNode_temporalNodes_temporalNodes`),datetime: `temporalNode_temporalNodes_temporalNodes`.datetime,time: `temporalNode_temporalNodes_temporalNodes`.time}], ['datetime','time']) | sortedElement { .* ,  datetime: {year: sortedElement.datetime.year,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}][1..3] }], ['^datetime']) | sortedElement { .* ,  datetime: {year: sortedElement.datetime.year,month: sortedElement.datetime.month,day: sortedElement.datetime.day,hour: sortedElement.datetime.hour,minute: sortedElement.datetime.minute,second: sortedElement.datetime.second,millisecond: sortedElement.datetime.millisecond,microsecond: sortedElement.datetime.microsecond,nanosecond: sortedElement.datetime.nanosecond,timezone: sortedElement.datetime.timezone,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}] } AS `temporalNode`";
+
+  t.plan(1);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+  ]);
+});
+
+test('query nested relationship with differences between selected and ordered fields', t => {
+  const graphQLQuery = `query {
+    TemporalNode(orderBy: [datetime_desc]) {
+      datetime {
+        year
+        formatted
+      }
+      temporalNodes(orderBy: [datetime_asc, datetime_desc]) {
+        _id
+        name
+        time {
+          hour
+        }
+        temporalNodes(first: 2, offset: 1, orderBy: [datetime_desc, name_asc]) {
+          _id
+          name
+        }
+      }
+    }
+  }
+  `,
+    expectedCypherQuery =
+      "MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC RETURN `temporalNode` {datetime: { year: `temporalNode`.datetime.year , formatted: toString(`temporalNode`.datetime) },temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes` {_id: ID(`temporalNode_temporalNodes`), .name ,time: `temporalNode_temporalNodes`.time,temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode_temporalNodes`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes_temporalNodes` {_id: ID(`temporalNode_temporalNodes_temporalNodes`), .name ,datetime: `temporalNode_temporalNodes_temporalNodes`.datetime}], ['datetime','^name']) | sortedElement { .* }][1..3] ,datetime: `temporalNode_temporalNodes`.datetime}], ['^datetime','datetime']) | sortedElement { .* ,  time: {hour: sortedElement.time.hour}}] } AS `temporalNode`";
+
+  t.plan(1);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      offset: 0,
+      first: -1,
+      '1_orderBy': ['datetime_asc', 'datetime_desc'],
+      '2_first': 2,
+      '2_offset': 1,
+      '2_orderBy': ['datetime_desc', 'name_asc'],
+      cypherParams: CYPHER_PARAMS
+    })
+  ]);
+});
+
+test('Deeply nested query using temporal orderBy without temporal field selection', t => {
+  const graphQLQuery = `query {
+    TemporalNode(orderBy: [datetime_desc]) {
+      _id
+      temporalNodes(first: 2, offset: 1, orderBy: [datetime_desc, time_desc]) {
+        _id
+      }
+    }
+  }`,
+    expectedCypherQuery =
+      "MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC RETURN `temporalNode` {_id: ID(`temporalNode`),temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes` {_id: ID(`temporalNode_temporalNodes`),datetime: `temporalNode_temporalNodes`.datetime,time: `temporalNode_temporalNodes`.time}], ['datetime','time']) | sortedElement { .* }][1..3] } AS `temporalNode`";
 
   t.plan(1);
   return Promise.all([
@@ -5346,7 +6292,7 @@ test('Handle order by field with underscores - nested field ', t => {
   }
   `,
     expectedCypherQuery =
-      'WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {offset:$offset, first:$first, substring:$substring, cypherParams: $cypherParams}, True) AS x UNWIND x AS `genre` RETURN `genre` {movies: apoc.coll.sortMulti([(`genre`)<-[:`IN_GENRE`]-(`genre_movies`:`Movie`:`u_user-id`:`newMovieLabel`) | `genre_movies` { .title }], [\'someprefix_title_with_underscores\']) } AS `genre`';
+      'WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {offset:$offset, first:$first, substring:$substring, cypherParams: $cypherParams}, True) AS x UNWIND x AS `genre` RETURN `genre` {movies: apoc.coll.sortMulti([(`genre`)<-[:`IN_GENRE`]-(`genre_movies`:`Movie`:`u_user-id`:`newMovieLabel`) | `genre_movies` { .title , .someprefix_title_with_underscores }], [\'someprefix_title_with_underscores\']) } AS `genre`';
 
   t.plan(1);
   return Promise.all([
@@ -5492,6 +6438,77 @@ test('query interface type relationship field', t => {
     }),
     augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
   ]);
+});
+
+test('query reflexive interface type relationship field', t => {
+  const graphQLQuery = `query {
+    NewCamera {
+      id
+      make
+      reflexiveInterfaceRelationship {
+        id
+        type
+        weight
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`newCamera\`:\`NewCamera\`) RETURN \`newCamera\` { .id , .make ,reflexiveInterfaceRelationship: [(\`newCamera\`)-[:\`REFLEXIVE_INTERFACE_RELATIONSHIP\`]->(\`newCamera_reflexiveInterfaceRelationship\`:\`Camera\`) | \`newCamera_reflexiveInterfaceRelationship\` {FRAGMENT_TYPE: head( [ label IN labels(\`newCamera_reflexiveInterfaceRelationship\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .weight }] } AS \`newCamera\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      Camera_derivedTypes: ['NewCamera', 'OldCamera'],
+      cypherParams: CYPHER_PARAMS
+    }
+  );
+});
+
+test('query reflexive interface type relationship field using fragments', t => {
+  const graphQLQuery = `query {
+    Camera {
+      id
+      ... on NewCamera {
+        make
+        reflexiveInterfaceRelationship {
+          ... on Camera {
+            id
+            type
+            weight
+            make
+          }
+        }
+      }
+      reflexiveInterfaceRelationship {
+        ... on OldCamera {
+          weight
+        }
+      }
+    }
+  }  
+  `,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .make ,reflexiveInterfaceRelationship: [(\`camera\`)-[:\`REFLEXIVE_INTERFACE_RELATIONSHIP\`]->(\`camera_reflexiveInterfaceRelationship\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`) OR "OldCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`)) | head([\`camera_reflexiveInterfaceRelationship\` IN [\`camera_reflexiveInterfaceRelationship\`] WHERE "NewCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`) | \`camera_reflexiveInterfaceRelationship\` { FRAGMENT_TYPE: "NewCamera",  .id , .type , .weight , .make  }] + [\`camera_reflexiveInterfaceRelationship\` IN [\`camera_reflexiveInterfaceRelationship\`] WHERE "OldCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`) | \`camera_reflexiveInterfaceRelationship\` { FRAGMENT_TYPE: "OldCamera",  .weight , .id , .type , .make  }])] , .id  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id ,reflexiveInterfaceRelationship: [(\`camera\`)-[:\`REFLEXIVE_INTERFACE_RELATIONSHIP\`]->(\`camera_reflexiveInterfaceRelationship\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`)) | head([\`camera_reflexiveInterfaceRelationship\` IN [\`camera_reflexiveInterfaceRelationship\`] WHERE "OldCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`) | \`camera_reflexiveInterfaceRelationship\` { FRAGMENT_TYPE: "OldCamera",  .weight  }])]  }]) AS \`camera\``;
+
+  t.plan(1);
+
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    }
+  );
 });
 
 test('query only __typename field on interface type relationship field', t => {


### PR DESCRIPTION
This PR includes various bug fixes that open up API features for interfaced `@relation` type fields, as well as some fixes to long-standing bugs with relationship field `orderBy` arguments.
#### Interfaced relationship types
#142 - Relationship with properties doesn't build with interface types.
The schema augmentation process now handles `@relation` types that use an interface type for either or both of it's incoming and outgoing node types.
* [query interfaced relationship type field for outgoing object type nodes](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2623)
* [query interfaced relationship type field for incoming interface type nodes](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2735)
* [query incoming interface type nodes using fragments in relationship type field](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2853)
* [query reflexive interfaced relationship type field using fragments](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2966)
* [query reflexive interface type relationship field](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L6443)
* [query reflexive interface type relationship field using fragments](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L6474)

#201 - Cannot generate multi-type relationships
The custom error shown at the bottom of this issue has been removed and the `Add`, `Remove`, `Update`, and `Merge` relationship type mutations are now generated and translated, shown with these tests:
* [Add interfaced relationship type mutation](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L1384)
* [Remove interfaced relationship type mutation](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L1673)
* [Merge interfaced relationship type mutation](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L1472)
* [Update interfaced relationship type mutation](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L1522)

#### Filtering
#477 - [Regression] 2.14.4 Breaks Nested Filters Previously Working in 2.14.0
Beginning with issue #446 and proceeding into #409, this issue arose due to a misinterpretation of the direction to use when querying the incoming nodes of a relationship type from the outgoing type node. The initial fix in #469 was incorrect and has been revised and covered by the following tests:
* [Nested filter for relationship type outgoing nodes](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/helpers/tck/filterTck.md#nested-filter-for-relationship-type-outgoing-nodes)
* [Nested filter for relationship type incoming nodes](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/helpers/tck/filterTck.md#nested-filter-for-relationship-type-incoming-nodes)
* [Root and nested relationship type filter](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/helpers/tck/filterTck.md#root-and-nested-relationship-type-filter)

#409 - Nested Filters do not work as expected for Interface types
* [fliter interfaced relationship type field for outgoing object type nodes](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2686)
* [fliter interfaced relationship type field for incoming interface type nodes](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2798)
* [filter incoming interface type nodes using only fragments in relationship type field](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2928)
* [filter reflexive interfaced relationship type field](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L3051)

#### Ordering
#173 - [BUG] Nested ordering errors
#272 - [Suggestion] Ordering by temporal field in relations
#373 - DateTime Ordering Argument Not Impacting Order
For quite some time, there has been a bug in nested ordering that causes it to silently fail when not also selecting the same fields being ordered. This issue was a result of misinterpreting how to handle the limitation of using `apoc.coll.sortMulti` and has been resolved in this PR. The translation strategy developed based on the misunderstanding was relied on in some post-processing code used for temporal ordering, so it showed up explicitly as a translation error in those cases.  
* [Deeply nested query using temporal orderBy (updated)](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L5640)
* [query for relationship properties using orderBy argument](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2224)
* [query nested relationship with differences between selected and ordered fields](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L5697)
* [Deeply nested query using temporal orderBy without temporal field selection](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L5735)

#232 - Add first, offset, orderBy generated arguments for relationship type fields
The `first`, `offset`, and `orderBy` query arguments are now added to `@relation` type fields and translated according to the below tests:
* [query interfaced relationship type using inline fragment and pagination](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2553)
* [query interfaced relation using inline fragment and pagination](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2486)
* [order interfaced relationship type field for incoming interface type nodes](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2766)
* [order interfaced relationship type field for outgoing object type nodes](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2654)
* [order incoming interface type nodes using fragments in relationship type field](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L2890)
* [order incoming and outgoing nodes of reflexive interfaced relationship type field](https://github.com/neo4j-graphql/neo4j-graphql-js/blob/b5f857fa05b53c7b7e5263df6716e3dc9f71b62b/test/unit/cypherTest.test.js#L3015)

##### Relevant remaining issues
#218 - Relationship mutation wrong return when only "to" fields are requested