### PR TITLE
Bug fixes for v2.16.0: Fragments, relationship types, and merge mutations

### DIFF
--- a/src/augment/fields.js
+++ b/src/augment/fields.js
@@ -254,11 +254,16 @@ export const propertyFieldExists = ({
     const fieldType = field.type;
     const unwrappedType = unwrapNamedType({ type: fieldType });
     const outputType = unwrappedType.name;
+    const typeWrappers = unwrappedType.wrappers;
     const outputDefinition = typeDefinitionMap[outputType];
     const outputKind = outputDefinition ? outputDefinition.kind : '';
-    return isPropertyTypeField({
-      kind: outputKind,
-      type: outputType
-    });
+    const isListType = typeWrappers[TypeWrappers.LIST_TYPE];
+    return (
+      !isListType &&
+      isPropertyTypeField({
+        kind: outputKind,
+        type: outputType
+      })
+    );
   });
 };

--- a/src/augment/types/node/mutation.js
+++ b/src/augment/types/node/mutation.js
@@ -118,11 +118,12 @@ const buildNodeMutationField = ({
     };
     if (mutationAction === NodeMutation.CREATE) {
       mutationFields.push(buildField(mutationField));
-    } else if (
-      mutationAction === NodeMutation.UPDATE ||
-      mutationAction === NodeMutation.MERGE
-    ) {
+    } else if (mutationAction === NodeMutation.UPDATE) {
       if (primaryKey && mutationField.args.length > 1) {
+        mutationFields.push(buildField(mutationField));
+      }
+    } else if (mutationAction === NodeMutation.MERGE) {
+      if (primaryKey) {
         mutationFields.push(buildField(mutationField));
       }
     } else if (mutationAction === NodeMutation.DELETE) {

--- a/src/augment/types/node/node.js
+++ b/src/augment/types/node/node.js
@@ -134,10 +134,8 @@ export const augmentNodeType = ({
     if (!isIgnoredType) {
       if (!isOperationType && !isInterfaceType && !isUnionType) {
         [propertyOutputFields, nodeInputTypeMap] = buildNeo4jSystemIDField({
-          definition,
           typeName,
           propertyOutputFields,
-          operationTypeMap,
           nodeInputTypeMap,
           config
         });

--- a/src/augment/types/node/query.js
+++ b/src/augment/types/node/query.js
@@ -17,6 +17,7 @@ import {
   TypeWrappers,
   getFieldDefinition,
   getTypeExtensionFieldDefinition,
+  isNeo4jIDField,
   Neo4jSystemIDField
 } from '../../fields';
 import {
@@ -216,11 +217,12 @@ const buildNodeQueryArguments = ({
         })
       })
     );
-    if (
-      !propertyInputValues.some(
-        field => field.name.value === Neo4jSystemIDField
-      )
-    ) {
+    const hasNeo4jIDField = propertyInputValues.some(field =>
+      isNeo4jIDField({
+        name: field.name.value
+      })
+    );
+    if (!hasNeo4jIDField) {
       propertyInputValues.push(
         buildInputValue({
           name: buildName({ name: Neo4jSystemIDField }),

--- a/src/augment/types/relationship/mutation.js
+++ b/src/augment/types/relationship/mutation.js
@@ -2,7 +2,7 @@ import { RelationshipDirectionField } from './relationship';
 import { buildNodeOutputFields } from './query';
 import { shouldAugmentRelationshipField } from '../../augment';
 import { OperationType } from '../../types/types';
-import { TypeWrappers, getFieldDefinition } from '../../fields';
+import { TypeWrappers, getFieldDefinition, isNeo4jIDField } from '../../fields';
 import {
   DirectiveDefinition,
   buildAuthScopeDirective,
@@ -322,7 +322,7 @@ const buildRelationshipMutationPropertyInputType = ({
         directives: field.directives,
         name: DirectiveDefinition.CYPHER
       });
-      return !cypherDirective;
+      return !cypherDirective && !isNeo4jIDField({ name: field.name });
     });
     const inputTypeName = `_${outputType}Input`;
     generatedTypeMap[inputTypeName] = buildInputObjectType({

--- a/src/augment/types/relationship/relationship.js
+++ b/src/augment/types/relationship/relationship.js
@@ -4,7 +4,8 @@ import {
   unwrapNamedType,
   isPropertyTypeField,
   getFieldType,
-  toSnakeCase
+  toSnakeCase,
+  buildNeo4jSystemIDField
 } from '../../fields';
 import {
   OrderingArgument,
@@ -169,7 +170,7 @@ const augmentRelationshipTypeFields = ({
     }
   };
   const propertyInputValues = [];
-  const propertyOutputFields = fields.reduce((outputFields, field) => {
+  let propertyOutputFields = fields.reduce((outputFields, field) => {
     const fieldName = field.name.value;
     const fieldDirectives = field.directives;
     if (!isIgnoredField({ directives: fieldDirectives })) {
@@ -202,6 +203,12 @@ const augmentRelationshipTypeFields = ({
     }
     return outputFields;
   }, []);
+  [propertyOutputFields, relationshipInputTypeMap] = buildNeo4jSystemIDField({
+    typeName,
+    propertyOutputFields,
+    nodeInputTypeMap: relationshipInputTypeMap,
+    config
+  });
   return [
     fromTypeName,
     toTypeName,

--- a/test/helpers/cypherTestHelpers.js
+++ b/test/helpers/cypherTestHelpers.js
@@ -26,6 +26,8 @@ type Mutation {
     UpdateMovie(movieId: ID!, title: String, year: Int, plot: String, poster: String, imdbRating: Float): Movie
     DeleteMovie(movieId: ID!): Movie
     MergeUser(userId: ID!, name: String): User
+    MergeBook(genre: BookGenre!): Book
+    MergeNodeTypeMutationTest(NodeTypeMutationTest: BookGenre!): NodeTypeMutationTest
     currentUserId: String @cypher(statement: "RETURN $cypherParams.currentUserId")
     computedObjectWithCypherParams: currentUserId @cypher(statement: "RETURN { userId: $cypherParams.currentUserId }")
     computedStringList: [String] @cypher(statement: "UNWIND ['hello', 'world'] AS stringList RETURN stringList")
@@ -63,6 +65,7 @@ type Mutation {
       Books: checkCypherQuery,
       State: checkCypherQuery,
       Camera: checkCypherQuery,
+      Person: checkCypherQuery,
       CustomCameras: checkCypherQuery,
       CustomCamera: checkCypherQuery,
       computedBoolean: checkCypherQuery,
@@ -86,6 +89,8 @@ type Mutation {
       UpdateMovie: checkCypherMutation,
       DeleteMovie: checkCypherMutation,
       MergeUser: checkCypherMutation,
+      MergeBook: checkCypherMutation,
+      MergeNodeTypeMutationTest: checkCypherMutation,
       currentUserId: checkCypherMutation,
       computedObjectWithCypherParams: checkCypherMutation,
       computedStringList: checkCypherMutation,
@@ -190,6 +195,7 @@ export function augmentedSchemaCypherTestRunner(
       State: checkCypherQuery,
       CasedType: checkCypherQuery,
       Camera: checkCypherQuery,
+      Person: checkCypherQuery,
       NewCamera: checkCypherQuery,
       CustomCameras: checkCypherQuery,
       CustomCamera: checkCypherQuery,
@@ -210,6 +216,8 @@ export function augmentedSchemaCypherTestRunner(
       CreateMovie: checkCypherMutation,
       CreateActor: checkCypherMutation,
       CreateState: checkCypherMutation,
+      MergeBook: checkCypherMutation,
+      MergeNodeTypeMutationTest: checkCypherMutation,
       CreateTemporalNode: checkCypherMutation,
       UpdateTemporalNode: checkCypherMutation,
       DeleteTemporalNode: checkCypherMutation,

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -282,6 +282,7 @@ export const testSchema = `
     extensionScalar: String
     interfacedRelationshipType: [InterfacedRelationshipType]
     reflexiveInterfacedRelationshipType: [ReflexiveInterfacedRelationshipType]    
+    _id: String
   }
 
   extend type Actor implements Person
@@ -352,6 +353,7 @@ export const testSchema = `
     localdatetime: LocalDateTime
     datetimes: [DateTime]
     location: Point
+    _id: String
     to: Movie
   }
 
@@ -366,6 +368,10 @@ export const testSchema = `
 
   type Book {
     genre: BookGenre
+  }
+  
+  type NodeTypeMutationTest {
+    NodeTypeMutationTest: BookGenre
   }
 
   """
@@ -445,6 +451,16 @@ export const testSchema = `
       orderBy: _CameraOrdering
       filter: _CameraFilter
     ): [Camera]
+    Person(
+      userId: ID
+      name: String
+      extensionScalar: String
+      _id: String
+      first: Int
+      offset: Int
+      orderBy: [_PersonOrdering]
+      filter: _PersonFilter
+    ): [Person]
     InterfaceNoScalars(
       orderBy: _InterfaceNoScalarsOrdering
     ): [InterfaceNoScalars]

--- a/test/unit/augmentSchemaTest.test.js
+++ b/test/unit/augmentSchemaTest.test.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import { parse, print, Kind, isTypeSystemExtensionNode } from 'graphql';
+import { parse, print, Kind } from 'graphql';
 import { printSchemaDocument } from '../../src/augment/augment';
 import { makeAugmentedSchema } from '../../src/index';
 import { testSchema } from '../helpers/testSchema';
@@ -12,6 +12,9 @@ test.cb('Test augmented schema', t => {
   const sourceSchema = makeAugmentedSchema({
     typeDefs: parseTypeDefs,
     config: {
+      query: {
+        exclude: ['NodeTypeMutationTest']
+      },
       auth: true
     }
   });
@@ -160,6 +163,16 @@ test.cb('Test augmented schema', t => {
         filter: _CameraFilter
         offset: Int
       ): [Camera]
+      Person(
+        userId: ID
+        name: String
+        extensionScalar: String
+        _id: String
+        first: Int
+        offset: Int
+        orderBy: [_PersonOrdering]
+        filter: _PersonFilter
+      ): [Person]
       InterfaceNoScalars(
         orderBy: _InterfaceNoScalarsOrdering
         first: Int
@@ -180,16 +193,6 @@ test.cb('Test augmented schema', t => {
         orderBy: [_GenreOrdering]
         filter: _GenreFilter
       ): [Genre] @hasScope(scopes: ["Genre: Read"])
-      Person(
-        userId: ID
-        name: String
-        extensionScalar: String
-        _id: String
-        first: Int
-        offset: Int
-        orderBy: [_PersonOrdering]
-        filter: _PersonFilter
-      ): [Person] @hasScope(scopes: ["Person: Read"])
       Actor(
         userId: ID
         name: String
@@ -525,6 +528,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _RemoveGenreInterfacedRelationshipTypePayload
@@ -547,6 +551,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _MergeGenreInterfacedRelationshipTypePayload
@@ -559,6 +564,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     input _ActorFilter {
@@ -1075,6 +1081,7 @@ test.cb('Test augmented schema', t => {
       ) {
       string: String!
       boolean: Boolean
+      _id: String
       Person: Person
     }
 
@@ -1083,6 +1090,8 @@ test.cb('Test augmented schema', t => {
       string_desc
       boolean_asc
       boolean_desc
+      _id_asc
+      _id_desc
     }
 
     input _GenreInterfacedRelationshipTypeFilter {
@@ -1191,6 +1200,7 @@ test.cb('Test augmented schema', t => {
       ) {
       string: String!
       boolean: Boolean
+      _id: String
       Genre: Genre
     }
 
@@ -1226,6 +1236,7 @@ test.cb('Test augmented schema', t => {
       localdatetime: _Neo4jLocalDateTime
       datetimes: [_Neo4jDateTime]
       location: _Neo4jPoint
+      _id: String
       User: User
     }
 
@@ -1372,6 +1383,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _RemoveUserInterfacedRelationshipTypePayload
@@ -1394,6 +1406,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _MergeUserInterfacedRelationshipTypePayload
@@ -1406,6 +1419,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _AddUserReflexiveInterfacedRelationshipTypePayload
@@ -1417,6 +1431,7 @@ test.cb('Test augmented schema', t => {
       from: Person
       to: Person
       boolean: Boolean
+      _id: String
     }
 
     type _RemoveUserReflexiveInterfacedRelationshipTypePayload
@@ -1438,6 +1453,7 @@ test.cb('Test augmented schema', t => {
       from: Person
       to: Person
       boolean: Boolean
+      _id: String
     }
 
     type _MergeUserReflexiveInterfacedRelationshipTypePayload
@@ -1449,6 +1465,7 @@ test.cb('Test augmented schema', t => {
       from: Person
       to: Person
       boolean: Boolean
+      _id: String
     }
 
     type _UserRated @relation(name: "RATED", from: "User", to: "Movie") {
@@ -1465,6 +1482,7 @@ test.cb('Test augmented schema', t => {
       localdatetime: _Neo4jLocalDateTime
       datetimes: [_Neo4jDateTime]
       location: _Neo4jPoint
+      _id: String
       Movie: Movie
     }
 
@@ -1511,6 +1529,7 @@ test.cb('Test augmented schema', t => {
       localtime: _Neo4jLocalTime
       localdatetime: _Neo4jLocalDateTime
       location: _Neo4jPoint
+      _id: String
       User: User
     }
 
@@ -1575,6 +1594,14 @@ test.cb('Test augmented schema', t => {
     type Book {
       genre: BookGenre
       _id: String
+    }
+
+    type NodeTypeMutationTest {
+      NodeTypeMutationTest: BookGenre
+    }
+
+    input _NodeTypeMutationTestInput {
+      NodeTypeMutationTest: BookGenre!
     }
 
     type currentUserId {
@@ -2513,8 +2540,10 @@ test.cb('Test augmented schema', t => {
         @hasScope(scopes: ["Person: Merge", "Genre: Merge"])
       CreateGenre(name: String): Genre @hasScope(scopes: ["Genre: Create"])
       DeleteGenre(name: String!): Genre @hasScope(scopes: ["Genre: Delete"])
+      MergeGenre(name: String!): Genre @hasScope(scopes: ["Genre: Merge"])
       CreateState(name: String!): State @hasScope(scopes: ["State: Create"])
       DeleteState(name: String!): State @hasScope(scopes: ["State: Delete"])
+      MergeState(name: String!): State @hasScope(scopes: ["State: Merge"])
       AddPersonInterfacedRelationshipType(
         from: _PersonInput!
         to: _GenreInput!
@@ -2897,10 +2926,24 @@ test.cb('Test augmented schema', t => {
         @hasScope(scopes: ["User: Merge"])
       CreateBook(genre: BookGenre): Book @hasScope(scopes: ["Book: Create"])
       DeleteBook(genre: BookGenre!): Book @hasScope(scopes: ["Book: Delete"])
+      MergeBook(genre: BookGenre!): Book @hasScope(scopes: ["Book: Merge"])
+      CreateNodeTypeMutationTest(
+        NodeTypeMutationTest: BookGenre
+      ): NodeTypeMutationTest
+        @hasScope(scopes: ["NodeTypeMutationTest: Create"])
+      DeleteNodeTypeMutationTest(
+        NodeTypeMutationTest: BookGenre!
+      ): NodeTypeMutationTest
+        @hasScope(scopes: ["NodeTypeMutationTest: Delete"])
+      MergeNodeTypeMutationTest(
+        NodeTypeMutationTest: BookGenre!
+      ): NodeTypeMutationTest @hasScope(scopes: ["NodeTypeMutationTest: Merge"])
       CreatecurrentUserId(userId: String): currentUserId
         @hasScope(scopes: ["currentUserId: Create"])
       DeletecurrentUserId(userId: String!): currentUserId
         @hasScope(scopes: ["currentUserId: Delete"])
+      MergecurrentUserId(userId: String!): currentUserId
+        @hasScope(scopes: ["currentUserId: Merge"])
       AddTemporalNodeTemporalNodes(
         from: _TemporalNodeInput!
         to: _TemporalNodeInput!
@@ -3020,6 +3063,8 @@ test.cb('Test augmented schema', t => {
         @hasScope(scopes: ["CasedType: Create"])
       DeleteCasedType(name: String!): CasedType
         @hasScope(scopes: ["CasedType: Delete"])
+      MergeCasedType(name: String!): CasedType
+        @hasScope(scopes: ["CasedType: Merge"])
       AddCameraOperators(
         from: _PersonInput!
         to: _CameraInput!
@@ -3512,6 +3557,7 @@ test.cb('Test augmented schema', t => {
       localdatetime: _Neo4jLocalDateTime
       datetimes: [_Neo4jDateTime]
       location: _Neo4jPoint
+      _id: String
     }
 
     type _RemoveMovieRatingsPayload
@@ -3537,6 +3583,7 @@ test.cb('Test augmented schema', t => {
       localdatetime: _Neo4jLocalDateTime
       datetimes: [_Neo4jDateTime]
       location: _Neo4jPoint
+      _id: String
     }
 
     type _MergeMovieRatingsPayload
@@ -3556,6 +3603,7 @@ test.cb('Test augmented schema', t => {
       localdatetime: _Neo4jLocalDateTime
       datetimes: [_Neo4jDateTime]
       location: _Neo4jPoint
+      _id: String
     }
 
     type _AddGenreMoviesPayload
@@ -3628,6 +3676,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _RemoveActorInterfacedRelationshipTypePayload
@@ -3650,6 +3699,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _MergeActorInterfacedRelationshipTypePayload
@@ -3662,6 +3712,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _AddActorReflexiveInterfacedRelationshipTypePayload
@@ -3673,6 +3724,7 @@ test.cb('Test augmented schema', t => {
       from: Person
       to: Person
       boolean: Boolean
+      _id: String
     }
 
     type _RemoveActorReflexiveInterfacedRelationshipTypePayload
@@ -3694,6 +3746,7 @@ test.cb('Test augmented schema', t => {
       from: Person
       to: Person
       boolean: Boolean
+      _id: String
     }
 
     type _MergeActorReflexiveInterfacedRelationshipTypePayload
@@ -3705,6 +3758,7 @@ test.cb('Test augmented schema', t => {
       from: Person
       to: Person
       boolean: Boolean
+      _id: String
     }
 
     type _RemoveActorKnowsPayload
@@ -3728,6 +3782,8 @@ test.cb('Test augmented schema', t => {
       localtime_desc
       localdatetime_asc
       localdatetime_desc
+      _id_asc
+      _id_desc
     }
 
     type _AddUserRatedPayload
@@ -3747,6 +3803,7 @@ test.cb('Test augmented schema', t => {
       localdatetime: _Neo4jLocalDateTime
       datetimes: [_Neo4jDateTime]
       location: _Neo4jPoint
+      _id: String
     }
 
     type _RemoveUserRatedPayload
@@ -3772,6 +3829,7 @@ test.cb('Test augmented schema', t => {
       localdatetime: _Neo4jLocalDateTime
       datetimes: [_Neo4jDateTime]
       location: _Neo4jPoint
+      _id: String
     }
 
     type _MergeUserRatedPayload
@@ -3791,6 +3849,7 @@ test.cb('Test augmented schema', t => {
       localdatetime: _Neo4jLocalDateTime
       datetimes: [_Neo4jDateTime]
       location: _Neo4jPoint
+      _id: String
     }
 
     enum _FriendOfOrdering {
@@ -3808,6 +3867,8 @@ test.cb('Test augmented schema', t => {
       localtime_desc
       localdatetime_asc
       localdatetime_desc
+      _id_asc
+      _id_desc
     }
 
     input _FriendOfInput {
@@ -3837,6 +3898,7 @@ test.cb('Test augmented schema', t => {
       localtime: _Neo4jLocalTime
       localdatetime: _Neo4jLocalDateTime
       location: _Neo4jPoint
+      _id: String
     }
 
     type _RemoveUserFriendsPayload
@@ -3861,6 +3923,7 @@ test.cb('Test augmented schema', t => {
       localtime: _Neo4jLocalTime
       localdatetime: _Neo4jLocalDateTime
       location: _Neo4jPoint
+      _id: String
     }
 
     type _MergeUserFriendsPayload
@@ -3879,6 +3942,7 @@ test.cb('Test augmented schema', t => {
       localtime: _Neo4jLocalTime
       localdatetime: _Neo4jLocalDateTime
       location: _Neo4jPoint
+      _id: String
     }
 
     type _AddUserFavoritesPayload
@@ -3975,6 +4039,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _RemoveCameraManInterfacedRelationshipTypePayload
@@ -3997,6 +4062,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _MergeCameraManInterfacedRelationshipTypePayload
@@ -4009,6 +4075,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _AddCameraManReflexiveInterfacedRelationshipTypePayload
@@ -4020,6 +4087,7 @@ test.cb('Test augmented schema', t => {
       from: Person
       to: Person
       boolean: Boolean
+      _id: String
     }
 
     type _RemoveCameraManReflexiveInterfacedRelationshipTypePayload
@@ -4041,6 +4109,7 @@ test.cb('Test augmented schema', t => {
       from: Person
       to: Person
       boolean: Boolean
+      _id: String
     }
 
     type _MergeCameraManReflexiveInterfacedRelationshipTypePayload
@@ -4052,6 +4121,7 @@ test.cb('Test augmented schema', t => {
       from: Person
       to: Person
       boolean: Boolean
+      _id: String
     }
 
     input _CameraManInput {
@@ -4149,6 +4219,8 @@ test.cb('Test augmented schema', t => {
       string_desc
       boolean_asc
       boolean_desc
+      _id_asc
+      _id_desc
     }
 
     type _AddPersonInterfacedRelationshipTypePayload
@@ -4161,6 +4233,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _RemovePersonInterfacedRelationshipTypePayload
@@ -4183,6 +4256,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
 
     type _MergePersonInterfacedRelationshipTypePayload
@@ -4195,6 +4269,7 @@ test.cb('Test augmented schema', t => {
       to: Genre
       string: String!
       boolean: Boolean
+      _id: String
     }
     type _PersonReflexiveInterfacedRelationshipTypeDirections
       @relation(
@@ -4223,6 +4298,7 @@ test.cb('Test augmented schema', t => {
         to: "Person"
       ) {
       boolean: Boolean
+      _id: String
       Person: Person
     }
 
@@ -4234,6 +4310,8 @@ test.cb('Test augmented schema', t => {
     enum _ReflexiveInterfacedRelationshipTypeOrdering {
       boolean_asc
       boolean_desc
+      _id_asc
+      _id_desc
     }
 
     input _ReflexiveInterfacedRelationshipTypeFilter {
@@ -4257,6 +4335,7 @@ test.cb('Test augmented schema', t => {
       from: Person
       to: Person
       boolean: Boolean
+      _id: String
     }
 
     type _RemovePersonReflexiveInterfacedRelationshipTypePayload
@@ -4278,6 +4357,7 @@ test.cb('Test augmented schema', t => {
       from: Person
       to: Person
       boolean: Boolean
+      _id: String
     }
 
     type _MergePersonReflexiveInterfacedRelationshipTypePayload
@@ -4289,6 +4369,7 @@ test.cb('Test augmented schema', t => {
       from: Person
       to: Person
       boolean: Boolean
+      _id: String
     }
 
     input _PersonInput {
@@ -4349,6 +4430,7 @@ test.cb('Test augmented schema', t => {
       localdatetime: _Neo4jLocalDateTime
       datetimes: [_Neo4jDateTime]
       location: _Neo4jPoint
+      _id: String
       to: Movie
     }
 


### PR DESCRIPTION
#### Query API

* **Fragments**<br><br>
  * Fixes #429 - Invalid input in generated query when using inline fragments inside fragments<br>
    When querying an interface type, a fragment can now be used on that same interface type:
    * [query only interface type fields using fragments](https://github.com/michaeldgraham/neo4j-graphql-js/blob/dbab3302dfec5ed2afffb72e51bfd86a95cb77cf/test/unit/cypherTest.test.js#L6905)
    * [query fields on interface and implementing object type using only fragments](https://github.com/michaeldgraham/neo4j-graphql-js/blob/dbab3302dfec5ed2afffb72e51bfd86a95cb77cf/test/unit/cypherTest.test.js#L6938)
    * [query fields on interface and implementing object types using only fragments](https://github.com/michaeldgraham/neo4j-graphql-js/blob/dbab3302dfec5ed2afffb72e51bfd86a95cb77cf/test/unit/cypherTest.test.js#L6971)<br><br>
  * Fixes #406 - Regression in v2.13.0<br>
    When querying an object type, a fragment can now be used on an interface implemented by that object:<br>
    * [query fields on object type using inline fragment on implemented interface](https://github.com/michaeldgraham/neo4j-graphql-js/blob/dbab3302dfec5ed2afffb72e51bfd86a95cb77cf/test/unit/cypherTest.test.js#L7006)
    * [query fields on object type using only fragments on implemented interface](https://github.com/michaeldgraham/neo4j-graphql-js/blob/dbab3302dfec5ed2afffb72e51bfd86a95cb77cf/test/unit/cypherTest.test.js#L7033)
<br>

* **Relationship Types**<br><br>
  * Fixes #234 - Errors adding _id to `@relation` types<br>
    When using relationship types, the Neo4j internal ID is now generated and translated appropriately. Corresponding `_id_asc` and `_id_desc` values are also generated for the relationship type's ordering enum. Because it is not recommended for unique selection, relationship field arguments are _not_ generated for the `_id` field.
    * [query for relationship internal ID](https://github.com/michaeldgraham/neo4j-graphql-js/blob/dbab3302dfec5ed2afffb72e51bfd86a95cb77cf/test/unit/cypherTest.test.js#L498)
    * [query for interfaced relationship internal ID](https://github.com/michaeldgraham/neo4j-graphql-js/blob/dbab3302dfec5ed2afffb72e51bfd86a95cb77cf/test/unit/cypherTest.test.js#L522)
    * [query relationship properties and order by internal ID](https://github.com/michaeldgraham/neo4j-graphql-js/blob/dbab3302dfec5ed2afffb72e51bfd86a95cb77cf/test/unit/cypherTest.test.js#L2513)<br><br>

  * Fixes #490 - Error when schema contains array of properties on relationship,br><br>
    This issue occurred during augmentation, when generating the `orderBy` field argument and enum type for a relationship type that does not have at least one non-list scalar field. There is currently no support for for ordering list type scalar fields or relationship fields, so in such a case an ordering enum and its field argument should not be generated. Although the enum type was not being generated, corresponding field arguments on the given relationship field were, resulting in the error noted in the issue. It is also generally prevented by the fix for #234, given that relationship types will now have at least an `_id` field, and so at least `_id_asc` and `_id_desc` ordering fields. Until current behavior changes, the `propertyFieldExists` function in `fields.js` has been updated to directly fix this issue.

#### Mutation API

* **Merge**<br><br>
  * Fixes #440 - Not getting Merge Mutations from makeAugmentedSchema<br>
    Merge node mutations are now generated even when the type does not have at least 1 field that could be updated. The generation of these mutations was inappropriately prevented, requiring there to be at least 1 field to be used in the case of property updates. 
    * [Merge node mutation using only primary key](https://github.com/michaeldgraham/neo4j-graphql-js/blob/dbab3302dfec5ed2afffb72e51bfd86a95cb77cf/test/unit/cypherTest.test.js#L753)<br><br>

  * Fixes #382 - MergeMyType(MyType: $example) isn´t working<br>
    This is currently working, so this test has been added to demonstrate the translation:
    * [Merge node mutation using argument for field with the same name as merged type](https://github.com/michaeldgraham/neo4j-graphql-js/blob/dbab3302dfec5ed2afffb72e51bfd86a95cb77cf/test/unit/cypherTest.test.js#L784)