### PR TITLE
Field arguments and filters for list type fields

### DIFF
--- a/src/augment/augment.js
+++ b/src/augment/augment.js
@@ -18,6 +18,7 @@ import {
 import { augmentDirectiveDefinitions } from './directives';
 import { extractResolversFromSchema, augmentResolvers } from './resolvers';
 import { addAuthDirectiveImplementations } from '../auth';
+
 /**
  * The main export for augmenting an SDL document
  */

--- a/src/augment/directives.js
+++ b/src/augment/directives.js
@@ -519,3 +519,30 @@ export const getDirectiveArgument = ({ directive, name }) => {
   }
   return value;
 };
+
+export const augmentDirectives = ({ directives = [] }) => {
+  let cypherDirective = getDirective({
+    directives,
+    name: DirectiveDefinition.CYPHER
+  });
+  if (cypherDirective) {
+    cypherDirective = escapeCypherStatement({
+      directive: cypherDirective
+    });
+  }
+  return directives;
+};
+
+const escapeCypherStatement = ({ directive }) => {
+  const arg = directive.arguments.find(arg => arg.name.value === 'statement');
+  if (arg) {
+    const value = arg.value;
+    if (value && value.kind === Kind.STRING && value.block) {
+      // Negative lookbehind assertion regex
+      const unescapedDoubleQuotes = /(?<!\\)"/g;
+      const escaped = value.value.replace(unescapedDoubleQuotes, '\\"');
+      arg.value.value = escaped;
+    }
+  }
+  return directive;
+};

--- a/src/augment/fields.js
+++ b/src/augment/fields.js
@@ -70,25 +70,15 @@ export const TypeWrappers = {
 };
 
 /**
- * Predicate function identifying whether a GraphQL NamedType
- * contained in a type was wrapped with a NonNullType wrapper
- */
-export const isNonNullNamedTypeField = ({ wrappers = {} }) =>
-  wrappers[TypeWrappers.NON_NULL_NAMED_TYPE];
-
-/**
  * Predicate function identifying whether a type was wrapped
  * with a GraphQL ListType wrapper
  */
-export const isListTypeField = ({ wrappers = {} }) =>
-  wrappers[TypeWrappers.LIST_TYPE];
-
-/**
- * Predicate function identifying whether a GraphQL ListType
- * contained in a type was wrapped with a NonNullType wrapper
- */
-export const isNonNullListTypeField = ({ wrappers = {} }) =>
-  wrappers[TypeWrappers.NON_NULL_LIST_TYPE];
+export const isListTypeField = ({ field = {} }) => {
+  const type = field.type;
+  const unwrappedType = unwrapNamedType({ type });
+  const typeWrappers = unwrappedType.wrappers;
+  return typeWrappers[TypeWrappers.LIST_TYPE];
+};
 
 /**
  * A helper function that reduces the type wrappers of a given type

--- a/src/augment/types/relationship/query.js
+++ b/src/augment/types/relationship/query.js
@@ -40,6 +40,7 @@ const RelationshipQueryArgument = {
 export const augmentRelationshipQueryAPI = ({
   typeName,
   definition,
+  field,
   fieldArguments,
   fieldName,
   outputType,
@@ -50,7 +51,6 @@ export const augmentRelationshipQueryAPI = ({
   generatedTypeMap,
   nodeInputTypeMap,
   relationshipInputTypeMap,
-  outputTypeWrappers,
   config,
   relationshipName,
   fieldType,
@@ -76,6 +76,7 @@ export const augmentRelationshipQueryAPI = ({
     });
     [fieldType, generatedTypeMap] = transformRelationshipTypeFieldOutput({
       typeName,
+      field,
       relatedType,
       fieldArguments,
       fieldName,
@@ -84,7 +85,6 @@ export const augmentRelationshipQueryAPI = ({
       toType,
       typeDefinitionMap,
       generatedTypeMap,
-      outputTypeWrappers,
       config,
       relationshipName,
       fieldType,
@@ -96,6 +96,8 @@ export const augmentRelationshipQueryAPI = ({
       nodeInputTypeMap
     ] = augmentRelationshipTypeFieldInput({
       typeName,
+      definition,
+      field,
       relatedType,
       fieldArguments,
       fieldName,
@@ -108,7 +110,6 @@ export const augmentRelationshipQueryAPI = ({
       generatedTypeMap,
       nodeInputTypeMap,
       relationshipInputTypeMap,
-      outputTypeWrappers,
       config
     });
   }
@@ -166,6 +167,8 @@ const getTypeDefiningField = ({
  * for the given field of the given relationship type
  */
 const augmentRelationshipTypeFieldInput = ({
+  definition,
+  field,
   typeName,
   relatedType,
   fieldArguments,
@@ -179,7 +182,6 @@ const augmentRelationshipTypeFieldInput = ({
   generatedTypeMap,
   nodeInputTypeMap,
   relationshipInputTypeMap,
-  outputTypeWrappers,
   config
 }) => {
   if (
@@ -203,14 +205,15 @@ const augmentRelationshipTypeFieldInput = ({
     nodeInputTypeMap[FilteringArgument.FILTER].fields.push(
       ...buildRelationshipFilters({
         typeName,
+        field,
         fieldName,
         outputType: `${relationshipFilterTypeName}Filter`,
         relatedType: outputType,
-        outputTypeWrappers,
         config
       })
     );
     [fieldArguments, generatedTypeMap] = augmentRelationshipTypeFieldArguments({
+      field,
       fieldArguments,
       typeName,
       fromType,
@@ -219,7 +222,6 @@ const augmentRelationshipTypeFieldInput = ({
       outputType,
       relatedType,
       relationshipFilterTypeName,
-      outputTypeWrappers,
       typeDefinitionMap,
       generatedTypeMap,
       relationshipInputTypeMap
@@ -234,6 +236,7 @@ const augmentRelationshipTypeFieldInput = ({
  */
 const augmentRelationshipTypeFieldArguments = ({
   fieldArguments,
+  field,
   typeName,
   fromType,
   toType,
@@ -241,18 +244,17 @@ const augmentRelationshipTypeFieldArguments = ({
   outputType,
   relatedType,
   relationshipFilterTypeName,
-  outputTypeWrappers,
   typeDefinitionMap,
   generatedTypeMap,
   relationshipInputTypeMap
 }) => {
   if (fromType !== toType) {
     fieldArguments = buildQueryFieldArguments({
+      field,
       argumentMap: RelationshipQueryArgument,
       fieldArguments,
       typeName,
       outputType,
-      outputTypeWrappers,
       typeDefinitionMap
     });
   } else {
@@ -283,6 +285,7 @@ const augmentRelationshipTypeFieldArguments = ({
  */
 const transformRelationshipTypeFieldOutput = ({
   typeName,
+  field,
   relatedType,
   fieldArguments,
   fieldName,
@@ -291,7 +294,6 @@ const transformRelationshipTypeFieldOutput = ({
   toType,
   typeDefinitionMap,
   generatedTypeMap,
-  outputTypeWrappers,
   relationshipName,
   fieldType,
   propertyOutputFields
@@ -310,10 +312,10 @@ const transformRelationshipTypeFieldOutput = ({
     fieldType = buildNamedType(unwrappedType);
   }
   generatedTypeMap = buildRelationshipFieldOutputTypes({
+    field,
     outputType,
     fromType,
     toType,
-    outputTypeWrappers,
     fieldArguments,
     relationshipOutputName,
     relationshipName,
@@ -331,10 +333,10 @@ const transformRelationshipTypeFieldOutput = ({
  */
 export const buildRelationshipFilters = ({
   typeName,
+  field,
   fieldName,
   outputType,
   relatedType,
-  outputTypeWrappers,
   config
 }) => {
   let filters = [];
@@ -347,7 +349,7 @@ export const buildRelationshipFilters = ({
       relatedType
     )
   ) {
-    if (isListTypeField({ wrappers: outputTypeWrappers })) {
+    if (isListTypeField({ field })) {
       filters = buildFilters({
         fieldName,
         fieldConfig: {
@@ -414,10 +416,10 @@ export const buildNodeOutputFields = ({
  * for querying relationship type fields on node types
  */
 const buildRelationshipFieldOutputTypes = ({
+  field,
   outputType,
   fromType,
   toType,
-  outputTypeWrappers,
   fieldArguments,
   relationshipOutputName,
   relationshipName,
@@ -433,10 +435,10 @@ const buildRelationshipFieldOutputTypes = ({
   });
   if (fromType === toType) {
     fieldArguments = buildQueryFieldArguments({
+      field,
       argumentMap: RelationshipQueryArgument,
       fieldArguments,
       outputType,
-      outputTypeWrappers,
       typeDefinitionMap
     });
     const reflexiveOutputName = `${relationshipOutputName}Directions`;

--- a/src/schemaAssert.js
+++ b/src/schemaAssert.js
@@ -71,9 +71,8 @@ const cypherMap = ({ typeMap = {} }) => {
   const cypherMapFormat = Object.entries(typeMap).map(([typeName, astNode]) => {
     const fields = astNode.fields || [];
     const fieldNames = fields.map(field => field.name.value);
-    return `${typeName}:${cypherList({ values: fieldNames })}`;
+    const assertions = JSON.stringify(fieldNames);
+    return `${typeName}:${assertions}`;
   });
   return `{${cypherMapFormat}}`;
 };
-
-const cypherList = ({ values = [] }) => JSON.stringify(values);

--- a/src/selections.js
+++ b/src/selections.js
@@ -229,12 +229,6 @@ export function buildCypherSelection({
     const fieldType =
       schemaTypeField && schemaTypeField.type ? schemaTypeField.type : {};
     const innerSchemaType = innerType(fieldType); // for target "type" aka label
-
-    // TODO Switch to using schemaTypeField.astNode instead of schemaTypeField
-    // so the field type could be extracted using unwrapNamedType. We could explicitly check
-    // the ast for list type wrappers (changing isArrayType calls in translate.js) and we
-    // could use in the branching logic here, the same astNode.kind based predicate functions
-    // used in the  augmentation code (ex: from isObjectType to isObjectTypeDefinition from ast.js)
     const fieldAstNode = schemaTypeField ? schemaTypeField.astNode : {};
     const fieldTypeWrappers = unwrapNamedType({ type: fieldAstNode });
     const fieldTypeName = fieldTypeWrappers[TypeWrappers.NAME];
@@ -337,9 +331,6 @@ export function buildCypherSelection({
           ? schemaTypeField.args.map(e => e.astNode)
           : [];
       const neo4jTypeArgs = getNeo4jTypeArguments(fieldArgs);
-      const queryParams = paramsToString(
-        innerFilterParams(filterParams, neo4jTypeArgs)
-      );
       const skipLimit = computeSkipLimit(
         headSelection,
         resolveInfo.variableValues
@@ -460,7 +451,6 @@ export function buildCypherSelection({
           fieldType,
           variableName,
           nestedVariable,
-          queryParams,
           subSelection,
           skipLimit,
           commaIfTail,
@@ -502,7 +492,6 @@ export function buildCypherSelection({
           schemaType,
           innerSchemaType,
           nestedVariable,
-          queryParams,
           filterParams,
           neo4jTypeArgs,
           resolveInfo,

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -42,6 +42,8 @@ export const testSchema = `
       offset: Int = 0
       name: String
       names: [String]
+      strings: [String]
+      datetimes: [DateTime]
     ): [Actor] @relation(name: "ACTED_IN", direction: "IN")
     avgStars: Float
     filmedIn: State @relation(name: "FILMED_IN", direction: "OUT")
@@ -64,12 +66,16 @@ export const testSchema = `
       localtime: LocalTime
       localdatetime: LocalDateTime
       location: Point
+      ratings: [Int]
+      datetimes: [DateTime]
     ): [Rated]
     years: [Int]
     titles: [String]
     imdbRatings: [Float]
     "Temporal type field line description"
     releases: [DateTime]
+    booleans: [Boolean]
+    enums: [BookGenre]
     "Ignored field line description"
     customField: String @neo4j_ignore
   }
@@ -281,6 +287,8 @@ export const testSchema = `
     movies: [Movie] @relation(name: "ACTED_IN", direction: "OUT")
     knows: [Person] @relation(name: "KNOWS", direction: "OUT")
     extensionScalar: String
+    datetimes: [DateTime]
+    strings: [String]
     interfacedRelationshipType: [InterfacedRelationshipType]
     reflexiveInterfacedRelationshipType: [ReflexiveInterfacedRelationshipType]    
     _id: String
@@ -314,6 +322,8 @@ export const testSchema = `
       localtime: LocalTime
       localdatetime: LocalDateTime
       location: Point
+      ratings: [String]
+      datetimes: [DateTime]  
     ): [FriendOf]
     favorites: [Movie] @relation(name: "FAVORITED", direction: "OUT")
     movieSearch: [MovieSearch]
@@ -332,6 +342,7 @@ export const testSchema = `
     time: Time
     date: Date
     datetime: DateTime
+    ratings: [String]
     datetimes: [DateTime]
     localtime: LocalTime
     localdatetime: LocalDateTime
@@ -386,38 +397,20 @@ export const testSchema = `
   
   "Query type line description"
   type QueryA {
-    "Object type query field line description"
-    Movie(
-      _id: String
-      "Query field argument line description"
-      movieId: ID
-      """
-      Query field argument
-      block description
-      """
-      title: String
-      year: Int
-      released: DateTime
-      plot: String
-      poster: String
-      imdbRating: Float
-      location: Point
-      first: Int
-      offset: Int
-    ): [Movie]
     """
     Query field
     block
     description
     """
     MoviesByYear(year: Int): [Movie]
-    MoviesByYears(year: [Int]): [Movie]
+    MoviesByYears(year: [Int], released: [DateTime]): [Movie]
     MovieById(movieId: ID!): Movie
     MovieBy_Id(_id: String!): Movie
     GenresBySubstring(substring: String): [Genre]
       @cypher(
         statement: "MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g"
       )
+    "Object type query field line description"
     State: [State]
     User(userId: ID, name: String, _id: String): [User]
     Books: [Book]
@@ -511,6 +504,15 @@ export const testSchema = `
     testPublish: Boolean @neo4j_ignore
     computedMovieSearch: [MovieSearch]
       @cypher(statement: "MATCH (ms:MovieSearch) RETURN ms")
+    customCreateNode(
+      integer: Int
+      datetime: DateTime
+      integers: [Int]
+      datetimes: [DateTime]
+      point: Point
+      points: [Point]
+    ): Boolean
+      @cypher(statement: "CREATE (n:Node { integer: $integer, datetime: datetime($datetime), point: point($point), integers: $integers, datetimes: [value IN $datetimes | datetime(value)], points: [value IN $points | point(value)] }) RETURN TRUE")  
   }
 
   extend type Mutation {

--- a/test/unit/augmentSchemaTest.test.js
+++ b/test/unit/augmentSchemaTest.test.js
@@ -58,27 +58,6 @@ test.cb('Test augmented schema', t => {
 
     "Query type line description"
     type QueryA {
-      "Object type query field line description"
-      Movie(
-        _id: String
-        "Query field argument line description"
-        movieId: ID
-        """
-        Query field argument
-        block description
-        """
-        title: String
-        year: Int
-        released: _Neo4jDateTimeInput
-        plot: String
-        poster: String
-        imdbRating: Float
-        location: _Neo4jPointInput
-        first: Int
-        offset: Int
-        orderBy: [_MovieOrdering]
-        filter: _MovieFilter
-      ): [Movie]
       """
       Query field
       block
@@ -93,6 +72,7 @@ test.cb('Test augmented schema', t => {
       ): [Movie]
       MoviesByYears(
         year: [Int]
+        released: [_Neo4jDateTimeInput]
         first: Int
         offset: Int
         orderBy: [_MovieOrdering]
@@ -109,6 +89,7 @@ test.cb('Test augmented schema', t => {
         @cypher(
           statement: "MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g"
         )
+      "Object type query field line description"
       State(
         first: Int
         offset: Int
@@ -191,6 +172,31 @@ test.cb('Test augmented schema', t => {
         orderBy: [_CameraOrdering]
       ): [Camera] @cypher(statement: "MATCH (c:Camera) RETURN c")
       CustomCamera: Camera @cypher(statement: "MATCH (c:Camera) RETURN c")
+      Movie(
+        _id: String
+        movieId: ID
+        title: String
+        someprefix_title_with_underscores: String
+        year: Int
+        released: _Neo4jDateTimeInput
+        plot: String
+        poster: String
+        imdbRating: Float
+        avgStars: Float
+        location: _Neo4jPointInput
+        locations: [_Neo4jPointInput]
+        years: [Int]
+        titles: [String]
+        imdbRatings: [Float]
+        releases: [_Neo4jDateTimeInput]
+        booleans: [Boolean]
+        enums: [BookGenre]
+        extensionScalar: String
+        first: Int
+        offset: Int
+        orderBy: [_MovieOrdering]
+        filter: _MovieFilter
+      ): [Movie] @hasScope(scopes: ["Movie: Read", "read:movie"])
       Genre(
         _id: String
         name: String
@@ -203,6 +209,8 @@ test.cb('Test augmented schema', t => {
         userId: ID
         name: String
         extensionScalar: String
+        datetimes: [_Neo4jDateTimeInput]
+        strings: [String]
         _id: String
         first: Int
         offset: Int
@@ -224,8 +232,7 @@ test.cb('Test augmented schema', t => {
         date: _Neo4jDateInput
         localtime: _Neo4jLocalTimeInput
         localdatetime: _Neo4jLocalDateTimeInput
-        localdatetimes: _Neo4jLocalDateTimeInput
-        computedTimestamp: String
+        localdatetimes: [_Neo4jLocalDateTimeInput]
         _id: String
         first: Int
         offset: Int
@@ -260,7 +267,7 @@ test.cb('Test augmented schema', t => {
         id: ID
         make: String
         weight: Int
-        features: String
+        features: [String]
         _id: String
         first: Int
         offset: Int
@@ -464,6 +471,13 @@ test.cb('Test augmented schema', t => {
       location_distance_lte: _Neo4jPointDistanceFilter
       location_distance_gt: _Neo4jPointDistanceFilter
       location_distance_gte: _Neo4jPointDistanceFilter
+      locations: [_Neo4jPointInput!]
+      locations_not: [_Neo4jPointInput!]
+      locations_distance: [_Neo4jPointDistanceFilter!]
+      locations_distance_lt: [_Neo4jPointDistanceFilter!]
+      locations_distance_lte: [_Neo4jPointDistanceFilter!]
+      locations_distance_gt: [_Neo4jPointDistanceFilter!]
+      locations_distance_gte: [_Neo4jPointDistanceFilter!]
       ratings: _MovieRatedFilter
       ratings_not: _MovieRatedFilter
       ratings_in: [_MovieRatedFilter!]
@@ -472,6 +486,36 @@ test.cb('Test augmented schema', t => {
       ratings_none: _MovieRatedFilter
       ratings_single: _MovieRatedFilter
       ratings_every: _MovieRatedFilter
+      years: [Int!]
+      years_not: [Int!]
+      years_lt: [Int!]
+      years_lte: [Int!]
+      years_gt: [Int!]
+      years_gte: [Int!]
+      titles: [String!]
+      titles_not: [String!]
+      titles_contains: [String!]
+      titles_not_contains: [String!]
+      titles_starts_with: [String!]
+      titles_not_starts_with: [String!]
+      titles_ends_with: [String!]
+      titles_not_ends_with: [String!]
+      imdbRatings: [Float!]
+      imdbRatings_not: [Float!]
+      imdbRatings_lt: [Float!]
+      imdbRatings_lte: [Float!]
+      imdbRatings_gt: [Float!]
+      imdbRatings_gte: [Float!]
+      releases: [_Neo4jDateTimeInput!]
+      releases_not: [_Neo4jDateTimeInput!]
+      releases_lt: [_Neo4jDateTimeInput!]
+      releases_lte: [_Neo4jDateTimeInput!]
+      releases_gt: [_Neo4jDateTimeInput!]
+      releases_gte: [_Neo4jDateTimeInput!]
+      booleans: [Boolean!]
+      booleans_not: [Boolean!]
+      enums: [BookGenre!]
+      enums_not: [BookGenre!]
       interfaceNoScalars: _InterfaceNoScalarsFilter
       interfaceNoScalars_not: _InterfaceNoScalarsFilter
       interfaceNoScalars_in: [_InterfaceNoScalarsFilter!]
@@ -644,6 +688,20 @@ test.cb('Test augmented schema', t => {
       extensionScalar_not_starts_with: String
       extensionScalar_ends_with: String
       extensionScalar_not_ends_with: String
+      datetimes: [_Neo4jDateTimeInput!]
+      datetimes_not: [_Neo4jDateTimeInput!]
+      datetimes_lt: [_Neo4jDateTimeInput!]
+      datetimes_lte: [_Neo4jDateTimeInput!]
+      datetimes_gt: [_Neo4jDateTimeInput!]
+      datetimes_gte: [_Neo4jDateTimeInput!]
+      strings: [String!]
+      strings_not: [String!]
+      strings_contains: [String!]
+      strings_not_contains: [String!]
+      strings_starts_with: [String!]
+      strings_not_starts_with: [String!]
+      strings_ends_with: [String!]
+      strings_not_ends_with: [String!]
       interfacedRelationshipType: _PersonInterfacedRelationshipTypeFilter
       interfacedRelationshipType_not: _PersonInterfacedRelationshipTypeFilter
       interfacedRelationshipType_in: [_PersonInterfacedRelationshipTypeFilter!]
@@ -698,6 +756,12 @@ test.cb('Test augmented schema', t => {
       rating_lte: Int
       rating_gt: Int
       rating_gte: Int
+      ratings: [Int!]
+      ratings_not: [Int!]
+      ratings_lt: [Int!]
+      ratings_lte: [Int!]
+      ratings_gt: [Int!]
+      ratings_gte: [Int!]
       time: _Neo4jTimeInput
       time_not: _Neo4jTimeInput
       time_in: [_Neo4jTimeInput!]
@@ -738,6 +802,12 @@ test.cb('Test augmented schema', t => {
       localdatetime_lte: _Neo4jLocalDateTimeInput
       localdatetime_gt: _Neo4jLocalDateTimeInput
       localdatetime_gte: _Neo4jLocalDateTimeInput
+      datetimes: [_Neo4jDateTimeInput!]
+      datetimes_not: [_Neo4jDateTimeInput!]
+      datetimes_lt: [_Neo4jDateTimeInput!]
+      datetimes_lte: [_Neo4jDateTimeInput!]
+      datetimes_gt: [_Neo4jDateTimeInput!]
+      datetimes_gte: [_Neo4jDateTimeInput!]
       location: _Neo4jPointInput
       location_not: _Neo4jPointInput
       location_distance: _Neo4jPointDistanceFilter
@@ -834,6 +904,12 @@ test.cb('Test augmented schema', t => {
       rating_lte: Int
       rating_gt: Int
       rating_gte: Int
+      ratings: [Int!]
+      ratings_not: [Int!]
+      ratings_lt: [Int!]
+      ratings_lte: [Int!]
+      ratings_gt: [Int!]
+      ratings_gte: [Int!]
       time: _Neo4jTimeInput
       time_not: _Neo4jTimeInput
       time_in: [_Neo4jTimeInput!]
@@ -874,6 +950,12 @@ test.cb('Test augmented schema', t => {
       localdatetime_lte: _Neo4jLocalDateTimeInput
       localdatetime_gt: _Neo4jLocalDateTimeInput
       localdatetime_gte: _Neo4jLocalDateTimeInput
+      datetimes: [_Neo4jDateTimeInput!]
+      datetimes_not: [_Neo4jDateTimeInput!]
+      datetimes_lt: [_Neo4jDateTimeInput!]
+      datetimes_lte: [_Neo4jDateTimeInput!]
+      datetimes_gt: [_Neo4jDateTimeInput!]
+      datetimes_gte: [_Neo4jDateTimeInput!]
       location: _Neo4jPointInput
       location_not: _Neo4jPointInput
       location_distance: _Neo4jPointDistanceFilter
@@ -924,6 +1006,20 @@ test.cb('Test augmented schema', t => {
       datetime_lte: _Neo4jDateTimeInput
       datetime_gt: _Neo4jDateTimeInput
       datetime_gte: _Neo4jDateTimeInput
+      ratings: [String!]
+      ratings_not: [String!]
+      ratings_contains: [String!]
+      ratings_not_contains: [String!]
+      ratings_starts_with: [String!]
+      ratings_not_starts_with: [String!]
+      ratings_ends_with: [String!]
+      ratings_not_ends_with: [String!]
+      datetimes: [_Neo4jDateTimeInput!]
+      datetimes_not: [_Neo4jDateTimeInput!]
+      datetimes_lt: [_Neo4jDateTimeInput!]
+      datetimes_lte: [_Neo4jDateTimeInput!]
+      datetimes_gt: [_Neo4jDateTimeInput!]
+      datetimes_gte: [_Neo4jDateTimeInput!]
       localtime: _Neo4jLocalTimeInput
       localtime_not: _Neo4jLocalTimeInput
       localtime_in: [_Neo4jLocalTimeInput!]
@@ -1006,6 +1102,8 @@ test.cb('Test augmented schema', t => {
         offset: Int = 0
         name: String
         names: [String]
+        strings: [String]
+        datetimes: [_Neo4jDateTimeInput]
         orderBy: [_ActorOrdering]
         filter: _ActorFilter
       ): [Actor] @relation(name: "ACTED_IN", direction: "IN")
@@ -1031,6 +1129,8 @@ test.cb('Test augmented schema', t => {
         localtime: _Neo4jLocalTimeInput
         localdatetime: _Neo4jLocalDateTimeInput
         location: _Neo4jPointInput
+        ratings: [Int]
+        datetimes: [_Neo4jDateTimeInput]
         first: Int
         offset: Int
         orderBy: [_RatedOrdering]
@@ -1041,6 +1141,8 @@ test.cb('Test augmented schema', t => {
       imdbRatings: [Float]
       "Temporal type field line description"
       releases: [_Neo4jDateTime]
+      booleans: [Boolean]
+      enums: [BookGenre]
       "Ignored field line description"
       customField: String @neo4j_ignore
     }
@@ -1177,6 +1279,8 @@ test.cb('Test augmented schema', t => {
         filter: _PersonFilter
       ): [Person] @relation(name: "KNOWS", direction: "OUT")
       extensionScalar: String
+      datetimes: [_Neo4jDateTime]
+      strings: [String]
       interfacedRelationshipType(
         first: Int
         offset: Int
@@ -1535,6 +1639,8 @@ test.cb('Test augmented schema', t => {
         localtime: _Neo4jLocalTimeInput
         localdatetime: _Neo4jLocalDateTimeInput
         location: _Neo4jPointInput
+        ratings: [String]
+        datetimes: [_Neo4jDateTimeInput]
         first: Int
         offset: Int
         orderBy: [_FriendOfOrdering]
@@ -1548,6 +1654,8 @@ test.cb('Test augmented schema', t => {
         localtime: _Neo4jLocalTimeInput
         localdatetime: _Neo4jLocalDateTimeInput
         location: _Neo4jPointInput
+        ratings: [String]
+        datetimes: [_Neo4jDateTimeInput]
         first: Int
         offset: Int
         orderBy: [_FriendOfOrdering]
@@ -1564,6 +1672,7 @@ test.cb('Test augmented schema', t => {
       time: _Neo4jTime
       date: _Neo4jDate
       datetime: _Neo4jDateTime
+      ratings: [String]
       datetimes: [_Neo4jDateTime]
       localtime: _Neo4jLocalTime
       localdatetime: _Neo4jLocalDateTime
@@ -1846,6 +1955,12 @@ test.cb('Test augmented schema', t => {
       localdatetime_lte: _Neo4jLocalDateTimeInput
       localdatetime_gt: _Neo4jLocalDateTimeInput
       localdatetime_gte: _Neo4jLocalDateTimeInput
+      localdatetimes: [_Neo4jLocalDateTimeInput!]
+      localdatetimes_not: [_Neo4jLocalDateTimeInput!]
+      localdatetimes_lt: [_Neo4jLocalDateTimeInput!]
+      localdatetimes_lte: [_Neo4jLocalDateTimeInput!]
+      localdatetimes_gt: [_Neo4jLocalDateTimeInput!]
+      localdatetimes_gte: [_Neo4jLocalDateTimeInput!]
       temporalNodes: _TemporalNodeFilter
       temporalNodes_not: _TemporalNodeFilter
       temporalNodes_in: [_TemporalNodeFilter!]
@@ -2156,6 +2271,14 @@ test.cb('Test augmented schema', t => {
       weight_lte: Int
       weight_gt: Int
       weight_gte: Int
+      features: [String!]
+      features_not: [String!]
+      features_contains: [String!]
+      features_not_contains: [String!]
+      features_starts_with: [String!]
+      features_not_starts_with: [String!]
+      features_ends_with: [String!]
+      features_not_ends_with: [String!]
       operators: _PersonFilter
       operators_not: _PersonFilter
       operators_in: [_PersonFilter!]
@@ -2386,6 +2509,17 @@ test.cb('Test augmented schema', t => {
       testPublish: Boolean @neo4j_ignore
       computedMovieSearch: [MovieSearch]
         @cypher(statement: "MATCH (ms:MovieSearch) RETURN ms")
+      customCreateNode(
+        integer: Int
+        datetime: _Neo4jDateTimeInput
+        integers: [Int]
+        datetimes: [_Neo4jDateTimeInput]
+        point: _Neo4jPointInput
+        points: [_Neo4jPointInput]
+      ): Boolean
+        @cypher(
+          statement: "CREATE (n:Node { integer: $integer, datetime: datetime($datetime), point: point($point), integers: $integers, datetimes: [value IN $datetimes | datetime(value)], points: [value IN $points | point(value)] }) RETURN TRUE"
+        )
       AddMovieExtensionNode(
         from: _MovieInput!
         to: _GenreInput!
@@ -2588,6 +2722,8 @@ test.cb('Test augmented schema', t => {
         titles: [String]
         imdbRatings: [Float]
         releases: [_Neo4jDateTimeInput]
+        booleans: [Boolean]
+        enums: [BookGenre]
         extensionScalar: String
       ): Movie @hasScope(scopes: ["Movie: Create", "create:movie"])
       UpdateMovie(
@@ -2606,6 +2742,8 @@ test.cb('Test augmented schema', t => {
         titles: [String]
         imdbRatings: [Float]
         releases: [_Neo4jDateTimeInput]
+        booleans: [Boolean]
+        enums: [BookGenre]
         extensionScalar: String
       ): Movie @hasScope(scopes: ["Movie: Update", "update:movie"])
       DeleteMovie(movieId: ID!): Movie
@@ -2626,6 +2764,8 @@ test.cb('Test augmented schema', t => {
         titles: [String]
         imdbRatings: [Float]
         releases: [_Neo4jDateTimeInput]
+        booleans: [Boolean]
+        enums: [BookGenre]
         extensionScalar: String
       ): Movie @hasScope(scopes: ["Movie: Merge", "merge:movie"])
       AddGenreMovies(
@@ -3104,14 +3244,29 @@ test.cb('Test augmented schema', t => {
             "merge:person"
           ]
         )
-      CreateActor(userId: ID, name: String, extensionScalar: String): Actor
-        @hasScope(scopes: ["Actor: Create", "create:actor"])
-      UpdateActor(userId: ID!, name: String, extensionScalar: String): Actor
-        @hasScope(scopes: ["Actor: Update", "update:actor"])
+      CreateActor(
+        userId: ID
+        name: String
+        extensionScalar: String
+        datetimes: [_Neo4jDateTimeInput]
+        strings: [String]
+      ): Actor @hasScope(scopes: ["Actor: Create", "create:actor"])
+      UpdateActor(
+        userId: ID!
+        name: String
+        extensionScalar: String
+        datetimes: [_Neo4jDateTimeInput]
+        strings: [String]
+      ): Actor @hasScope(scopes: ["Actor: Update", "update:actor"])
       DeleteActor(userId: ID!): Actor
         @hasScope(scopes: ["Actor: Delete", "delete:actor"])
-      MergeActor(userId: ID!, name: String, extensionScalar: String): Actor
-        @hasScope(scopes: ["Actor: Merge", "merge:actor"])
+      MergeActor(
+        userId: ID!
+        name: String
+        extensionScalar: String
+        datetimes: [_Neo4jDateTimeInput]
+        strings: [String]
+      ): Actor @hasScope(scopes: ["Actor: Merge", "merge:actor"])
       AddUserInterfacedRelationshipType(
         from: _PersonInput!
         to: _GenreInput!
@@ -4784,6 +4939,7 @@ test.cb('Test augmented schema', t => {
       time: _Neo4jTimeInput
       date: _Neo4jDateInput
       datetime: _Neo4jDateTimeInput
+      ratings: [String]
       datetimes: [_Neo4jDateTimeInput]
       localtime: _Neo4jLocalTimeInput
       localdatetime: _Neo4jLocalDateTimeInput
@@ -4802,6 +4958,7 @@ test.cb('Test augmented schema', t => {
       time: _Neo4jTime
       date: _Neo4jDate
       datetime: _Neo4jDateTime
+      ratings: [String]
       datetimes: [_Neo4jDateTime]
       localtime: _Neo4jLocalTime
       localdatetime: _Neo4jLocalDateTime
@@ -4827,6 +4984,7 @@ test.cb('Test augmented schema', t => {
       time: _Neo4jTime
       date: _Neo4jDate
       datetime: _Neo4jDateTime
+      ratings: [String]
       datetimes: [_Neo4jDateTime]
       localtime: _Neo4jLocalTime
       localdatetime: _Neo4jLocalDateTime
@@ -4846,6 +5004,7 @@ test.cb('Test augmented schema', t => {
       time: _Neo4jTime
       date: _Neo4jDate
       datetime: _Neo4jDateTime
+      ratings: [String]
       datetimes: [_Neo4jDateTime]
       localtime: _Neo4jLocalTime
       localdatetime: _Neo4jLocalDateTime
@@ -5486,6 +5645,7 @@ test.cb('Test augmented schema', t => {
       time: _Neo4jTime
       date: _Neo4jDate
       datetime: _Neo4jDateTime
+      ratings: [String]
       datetimes: [_Neo4jDateTime]
       localtime: _Neo4jLocalTime
       localdatetime: _Neo4jLocalDateTime

--- a/test/unit/cypherTest.test.js
+++ b/test/unit/cypherTest.test.js
@@ -16,17 +16,24 @@ test('simple Cypher query', t => {
       title
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title } AS \`movie\``,
+    expectedParams = {
       title: 'River Runs Through It, A',
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -38,17 +45,24 @@ test('Simple skip limit', t => {
   }
 }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title , .year } AS \`movie\` SKIP toInteger($offset) LIMIT toInteger($first)`;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title , .year } AS \`movie\` SKIP toInteger($offset) LIMIT toInteger($first)`,
+    expectedParams = {
       title: 'River Runs Through It, A',
       first: 2,
       cypherParams: CYPHER_PARAMS,
       offset: 1
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -64,18 +78,25 @@ test('Cypher projection skip limit', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $1_first}, true) | movie_similar { .title }][..3] } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $1_first}, true) | movie_similar { .title }][..3] } AS \`movie\``,
+    expectedParams = {
       title: 'River Runs Through It, A',
       '1_first': 3,
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -86,17 +107,24 @@ test('Handle Query with name not aligning to type', t => {
   }
 }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title } AS \`movie\``,
+    expectedParams = {
       year: 2010,
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -106,16 +134,23 @@ test('Query without arguments, non-null type', t => {
     movieId
   }
 }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` { .movieId } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` { .movieId } AS \`movie\``,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -126,17 +161,24 @@ test('Query single object', t => {
       title
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId:$movieId}) RETURN \`movie\` { .title } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId:$movieId}) RETURN \`movie\` { .title } AS \`movie\``,
+    expectedParams = {
       movieId: '18',
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -151,17 +193,24 @@ test('Query single object relation', t => {
       }
     }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId:$movieId}) RETURN \`movie\` { .title ,filmedIn: head([(\`movie\`)-[:\`FILMED_IN\`]->(\`movie_filmedIn\`:\`State\`) | \`movie_filmedIn\` { .name }]) } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId:$movieId}) RETURN \`movie\` { .title ,filmedIn: head([(\`movie\`)-[:\`FILMED_IN\`]->(\`movie_filmedIn\`:\`State\`) | \`movie_filmedIn\` { .name }]) } AS \`movie\``,
+    expectedParams = {
       movieId: '3100',
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -178,17 +227,24 @@ test('Query single object and array of objects relations', t => {
         }
       }
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId:$movieId}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] ,filmedIn: head([(\`movie\`)-[:\`FILMED_IN\`]->(\`movie_filmedIn\`:\`State\`) | \`movie_filmedIn\` { .name }]) } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId:$movieId}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] ,filmedIn: head([(\`movie\`)-[:\`FILMED_IN\`]->(\`movie_filmedIn\`:\`State\`) | \`movie_filmedIn\` { .name }]) } AS \`movie\``,
+    expectedParams = {
       movieId: '3100',
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -216,19 +272,26 @@ test('Deeply nested object query', t => {
     }
   }
 }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name ,movies: [(\`movie_actors\`)-[:\`ACTED_IN\`]->(\`movie_actors_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`movie_actors_movies\` { .title ,actors: [(\`movie_actors_movies\`)<-[:\`ACTED_IN\`]-(\`movie_actors_movies_actors\`:\`Actor\`{name:$1_name}) | \`movie_actors_movies_actors\` { .name ,movies: [(\`movie_actors_movies_actors\`)-[:\`ACTED_IN\`]->(\`movie_actors_movies_actors_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`movie_actors_movies_actors_movies\` { .title , .year ,similar: [ movie_actors_movies_actors_movies_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie_actors_movies_actors_movies, cypherParams: $cypherParams, offset: 0, first: $2_first}, true) | movie_actors_movies_actors_movies_similar { .title , .year }][..3] }] }] }] }] } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name ,movies: [(\`movie_actors\`)-[:\`ACTED_IN\`]->(\`movie_actors_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`movie_actors_movies\` { .title ,actors: [(\`movie_actors_movies\`)<-[:\`ACTED_IN\`]-(\`movie_actors_movies_actors\`:\`Actor\`{name:$1_name}) | \`movie_actors_movies_actors\` { .name ,movies: [(\`movie_actors_movies_actors\`)-[:\`ACTED_IN\`]->(\`movie_actors_movies_actors_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`movie_actors_movies_actors_movies\` { .title , .year ,similar: [ movie_actors_movies_actors_movies_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie_actors_movies_actors_movies, cypherParams: $cypherParams, offset: 0, first: $2_first}, true) | movie_actors_movies_actors_movies_similar { .title , .year }][..3] }] }] }] }] } AS \`movie\``,
+    expectedParams = {
       title: 'River Runs Through It, A',
       '1_name': 'Tom Hanks',
       '2_first': 3,
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -240,17 +303,24 @@ test('Handle meta field at beginning of selection set', t => {
       title
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title } AS \`movie\``,
+    expectedParams = {
       title: 'River Runs Through It, A',
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -263,17 +333,24 @@ test('Handle meta field at end of selection set', t => {
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title } AS \`movie\``,
+    expectedParams = {
       title: 'River Runs Through It, A',
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -287,17 +364,24 @@ test('Handle meta field in middle of selection set', t => {
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title , .year } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title , .year } AS \`movie\``,
+    expectedParams = {
       title: 'River Runs Through It, A',
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -311,17 +395,24 @@ test('Handle @cypher directive without any params for sub-query', t => {
     }
 
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` {mostSimilar: head([ movie_mostSimilar IN apoc.cypher.runFirstColumn("WITH {this} AS this RETURN this", {this: movie, cypherParams: $cypherParams}, true) | movie_mostSimilar { .title , .year }]) } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` {mostSimilar: head([ movie_mostSimilar IN apoc.cypher.runFirstColumn("WITH {this} AS this RETURN this", {this: movie, cypherParams: $cypherParams}, true) | movie_mostSimilar { .title , .year }]) } AS \`movie\``,
+    expectedParams = {
       title: 'River Runs Through It, A',
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -332,17 +423,24 @@ test('Pass @cypher directive default params to sub-query', t => {
     }
 
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` {scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie, cypherParams: $cypherParams, scale: 3}, false)} AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` {scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie, cypherParams: $cypherParams, scale: 3}, false)} AS \`movie\``,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0,
       title: 'River Runs Through It, A'
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -353,18 +451,25 @@ test('Pass @cypher directive params to sub-query', t => {
     }
 
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` {scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie, cypherParams: $cypherParams, scale: $1_scale}, false)} AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` {scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie, cypherParams: $cypherParams, scale: $1_scale}, false)} AS \`movie\``,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0,
       title: 'River Runs Through It, A',
       '1_scale': 10
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -376,16 +481,23 @@ test('Query for Neo4js internal _id', t => {
     }
 
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ID(\`movie\`)=0 RETURN \`movie\` { .title , .year } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ID(\`movie\`)=0 RETURN \`movie\` { .title , .year } AS \`movie\``,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -397,17 +509,24 @@ test('Query for Neo4js internal _id and another param before _id', t => {
     }
 
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) WHERE ID(\`movie\`)=0 RETURN \`movie\` { .title , .year } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) WHERE ID(\`movie\`)=0 RETURN \`movie\` { .title , .year } AS \`movie\``,
+    expectedParams = {
       title: 'River Runs Through It, A',
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -419,17 +538,24 @@ test('Query for Neo4js internal _id and another param after _id', t => {
     }
 
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) WHERE ID(\`movie\`)=0 RETURN \`movie\` { .title , .year } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) WHERE ID(\`movie\`)=0 RETURN \`movie\` { .title , .year } AS \`movie\``,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0,
       year: 2010
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -441,16 +567,23 @@ test('Query for Neo4js internal _id by dedicated Query MovieBy_Id(_id: String!)'
     }
 
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ID(\`movie\`)=0 RETURN \`movie\` { .title , .year } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ID(\`movie\`)=0 RETURN \`movie\` { .title , .year } AS \`movie\``,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -461,16 +594,23 @@ test(`Query for null value translates to 'IS NULL' WHERE clause`, t => {
       year
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE movie.poster IS NULL RETURN \`movie\` { .title , .year } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE movie.poster IS NULL RETURN \`movie\` { .title , .year } AS \`movie\``,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -481,17 +621,24 @@ test(`Query for null value combined with internal ID and another param`, t => {
         year
       }
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) WHERE ID(\`movie\`)=0 AND movie.poster IS NULL RETURN \`movie\` { .title , .year } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) WHERE ID(\`movie\`)=0 AND movie.poster IS NULL RETURN \`movie\` { .title , .year } AS \`movie\``,
+    expectedParams = {
       year: 2010,
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -506,16 +653,23 @@ test(`query for relationship internal ID`, t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .movieId , .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,_id: ID(\`movie_ratings_relation\`)}] } AS \`movie\``;
-
-  t.plan(1);
-  return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .movieId , .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,_id: ID(\`movie_ratings_relation\`)}] } AS \`movie\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       title: 'River Runs Through It, A',
       cypherParams: CYPHER_PARAMS
-    })
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -530,23 +684,23 @@ test('query for interfaced relationship internal ID', t => {
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,_id: ID(\`genre_interfacedRelationshipType_relation\`)}] } AS \`genre\``;
-
-  t.plan(1);
-
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery,
-    {
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,_id: ID(\`genre_interfacedRelationshipType_relation\`)}] } AS \`genre\``,
+    expectedParams = {
       offset: 0,
       first: -1,
-      title: 'River Runs Through It, A',
-      '1_orderBy': ['datetime_asc'],
       cypherParams: CYPHER_PARAMS
-    }
-  );
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });
 
 test('Cypher subquery filters', t => {
@@ -562,19 +716,26 @@ test('Cypher subquery filters', t => {
         }
       }
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`{name:$1_name}) | \`movie_actors\` { .name }] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $3_first}, true) | movie_similar { .title }][..3] } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`{name:$1_name}) | \`movie_actors\` { .name }] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $3_first}, true) | movie_similar { .title }][..3] } AS \`movie\``,
+    expectedParams = {
       title: 'River Runs Through It, A',
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0,
       '1_name': 'Tom Hanks',
       '3_first': 3
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -589,11 +750,27 @@ test('cypher subquery preserves case through filters', t => {
       }
     }`,
     expectedCypherQuery =
-      'MATCH (`casedType`:`CasedType`) WHERE (EXISTS((`casedType`)-[:FILMED_IN]->(:State)) AND ALL(`state` IN [(`casedType`)-[:FILMED_IN]->(`_state`:State) | `_state`] WHERE (`state`.name = $filter.state.name))) RETURN `casedType` { .name ,state: head([(`casedType`)-[:`FILMED_IN`]->(`casedType_state`:`State`) | `casedType_state` { .name }]) } AS `casedType`';
+      'MATCH (`casedType`:`CasedType`) WHERE (EXISTS((`casedType`)-[:FILMED_IN]->(:State)) AND ALL(`state` IN [(`casedType`)-[:FILMED_IN]->(`_state`:State) | `_state`] WHERE (`state`.name = $filter.state.name))) RETURN `casedType` { .name ,state: head([(`casedType`)-[:`FILMED_IN`]->(`casedType_state`:`State`) | `casedType_state` { .name }]) } AS `casedType`',
+    expectedParams = {
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      offset: 0,
+      filter: {
+        state: {
+          name: 'hello'
+        }
+      }
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -610,11 +787,8 @@ test('Cypher subquery filters with paging', t => {
         }
       }
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`{name:$1_name}) | \`movie_actors\` { .name }][..3] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $3_first}, true) | movie_similar { .title }][..3] } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`{name:$1_name}) | \`movie_actors\` { .name }][..3] ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $3_first}, true) | movie_similar { .title }][..3] } AS \`movie\``,
+    expectedParams = {
       title: 'River Runs Through It, A',
       cypherParams: CYPHER_PARAMS,
       first: -1,
@@ -622,8 +796,18 @@ test('Cypher subquery filters with paging', t => {
       '1_first': 3,
       '1_name': 'Tom Hanks',
       '3_first': 3
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -638,22 +822,29 @@ test('Handle @cypher directive on Query Type', t => {
   }
 }
   `,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {offset:$offset, first:$first, substring:$substring, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`genre\` RETURN \`genre\` { .name ,movies: [(\`genre\`)<-[:\`IN_GENRE\`]-(\`genre_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`genre_movies\` { .title }][..3] } AS \`genre\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {offset:$offset, first:$first, substring:$substring, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`genre\` RETURN \`genre\` { .name ,movies: [(\`genre\`)<-[:\`IN_GENRE\`]-(\`genre_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`genre_movies\` { .title }][..3] } AS \`genre\``,
+    expectedParams = {
       substring: 'Action',
       first: -1,
       offset: 0,
       '1_first': 3,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
-test.cb('Handle @cypher directive on Mutation type', t => {
+test('Handle @cypher directive on Mutation type', t => {
   const graphQLQuery = `mutation someMutation {
   CreateGenre(name: "Wildlife Documentary") {
     name
@@ -661,42 +852,45 @@ test.cb('Handle @cypher directive on Mutation type', t => {
 }`,
     expectedCypherQuery = `CALL apoc.cypher.doIt("CREATE (g:Genre) SET g.name = $name RETURN g", {name:$name, first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
     WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`genre\`
-    RETURN \`genre\` { .name } AS \`genre\``;
+    RETURN \`genre\` { .name } AS \`genre\``,
+    expectedParams = {
+      name: 'Wildlife Documentary',
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      offset: 0
+    };
 
   t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-    name: 'Wildlife Documentary',
-    first: -1,
-    cypherParams: CYPHER_PARAMS,
-    offset: 0
-  });
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams)
+  ]);
 });
 
-test.cb(
-  'Handle @cypher directive on Mutation type with nested @cypher directive on field',
-  t => {
-    const graphQLQuery = `mutation someMutation {
+test('Handle @cypher directive on Mutation type with nested @cypher directive on field', t => {
+  const graphQLQuery = `mutation someMutation {
     CreateGenre(name: "Wildlife Documentary") {
       highestRatedMovie {
         movieId
       }
     }
 }`,
-      expectedCypherQuery = `CALL apoc.cypher.doIt("CREATE (g:Genre) SET g.name = $name RETURN g", {name:$name, first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
+    expectedCypherQuery = `CALL apoc.cypher.doIt("CREATE (g:Genre) SET g.name = $name RETURN g", {name:$name, first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
     WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`genre\`
-    RETURN \`genre\` {highestRatedMovie: head([ genre_highestRatedMovie IN apoc.cypher.runFirstColumn("MATCH (m:Movie)-[:IN_GENRE]->(this) RETURN m ORDER BY m.imdbRating DESC LIMIT 1", {this: genre, cypherParams: $cypherParams}, true) | genre_highestRatedMovie { .movieId }]) } AS \`genre\``;
-
-    t.plan(2);
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    RETURN \`genre\` {highestRatedMovie: head([ genre_highestRatedMovie IN apoc.cypher.runFirstColumn("MATCH (m:Movie)-[:IN_GENRE]->(this) RETURN m ORDER BY m.imdbRating DESC LIMIT 1", {this: genre, cypherParams: $cypherParams}, true) | genre_highestRatedMovie { .movieId }]) } AS \`genre\``,
+    expectedParams = {
       name: 'Wildlife Documentary',
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    });
-  }
-);
+    };
 
-test.cb('Create node mutation', t => {
+  t.plan(2);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams)
+  ]);
+});
+
+test('Create node mutation', t => {
   const graphQLQuery = `	mutation someMutation {
   	CreateMovie(movieId: "12dd334d5", title:"My Super Awesome Movie", year:2018, plot:"An unending saga", poster:"www.movieposter.com/img.png", imdbRating: 1.0) {
 			_id
@@ -709,24 +903,37 @@ test.cb('Create node mutation', t => {
     expectedCypherQuery = `
     CREATE (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}:\`MovieSearch\` {movieId:$params.movieId,title:$params.title,year:$params.year,plot:$params.plot,poster:$params.poster,imdbRating:$params.imdbRating})
     RETURN \`movie\` {_id: ID(\`movie\`), .title ,genres: [(\`movie\`)-[:\`IN_GENRE\`]->(\`movie_genres\`:\`Genre\`) | \`movie_genres\` { .name }] } AS \`movie\`
-  `;
+  `,
+    expectedParams = {
+      params: {
+        movieId: '12dd334d5',
+        title: 'My Super Awesome Movie',
+        year: {
+          high: 0,
+          low: 2018
+        },
+        plot: 'An unending saga',
+        poster: 'www.movieposter.com/img.png',
+        imdbRating: 1
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-    params: {
-      movieId: '12dd334d5',
-      title: 'My Super Awesome Movie',
-      year: 2018,
-      plot: 'An unending saga',
-      poster: 'www.movieposter.com/img.png',
-      imdbRating: 1.0
-    },
-    first: -1,
-    offset: 0
-  });
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });
 
-test.cb('Merge node mutation (interface implemented)', t => {
+test('Merge node mutation (interface implemented)', t => {
   const graphQLQuery = `mutation {
     MergeUser(
       userId: "883c6b3e-3863-49a1-b190-1cee083c98b1",
@@ -737,17 +944,27 @@ test.cb('Merge node mutation (interface implemented)', t => {
     }
   }`,
     expectedCypherQuery = `MERGE (\`user\`:\`User\`:\`Person\`{userId: $params.userId})
-  SET \`user\` += {name:$params.name} RETURN \`user\` { .userId , .name } AS \`user\``;
+  SET \`user\` += {name:$params.name} RETURN \`user\` { .userId , .name } AS \`user\``,
+    expectedParams = {
+      params: {
+        userId: '883c6b3e-3863-49a1-b190-1cee083c98b1',
+        name: 'Michael'
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-    params: {
-      userId: '883c6b3e-3863-49a1-b190-1cee083c98b1',
-      name: 'Michael'
-    },
-    first: -1,
-    offset: 0
-  });
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });
 
 test('Merge node mutation using only primary key', t => {
@@ -759,75 +976,67 @@ test('Merge node mutation using only primary key', t => {
     }
   }`,
     expectedCypherQuery = `MERGE (\`book\`:\`Book\`:\`MovieSearch\`{genre: $params.genre})
-  RETURN \`book\` { .genre } AS \`book\``;
+  RETURN \`book\` { .genre } AS \`book\``,
+    expectedParams = {
+      params: {
+        genre: 'Mystery'
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(3);
-
+  t.plan(4);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      params: {
-        genre: 'Mystery'
-      },
-      first: -1,
-      offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      params: {
-        genre: 'Mystery'
-      },
-      first: -1,
-      offset: 0
-    })
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
 test('Merge node mutation using argument for field with the same name as merged type', t => {
   const graphQLQuery = `mutation MergeNodeTypeMutationTest($example: BookGenre!) {
-    MergeNodeTypeMutationTest(NodeTypeMutationTest: $example) {
-      NodeTypeMutationTest
+      MergeNodeTypeMutationTest(NodeTypeMutationTest: $example) {
+        NodeTypeMutationTest
+      }
     }
-  }
-`,
+  `,
+    graphqlParams = {
+      example: 'Mystery'
+    },
     expectedCypherQuery = `MERGE (\`nodeTypeMutationTest\`:\`NodeTypeMutationTest\`{NodeTypeMutationTest: $params.NodeTypeMutationTest})
-  RETURN \`nodeTypeMutationTest\` { .NodeTypeMutationTest } AS \`nodeTypeMutationTest\``;
-
-  t.plan(3);
-
+  RETURN \`nodeTypeMutationTest\` { .NodeTypeMutationTest } AS \`nodeTypeMutationTest\``,
+    expectedParams = {
+      params: {
+        NodeTypeMutationTest: 'Mystery'
+      },
+      first: -1,
+      offset: 0
+    };
+  t.plan(4);
   return Promise.all([
     cypherTestRunner(
       t,
       graphQLQuery,
-      {
-        example: 'Mystery'
-      },
+      graphqlParams,
       expectedCypherQuery,
-      {
-        first: -1,
-        offset: 0,
-        params: {
-          NodeTypeMutationTest: 'Mystery'
-        }
-      }
+      expectedParams
     ),
     augmentedSchemaCypherTestRunner(
       t,
       graphQLQuery,
-      {
-        example: 'Mystery'
-      },
+      graphqlParams,
       expectedCypherQuery,
-      {
-        first: -1,
-        offset: 0,
-        params: {
-          NodeTypeMutationTest: 'Mystery'
-        }
-      }
+      expectedParams
     )
   ]);
 });
 
-test.cb('Update node mutation', t => {
+test('Update node mutation', t => {
   const graphQLQuery = `mutation updateMutation {
     UpdateMovie(movieId: "12dd334d5", year: 2010) {
       _id
@@ -836,20 +1045,32 @@ test.cb('Update node mutation', t => {
     }
   }`,
     expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`{movieId: $params.movieId})
-  SET \`movie\` += {year:$params.year} RETURN \`movie\` {_id: ID(\`movie\`), .title , .year } AS \`movie\``;
-
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-    params: {
-      year: 2010,
-      movieId: '12dd334d5'
-    },
-    first: -1,
-    offset: 0
-  });
+  SET \`movie\` += {year:$params.year} RETURN \`movie\` {_id: ID(\`movie\`), .title , .year } AS \`movie\``,
+    expectedParams = {
+      params: {
+        year: {
+          high: 0,
+          low: 2010
+        },
+        movieId: '12dd334d5'
+      },
+      first: -1,
+      offset: 0
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });
 
-test.cb('Delete node mutation', t => {
+test('Delete node mutation', t => {
   const graphQLQuery = `mutation deleteMutation{
       DeleteMovie(movieId: "12dd334d5") {
         _id
@@ -859,14 +1080,23 @@ test.cb('Delete node mutation', t => {
     expectedCypherQuery = `MATCH (\`movie\`:\`Movie\` {movieId: $movieId})
 WITH \`movie\` AS \`movie_toDelete\`, \`movie\` {_id: ID(\`movie\`), .movieId } AS \`movie\`
 DETACH DELETE \`movie_toDelete\`
-RETURN \`movie\``;
-
-  t.plan(2);
-  cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-    movieId: '12dd334d5',
-    first: -1,
-    offset: 0
-  });
+RETURN \`movie\``,
+    expectedParams = {
+      movieId: '12dd334d5',
+      first: -1,
+      offset: 0
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });
 
 test('Add relationship mutation', t => {
@@ -892,21 +1122,24 @@ test('Add relationship mutation', t => {
       MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
       CREATE (\`movie_from\`)-[\`in_genre_relation\`:\`IN_GENRE\`]->(\`genre_to\`)
       RETURN \`in_genre_relation\` { from: \`movie_from\` { .movieId ,genres: [(\`movie_from\`)-[:\`IN_GENRE\`]->(\`movie_from_genres\`:\`Genre\`) | \`movie_from_genres\` {_id: ID(\`movie_from_genres\`), .name }] } ,to: \`genre_to\` { .name }  } AS \`_AddMovieGenresPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { movieId: '123' },
       to: { name: 'Action' },
       first: -1,
       offset: 0
-    },
-    expectedCypherQuery,
-    {}
-  );
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });
 
 test('Add relationship mutation and query only outgoing nodes', t => {
@@ -925,20 +1158,21 @@ test('Add relationship mutation and query only outgoing nodes', t => {
       MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
       CREATE (\`movie_from\`)-[\`in_genre_relation\`:\`IN_GENRE\`]->(\`genre_to\`)
       RETURN \`in_genre_relation\` { to: \`genre_to\` { .name }  } AS \`_AddMovieGenresPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { movieId: '123' },
       to: { name: 'Action' },
       first: -1,
       offset: 0
-    },
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -965,20 +1199,21 @@ test('Merge relationship mutation', t => {
       MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
       MERGE (\`movie_from\`)-[\`in_genre_relation\`:\`IN_GENRE\`]->(\`genre_to\`)
       RETURN \`in_genre_relation\` { from: \`movie_from\` { .movieId ,genres: [(\`movie_from\`)-[:\`IN_GENRE\`]->(\`movie_from_genres\`:\`Genre\`) | \`movie_from_genres\` {_id: ID(\`movie_from_genres\`), .name }] } ,to: \`genre_to\` { .name }  } AS \`_MergeMovieGenresPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { movieId: '123' },
       to: { name: 'Action' },
       first: -1,
       offset: 0
-    },
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -1000,24 +1235,32 @@ test('Add relationship mutation with GraphQL variables', t => {
       }
     }
   }`,
-    expectedCypherQuery = `
-      MATCH (\`movie_from\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId: $from.movieId})
-      MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
-      CREATE (\`movie_from\`)-[\`in_genre_relation\`:\`IN_GENRE\`]->(\`genre_to\`)
-      RETURN \`in_genre_relation\` { from: \`movie_from\` { .movieId ,genres: [(\`movie_from\`)-[:\`IN_GENRE\`]->(\`movie_from_genres\`:\`Genre\`) | \`movie_from_genres\` {_id: ID(\`movie_from_genres\`), .name }] } ,to: \`genre_to\` { .name }  } AS \`_AddMovieGenresPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    graphqlParams = {
       from: { movieId: '123' },
       to: { name: 'Action' },
       first: -1,
       offset: 0
     },
-    expectedCypherQuery
+    expectedCypherQuery = `
+      MATCH (\`movie_from\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId: $from.movieId})
+      MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
+      CREATE (\`movie_from\`)-[\`in_genre_relation\`:\`IN_GENRE\`]->(\`genre_to\`)
+      RETURN \`in_genre_relation\` { from: \`movie_from\` { .movieId ,genres: [(\`movie_from\`)-[:\`IN_GENRE\`]->(\`movie_from_genres\`:\`Genre\`) | \`movie_from_genres\` {_id: ID(\`movie_from_genres\`), .name }] } ,to: \`genre_to\` { .name }  } AS \`_AddMovieGenresPayload\`;
+    `,
+    expectedParams = {
+      from: { movieId: '123' },
+      to: { name: 'Action' },
+      first: -1,
+      offset: 0
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    graphqlParams,
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -1068,20 +1311,27 @@ test('Add relationship mutation with relationship property', t => {
       MATCH (\`movie_to\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId: $to.movieId})
       CREATE (\`user_from\`)-[\`rated_relation\`:\`RATED\` {rating:$data.rating}]->(\`movie_to\`)
       RETURN \`rated_relation\` { from: \`user_from\` {_id: ID(\`user_from\`), .userId , .name ,rated: [(\`user_from\`)-[\`user_from_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_relation { .rating ,Movie: head([(:\`User\`)-[\`user_from_rated_relation\`]->(\`user_from_rated_Movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_Movie {_id: ID(\`user_from_rated_Movie\`), .movieId , .title }]) }] } ,to: \`movie_to\` {_id: ID(\`movie_to\`), .movieId , .title ,ratings: [(\`movie_to\`)<-[\`movie_to_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_to_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_to_ratings_relation\`]-(\`movie_to_ratings_User\`:\`User\`) | movie_to_ratings_User {_id: ID(\`movie_to_ratings_User\`), .userId , .name }]) }] } , .rating  } AS \`_AddUserRatedPayload\`;
-    `;
+    `,
+    expectedParams = {
+      from: { userId: '123' },
+      to: { movieId: '456' },
+      data: {
+        rating: {
+          high: 0,
+          low: 5
+        }
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(1);
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
-    {
-      from: { userId: '123' },
-      to: { movieId: '456' },
-      data: { rating: 5 },
-      first: -1,
-      offset: 0
-    },
-    expectedCypherQuery
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -1127,20 +1377,27 @@ test('Merge relationship mutation with relationship property', t => {
       MERGE (\`user_from\`)-[\`rated_relation\`:\`RATED\`]->(\`movie_to\`)
       SET \`rated_relation\` += {rating:$data.rating} 
       RETURN \`rated_relation\` { from: \`user_from\` {_id: ID(\`user_from\`), .userId , .name ,rated: [(\`user_from\`)-[\`user_from_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_relation { .rating ,Movie: head([(:\`User\`)-[\`user_from_rated_relation\`]->(\`user_from_rated_Movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_Movie {_id: ID(\`user_from_rated_Movie\`), .movieId , .title }]) }] } ,to: \`movie_to\` {_id: ID(\`movie_to\`), .movieId , .title ,ratings: [(\`movie_to\`)<-[\`movie_to_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_to_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_to_ratings_relation\`]-(\`movie_to_ratings_User\`:\`User\`) | movie_to_ratings_User {_id: ID(\`movie_to_ratings_User\`), .userId , .name }]) }] } , .rating  } AS \`_MergeUserRatedPayload\`;
-    `;
+    `,
+    expectedParams = {
+      from: { userId: '123' },
+      to: { movieId: '8' },
+      data: {
+        rating: {
+          high: 0,
+          low: 9
+        }
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(1);
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
-    {
-      from: { userId: '123' },
-      to: { movieId: '456' },
-      data: { rating: 9 },
-      first: -1,
-      offset: 0
-    },
-    expectedCypherQuery
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -1193,17 +1450,15 @@ test('Update relationship mutation with relationship property', t => {
       MATCH (\`user_from\`)-[\`rated_relation\`:\`RATED\`]->(\`movie_to\`)
       SET \`rated_relation\` += {rating:$data.rating,location: point($data.location)} 
       RETURN \`rated_relation\` { from: \`user_from\` {_id: ID(\`user_from\`), .userId , .name ,rated: [(\`user_from\`)-[\`user_from_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_relation { .rating ,Movie: head([(:\`User\`)-[\`user_from_rated_relation\`]->(\`user_from_rated_Movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_Movie {_id: ID(\`user_from_rated_Movie\`), .movieId , .title }]) }] } ,to: \`movie_to\` {_id: ID(\`movie_to\`), .movieId , .title ,ratings: [(\`movie_to\`)<-[\`movie_to_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_to_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_to_ratings_relation\`]-(\`movie_to_ratings_User\`:\`User\`) | movie_to_ratings_User {_id: ID(\`movie_to_ratings_User\`), .userId , .name }]) }] } , .rating  } AS \`_UpdateUserRatedPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { userId: '123' },
       to: { movieId: '2kljghd' },
       data: {
-        rating: 1,
+        rating: {
+          high: 0,
+          low: 1
+        },
         location: {
           longitude: 3.0,
           latitude: 4.5,
@@ -1212,8 +1467,15 @@ test('Update relationship mutation with relationship property', t => {
       },
       first: -1,
       offset: 0
-    },
-    expectedCypherQuery
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -1250,17 +1512,15 @@ test('Update relationship mutation with relationship property and query only out
       MATCH (\`user_from\`)-[\`rated_relation\`:\`RATED\`]->(\`movie_to\`)
       SET \`rated_relation\` += {rating:$data.rating,location: point($data.location)} 
       RETURN \`rated_relation\` { to: \`movie_to\` {_id: ID(\`movie_to\`), .movieId , .title ,ratings: [(\`movie_to\`)<-[\`movie_to_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_to_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_to_ratings_relation\`]-(\`movie_to_ratings_User\`:\`User\`) | movie_to_ratings_User {_id: ID(\`movie_to_ratings_User\`), .userId , .name }]) }] } , .rating  } AS \`_UpdateUserRatedPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { userId: '123' },
       to: { movieId: '2kljghd' },
       data: {
-        rating: 1,
+        rating: {
+          high: 0,
+          low: 1
+        },
         location: {
           longitude: 3.0,
           latitude: 4.5,
@@ -1269,8 +1529,15 @@ test('Update relationship mutation with relationship property and query only out
       },
       first: -1,
       offset: 0
-    },
-    expectedCypherQuery
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -1353,20 +1620,27 @@ test('Add reflexive relationship mutation with relationship property', t => {
       MATCH (\`user_to\`:\`User\` {userId: $to.userId})
       CREATE (\`user_from\`)-[\`friend_of_relation\`:\`FRIEND_OF\` {since:$data.since}]->(\`user_to\`)
       RETURN \`friend_of_relation\` { from: \`user_from\` {_id: ID(\`user_from\`), .userId , .name ,friends: {from: [(\`user_from\`)<-[\`user_from_from_relation\`:\`FRIEND_OF\`]-(\`user_from_from\`:\`User\`) | user_from_from_relation { .since ,User: user_from_from {_id: ID(\`user_from_from\`), .name ,friends: {from: [(\`user_from_from\`)<-[\`user_from_from_from_relation\`:\`FRIEND_OF\`]-(\`user_from_from_from\`:\`User\`) | user_from_from_from_relation { .since ,User: user_from_from_from {_id: ID(\`user_from_from_from\`), .name } }] ,to: [(\`user_from_from\`)-[\`user_from_from_to_relation\`:\`FRIEND_OF\`]->(\`user_from_from_to\`:\`User\`) | user_from_from_to_relation { .since ,User: user_from_from_to {_id: ID(\`user_from_from_to\`), .name } }] } } }] ,to: [(\`user_from\`)-[\`user_from_to_relation\`:\`FRIEND_OF\`]->(\`user_from_to\`:\`User\`) | user_from_to_relation { .since ,User: user_from_to {_id: ID(\`user_from_to\`), .name } }] } } ,to: \`user_to\` {_id: ID(\`user_to\`), .name ,friends: {from: [(\`user_to\`)<-[\`user_to_from_relation\`:\`FRIEND_OF\`]-(\`user_to_from\`:\`User\`) | user_to_from_relation { .since ,User: user_to_from {_id: ID(\`user_to_from\`), .name } }] ,to: [(\`user_to\`)-[\`user_to_to_relation\`:\`FRIEND_OF\`]->(\`user_to_to\`:\`User\`) | user_to_to_relation { .since ,User: user_to_to {_id: ID(\`user_to_to\`), .name } }] } } , .since  } AS \`_AddUserFriendsPayload\`;
-    `;
+    `,
+    expectedParams = {
+      from: { userId: '123' },
+      to: { userId: '456' },
+      data: {
+        since: {
+          high: 0,
+          low: 7
+        }
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(1);
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
-    {
-      from: { userId: '123' },
-      to: { userId: '456' },
-      data: { since: 7 },
-      first: -1,
-      offset: 0
-    },
-    expectedCypherQuery
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -1450,20 +1724,27 @@ test('Merge reflexive relationship mutation with relationship property', t => {
       MERGE (\`user_from\`)-[\`friend_of_relation\`:\`FRIEND_OF\`]->(\`user_to\`)
       SET \`friend_of_relation\` += {since:$data.since} 
       RETURN \`friend_of_relation\` { from: \`user_from\` {_id: ID(\`user_from\`), .userId , .name ,friends: {from: [(\`user_from\`)<-[\`user_from_from_relation\`:\`FRIEND_OF\`]-(\`user_from_from\`:\`User\`) | user_from_from_relation { .since ,User: user_from_from {_id: ID(\`user_from_from\`), .name ,friends: {from: [(\`user_from_from\`)<-[\`user_from_from_from_relation\`:\`FRIEND_OF\`]-(\`user_from_from_from\`:\`User\`) | user_from_from_from_relation { .since ,User: user_from_from_from {_id: ID(\`user_from_from_from\`), .name } }] ,to: [(\`user_from_from\`)-[\`user_from_from_to_relation\`:\`FRIEND_OF\`]->(\`user_from_from_to\`:\`User\`) | user_from_from_to_relation { .since ,User: user_from_from_to {_id: ID(\`user_from_from_to\`), .name } }] } } }] ,to: [(\`user_from\`)-[\`user_from_to_relation\`:\`FRIEND_OF\`]->(\`user_from_to\`:\`User\`) | user_from_to_relation { .since ,User: user_from_to {_id: ID(\`user_from_to\`), .name } }] } } ,to: \`user_to\` {_id: ID(\`user_to\`), .name ,friends: {from: [(\`user_to\`)<-[\`user_to_from_relation\`:\`FRIEND_OF\`]-(\`user_to_from\`:\`User\`) | user_to_from_relation { .since ,User: user_to_from {_id: ID(\`user_to_from\`), .name } }] ,to: [(\`user_to\`)-[\`user_to_to_relation\`:\`FRIEND_OF\`]->(\`user_to_to\`:\`User\`) | user_to_to_relation { .since ,User: user_to_to {_id: ID(\`user_to_to\`), .name } }] } } , .since  } AS \`_MergeUserFriendsPayload\`;
-    `;
+    `,
+    expectedParams = {
+      from: { userId: '123' },
+      to: { userId: '456' },
+      data: {
+        since: {
+          high: 0,
+          low: 8
+        }
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(1);
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
-    {
-      from: { userId: '123' },
-      to: { userId: '456' },
-      data: { since: 8 },
-      first: -1,
-      offset: 0
-    },
-    expectedCypherQuery
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -1547,20 +1828,27 @@ test('Update reflexive relationship mutation with relationship property', t => {
       MATCH (\`user_from\`)-[\`friend_of_relation\`:\`FRIEND_OF\`]->(\`user_to\`)
       SET \`friend_of_relation\` += {since:$data.since} 
       RETURN \`friend_of_relation\` { from: \`user_from\` {_id: ID(\`user_from\`), .userId , .name ,friends: {from: [(\`user_from\`)<-[\`user_from_from_relation\`:\`FRIEND_OF\`]-(\`user_from_from\`:\`User\`) | user_from_from_relation { .since ,User: user_from_from {_id: ID(\`user_from_from\`), .name ,friends: {from: [(\`user_from_from\`)<-[\`user_from_from_from_relation\`:\`FRIEND_OF\`]-(\`user_from_from_from\`:\`User\`) | user_from_from_from_relation { .since ,User: user_from_from_from {_id: ID(\`user_from_from_from\`), .name } }] ,to: [(\`user_from_from\`)-[\`user_from_from_to_relation\`:\`FRIEND_OF\`]->(\`user_from_from_to\`:\`User\`) | user_from_from_to_relation { .since ,User: user_from_from_to {_id: ID(\`user_from_from_to\`), .name } }] } } }] ,to: [(\`user_from\`)-[\`user_from_to_relation\`:\`FRIEND_OF\`]->(\`user_from_to\`:\`User\`) | user_from_to_relation { .since ,User: user_from_to {_id: ID(\`user_from_to\`), .name } }] } } ,to: \`user_to\` {_id: ID(\`user_to\`), .name ,friends: {from: [(\`user_to\`)<-[\`user_to_from_relation\`:\`FRIEND_OF\`]-(\`user_to_from\`:\`User\`) | user_to_from_relation { .since ,User: user_to_from {_id: ID(\`user_to_from\`), .name } }] ,to: [(\`user_to\`)-[\`user_to_to_relation\`:\`FRIEND_OF\`]->(\`user_to_to\`:\`User\`) | user_to_to_relation { .since ,User: user_to_to {_id: ID(\`user_to_to\`), .name } }] } } , .since  } AS \`_UpdateUserFriendsPayload\`;
-    `;
+    `,
+    expectedParams = {
+      from: { userId: '123' },
+      to: { userId: '456' },
+      data: {
+        since: {
+          high: 0,
+          low: 8
+        }
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(1);
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
-    {
-      from: { userId: '123' },
-      to: { userId: '456' },
-      data: { since: 8 },
-      first: -1,
-      offset: 0
-    },
-    expectedCypherQuery
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -1585,20 +1873,22 @@ test('Add interfaced relationship mutation', t => {
       MATCH (\`person_to\`:\`Person\` {userId: $to.userId})
       CREATE (\`actor_from\`)-[\`knows_relation\`:\`KNOWS\`]->(\`person_to\`)
       RETURN \`knows_relation\` { from: \`actor_from\` { .userId , .name } ,to: \`person_to\` {FRAGMENT_TYPE: head( [ label IN labels(\`person_to\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }  } AS \`_AddActorKnowsPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { userId: '123' },
       to: { userId: '456' },
       first: -1,
-      offset: 0
-    },
+      offset: 0,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -1626,16 +1916,8 @@ test('Add interfaced relationship type mutation', t => {
       MATCH (\`genre_to\`:\`Genre\` {name: $to.name})
       CREATE (\`person_from\`)-[\`interfaced_relationship_type_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\` {string:$data.string}]->(\`genre_to\`)
       RETURN \`interfaced_relationship_type_relation\` { from: \`person_from\` {FRAGMENT_TYPE: head( [ label IN labels(\`person_from\`) WHERE label IN $Person_derivedTypes ] ), .userId ,interfacedRelationshipType: [(\`person_from\`)-[\`person_from_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_from_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_from_interfacedRelationshipType_relation\`]->(\`person_from_interfacedRelationshipType_Genre\`:\`Genre\`) | person_from_interfacedRelationshipType_Genre { .name }]) }] } , .string  } AS \`_AddActorInterfacedRelationshipTypePayload\`;
-    `;
-
-  t.plan(1);
-
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery,
-    {
+    `,
+    expectedParams = {
       from: {
         userId: '744c23c8-2042-402d-b482-28d089f976f9'
       },
@@ -1648,7 +1930,15 @@ test('Add interfaced relationship type mutation', t => {
       first: -1,
       offset: 0,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    }
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -1673,20 +1963,22 @@ test('Merge interfaced relationship mutation', t => {
       MATCH (\`person_to\`:\`Person\` {userId: $to.userId})
       MERGE (\`actor_from\`)-[\`knows_relation\`:\`KNOWS\`]->(\`person_to\`)
       RETURN \`knows_relation\` { from: \`actor_from\` { .userId , .name } ,to: \`person_to\` {FRAGMENT_TYPE: head( [ label IN labels(\`person_to\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }  } AS \`_MergeActorKnowsPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { userId: '123' },
       to: { userId: '456' },
       first: -1,
-      offset: 0
-    },
+      offset: 0,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -1715,13 +2007,8 @@ test('Merge interfaced relationship type mutation', t => {
       MERGE (\`person_from\`)-[\`interfaced_relationship_type_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(\`genre_to\`)
       SET \`interfaced_relationship_type_relation\` += {string:$data.string} 
       RETURN \`interfaced_relationship_type_relation\` { from: \`person_from\` {FRAGMENT_TYPE: head( [ label IN labels(\`person_from\`) WHERE label IN $Person_derivedTypes ] ), .userId ,interfacedRelationshipType: [(\`person_from\`)-[\`person_from_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_from_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_from_interfacedRelationshipType_relation\`]->(\`person_from_interfacedRelationshipType_Genre\`:\`Genre\`) | person_from_interfacedRelationshipType_Genre { .name }]) }] } , .string  } AS \`_MergeActorInterfacedRelationshipTypePayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: {
         userId: '744c23c8-2042-402d-b482-28d089f976f9'
       },
@@ -1734,9 +2021,15 @@ test('Merge interfaced relationship type mutation', t => {
       first: -1,
       offset: 0,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    },
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -1765,13 +2058,8 @@ test('Update interfaced relationship type mutation', t => {
       MATCH (\`person_from\`)-[\`interfaced_relationship_type_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(\`genre_to\`)
       SET \`interfaced_relationship_type_relation\` += {string:$data.string} 
       RETURN \`interfaced_relationship_type_relation\` { from: \`person_from\` {FRAGMENT_TYPE: head( [ label IN labels(\`person_from\`) WHERE label IN $Person_derivedTypes ] ), .userId ,interfacedRelationshipType: [(\`person_from\`)-[\`person_from_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_from_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_from_interfacedRelationshipType_relation\`]->(\`person_from_interfacedRelationshipType_Genre\`:\`Genre\`) | person_from_interfacedRelationshipType_Genre { .name }]) }] } , .string  } AS \`_UpdateActorInterfacedRelationshipTypePayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: {
         userId: '744c23c8-2042-402d-b482-28d089f976f9'
       },
@@ -1784,9 +2072,15 @@ test('Update interfaced relationship type mutation', t => {
       first: -1,
       offset: 0,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    },
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -1826,13 +2120,8 @@ test('Merge interfaced relationship type mutation (additional operation)', t => 
       MERGE (\`person_from\`)-[\`interfaced_relationship_type_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(\`genre_to\`)
       SET \`interfaced_relationship_type_relation\` += {string:$data.string} 
       RETURN \`interfaced_relationship_type_relation\` { from: \`person_from\` {FRAGMENT_TYPE: head( [ label IN labels(\`person_from\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: [(\`person_from\`)-[\`person_from_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_from_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_from_interfacedRelationshipType_relation\`]->(\`person_from_interfacedRelationshipType_Genre\`:\`Genre\`) | person_from_interfacedRelationshipType_Genre { .name }]) }] } ,to: \`genre_to\` { .name ,interfacedRelationshipType: [(\`genre_to\`)<-[\`genre_to_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_to_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_to_interfacedRelationshipType_relation\`]-(\`genre_to_interfacedRelationshipType_Person\`:\`Person\`) | genre_to_interfacedRelationshipType_Person {FRAGMENT_TYPE: head( [ label IN labels(genre_to_interfacedRelationshipType_Person) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]) }] } , .string  } AS \`_MergeGenreInterfacedRelationshipTypePayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: {
         userId: '744c23c8-2042-402d-b482-28d089f976f9'
       },
@@ -1845,9 +2134,15 @@ test('Merge interfaced relationship type mutation (additional operation)', t => 
       first: -1,
       offset: 0,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    },
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -1874,20 +2169,22 @@ test('Remove interfaced relationship mutation', t => {
       DELETE \`actor_fromperson_to\`
       WITH COUNT(*) AS scope, \`actor_from\` AS \`_actor_from\`, \`person_to\` AS \`_person_to\`
       RETURN {from: \`_actor_from\` { .userId , .name } ,to: \`_person_to\` {FRAGMENT_TYPE: head( [ label IN labels(\`_person_to\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name } } AS \`_RemoveActorKnowsPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { userId: '123' },
       to: { userId: '456' },
       first: -1,
-      offset: 0
-    },
+      offset: 0,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -1915,13 +2212,8 @@ test('Remove interfaced relationship type mutation', t => {
       DELETE \`person_fromgenre_to\`
       WITH COUNT(*) AS scope, \`person_from\` AS \`_person_from\`, \`genre_to\` AS \`_genre_to\`
       RETURN {from: \`_person_from\` {FRAGMENT_TYPE: head( [ label IN labels(\`_person_from\`) WHERE label IN $Person_derivedTypes ] ), .userId ,interfacedRelationshipType: [(\`_person_from\`)-[\`_person_from_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | _person_from_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`_person_from_interfacedRelationshipType_relation\`]->(\`_person_from_interfacedRelationshipType_Genre\`:\`Genre\`) | _person_from_interfacedRelationshipType_Genre { .name }]) }] } } AS \`_RemoveActorInterfacedRelationshipTypePayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: {
         userId: '744c23c8-2042-402d-b482-28d089f976f9'
       },
@@ -1931,9 +2223,15 @@ test('Remove interfaced relationship type mutation', t => {
       first: -1,
       offset: 0,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    },
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -1960,19 +2258,21 @@ test('Remove relationship mutation', t => {
       DELETE \`movie_fromgenre_to\`
       WITH COUNT(*) AS scope, \`movie_from\` AS \`_movie_from\`, \`genre_to\` AS \`_genre_to\`
       RETURN {from: \`_movie_from\` {_id: ID(\`_movie_from\`), .title } ,to: \`_genre_to\` {_id: ID(\`_genre_to\`), .name } } AS \`_RemoveMovieGenresPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { movieId: '123' },
       to: { name: 'Action' },
       first: -1,
       offset: 0
-    },
-    expectedCypherQuery
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -1995,19 +2295,21 @@ test('Remove relationship mutation and query only outgoing nodes', t => {
       DELETE \`movie_fromgenre_to\`
       WITH COUNT(*) AS scope, \`movie_from\` AS \`_movie_from\`, \`genre_to\` AS \`_genre_to\`
       RETURN {to: \`_genre_to\` {_id: ID(\`_genre_to\`), .name } } AS \`_RemoveMovieGenresPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { movieId: '123' },
       to: { name: 'Action' },
       first: -1,
       offset: 0
-    },
-    expectedCypherQuery
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -2071,125 +2373,143 @@ test('Remove reflexive relationship mutation', t => {
       DELETE \`user_fromuser_to\`
       WITH COUNT(*) AS scope, \`user_from\` AS \`_user_from\`, \`user_to\` AS \`_user_to\`
       RETURN {from: \`_user_from\` {_id: ID(\`_user_from\`), .name ,friends: {from: [(\`_user_from\`)<-[\`_user_from_from_relation\`:\`FRIEND_OF\`]-(\`_user_from_from\`:\`User\`) | _user_from_from_relation { .since ,User: _user_from_from {_id: ID(\`_user_from_from\`), .name } }] ,to: [(\`_user_from\`)-[\`_user_from_to_relation\`:\`FRIEND_OF\`]->(\`_user_from_to\`:\`User\`) | _user_from_to_relation { .since ,User: _user_from_to {_id: ID(\`_user_from_to\`), .name } }] } } ,to: \`_user_to\` {_id: ID(\`_user_to\`), .name ,friends: {from: [(\`_user_to\`)<-[\`_user_to_from_relation\`:\`FRIEND_OF\`]-(\`_user_to_from\`:\`User\`) | _user_to_from_relation { .since ,User: _user_to_from {_id: ID(\`_user_to_from\`), .name } }] ,to: [(\`_user_to\`)-[\`_user_to_to_relation\`:\`FRIEND_OF\`]->(\`_user_to_to\`:\`User\`) | _user_to_to_relation { .since ,User: _user_to_to {_id: ID(\`_user_to_to\`), .name } }] } } } AS \`_RemoveUserFriendsPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { userId: '123' },
       to: { userId: '456' },
       first: -1,
       offset: 0
-    },
-    expectedCypherQuery
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
 test('Handle GraphQL variables in nested selection - first/offset', t => {
   const graphQLQuery = `query ($year: Int!, $first: Int!) {
-
-  Movie(year: $year) {
-    title
-    year
-    similar(first: $first) {
+    Movie(year: $year) {
       title
+      year
+      similar(first: $first) {
+        title
+      }
     }
-  }
-}`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title , .year ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $1_first}, true) | movie_similar { .title }][..3] } AS \`movie\``;
+  }`,
+    graphqlParams = {
+      year: 2016,
+      first: 3
+    },
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title , .year ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $1_first}, true) | movie_similar { .title }][..3] } AS \`movie\``,
+    expectedParams = {
+      '1_first': 3,
+      cypherParams: CYPHER_PARAMS,
+      year: 2016,
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(3);
-
+  t.plan(4);
   return Promise.all([
     cypherTestRunner(
       t,
       graphQLQuery,
-      { year: 2016, first: 3 },
+      graphqlParams,
       expectedCypherQuery,
-      {
-        '1_first': 3,
-        cypherParams: CYPHER_PARAMS,
-        year: 2016,
-        first: -1,
-        offset: 0
-      }
+      expectedParams
     ),
     augmentedSchemaCypherTestRunner(
       t,
       graphQLQuery,
-      { year: 2016, first: 3 },
-      expectedCypherQuery
+      graphqlParams,
+      expectedCypherQuery,
+      expectedParams
     )
   ]);
 });
 
 test('Handle GraphQL variables in nest selection - @cypher param (not first/offset)', t => {
   const graphQLQuery = `query ($year: Int = 2016, $first: Int = 2, $scale:Int) {
-
-  Movie(year: $year) {
-    title
-    year
-    similar(first: $first) {
+    Movie(year: $year) {
       title
-      scaleRating(scale:$scale)
+      year
+      similar(first: $first) {
+        title
+        scaleRating(scale:$scale)
+      }
+
     }
+  }`,
+    graphqlParams = {
+      year: 2016,
+      first: 3,
+      scale: 5
+    },
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title , .year ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $1_first}, true) | movie_similar { .title ,scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie_similar, cypherParams: $cypherParams, scale: $2_scale}, false)}][..3] } AS \`movie\``,
+    expectedParams = {
+      year: 2016,
+      first: -1,
+      offset: 0,
+      '1_first': 3,
+      '2_scale': 5,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  }
-}`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title , .year ,similar: [ movie_similar IN apoc.cypher.runFirstColumn("WITH {this} AS this MATCH (this)--(:Genre)--(o:Movie) RETURN o", {this: movie, cypherParams: $cypherParams, offset: 0, first: $1_first}, true) | movie_similar { .title ,scaleRating: apoc.cypher.runFirstColumn("WITH $this AS this RETURN $scale * this.imdbRating", {this: movie_similar, cypherParams: $cypherParams, scale: $2_scale}, false)}][..3] } AS \`movie\``;
-
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
     cypherTestRunner(
       t,
       graphQLQuery,
-      { year: 2016, first: 3, scale: 5 },
+      graphqlParams,
       expectedCypherQuery,
-      {
-        year: 2016,
-        first: -1,
-        offset: 0,
-        '1_first': 3,
-        '2_scale': 5,
-        cypherParams: CYPHER_PARAMS
-      }
+      expectedParams
     ),
     augmentedSchemaCypherTestRunner(
       t,
       graphQLQuery,
-      { year: 2016, first: 3, scale: 5 },
-      expectedCypherQuery
+      graphqlParams,
+      expectedCypherQuery,
+      expectedParams
     )
   ]);
 });
 
 test('Return internal node id for _id field', t => {
   const graphQLQuery = `{
-  Movie(year: 2016) {
-    _id
-    title
-    year
-    genres {
+    Movie(year: 2016) {
       _id
-      name
+      title
+      year
+      genres {
+        _id
+        name
+      }
     }
   }
-}
-`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` {_id: ID(\`movie\`), .title , .year ,genres: [(\`movie\`)-[:\`IN_GENRE\`]->(\`movie_genres\`:\`Genre\`) | \`movie_genres\` {_id: ID(\`movie_genres\`), .name }] } AS \`movie\``;
-
-  t.plan(3);
-
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` {_id: ID(\`movie\`), .title , .year ,genres: [(\`movie\`)-[:\`IN_GENRE\`]->(\`movie_genres\`:\`Genre\`) | \`movie_genres\` {_id: ID(\`movie_genres\`), .name }] } AS \`movie\``,
+    expectedParams = {
       year: 2016,
       cypherParams: CYPHER_PARAMS,
       first: -1,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -2200,46 +2520,59 @@ test('Treat enum as a scalar', t => {
       genre
     }
   }`,
-    expectedCypherQuery = `MATCH (\`book\`:\`Book\`) RETURN \`book\` { .genre } AS \`book\``;
-
-  t.plan(3);
-
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`book\`:\`Book\`) RETURN \`book\` { .genre } AS \`book\``,
+    expectedParams = {
       cypherParams: CYPHER_PARAMS,
       first: -1,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
 test('Handle fragment spread on object type', t => {
   const graphQLQuery = `
-fragment myTitle on Movie {
-  title
-  actors {
-    name
-  }
-}
+    fragment myTitle on Movie {
+      title
+      actors {
+        name
+      }
+    }
 
-query getMovie {
-  Movie(title: "River Runs Through It, A") {
-    ...myTitle
-    year
-  }
-}`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] , .year } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    query getMovie {
+      Movie(title: "River Runs Through It, A") {
+        ...myTitle
+        year
+      }
+    }`,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] , .year } AS \`movie\``,
+    expectedParams = {
       cypherParams: CYPHER_PARAMS,
       title: 'River Runs Through It, A',
       first: -1,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -2255,51 +2588,65 @@ test('Handle inline fragment on object type', t => {
       year
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] , .year } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] , .year } AS \`movie\``,
+    expectedParams = {
       cypherParams: CYPHER_PARAMS,
       title: 'River Runs Through It, A',
       first: -1,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
 test('Handle multiple query fragments on object type', t => {
   const graphQLQuery = `
     fragment myTitle on Movie {
-  title
-}
+      title
+    }
 
-fragment myActors on Movie {
-  actors {
-    name
-  }
-}
+    fragment myActors on Movie {
+      actors {
+        name
+      }
+    }
 
-query getMovie {
-  Movie(title: "River Runs Through It, A") {
-    ...myTitle
-    ...myActors
-    year
-  }
-}
+    query getMovie {
+      Movie(title: "River Runs Through It, A") {
+        ...myTitle
+        ...myActors
+        year
+      }
+    }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] , .year } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] , .year } AS \`movie\``,
+    expectedParams = {
       cypherParams: CYPHER_PARAMS,
       title: 'River Runs Through It, A',
       first: -1,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -2319,17 +2666,24 @@ test('query object type using inline fragment and fragment spread', t => {
       year
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] , .year } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] , .year } AS \`movie\``,
+    expectedParams = {
       cypherParams: CYPHER_PARAMS,
       title: 'River Runs Through It, A',
       first: -1,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -2349,17 +2703,24 @@ test('nested fragments on object type', t => {
     fragment Bar on Movie {
       year
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title , .year } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title , .year } AS \`movie\``,
+    expectedParams = {
       cypherParams: CYPHER_PARAMS,
       year: 2010,
       first: -1,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -2377,17 +2738,24 @@ test('fragments on object type relations', t => {
     fragment Foo on Actor {
       name
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }] } AS \`movie\``,
+    expectedParams = {
       year: 2010,
       cypherParams: CYPHER_PARAMS,
       first: -1,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -2410,17 +2778,24 @@ test('nested fragments on object type relations', t => {
     fragment Bar on Actor {
       name
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .userId , .name }] } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .userId , .name }] } AS \`movie\``,
+    expectedParams = {
       cypherParams: CYPHER_PARAMS,
       year: 2010,
       first: -1,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -2432,23 +2807,23 @@ test('orderBy test - descending, top level - augmented schema', t => {
         name
       }
     }
-  }
-  `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) WITH \`movie\` ORDER BY movie.title DESC RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }][..3] } AS \`movie\` LIMIT toInteger($first)`;
+  }`,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {year:$year}) WITH \`movie\` ORDER BY movie.title DESC RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name }][..3] } AS \`movie\` LIMIT toInteger($first)`,
+    expectedParams = {
+      offset: 0,
+      first: 10,
+      year: 2010,
+      '1_first': 3,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {
-      offset: 0,
-      first: 10,
-      year: 2010,
-      '1_first': 3
-    }
+    expectedParams
   );
 });
 
@@ -2464,16 +2839,21 @@ test('query for relationship properties', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .name }]) }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .name }]) }] } AS \`movie\``,
+    expectedParams = {
+      cypherParams: CYPHER_PARAMS,
+      title: 'River Runs Through It, A',
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -2491,22 +2871,22 @@ test('query relationship properties and order by unselected field', t => {
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\` {title:$title}) RETURN \`movie\` { .title ,ratings: [sortedElement IN apoc.coll.sortMulti([(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,User: head([(:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`)<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .userId , .name }]) ,datetime: \`movie_ratings_relation\`.datetime}], ['^datetime']) | sortedElement { .* }] } AS \`movie\``;
-
-  t.plan(1);
-
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery,
-    {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\` {title:$title}) RETURN \`movie\` { .title ,ratings: [sortedElement IN apoc.coll.sortMulti([(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,User: head([(:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`)<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .userId , .name }]) ,datetime: \`movie_ratings_relation\`.datetime}], ['^datetime']) | sortedElement { .* }] } AS \`movie\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       title: 'River Runs Through It, A',
       '1_orderBy': ['datetime_asc'],
       cypherParams: CYPHER_PARAMS
-    }
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -2522,22 +2902,22 @@ test('query relationship properties and order by internal ID', t => {
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .movieId , .title ,ratings: apoc.coll.sortMulti([(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,_id: ID(\`movie_ratings_relation\`)}], ['^_id']) } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .movieId , .title ,ratings: apoc.coll.sortMulti([(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,_id: ID(\`movie_ratings_relation\`)}], ['^_id']) } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      title: 'River Runs Through It, A',
+      '1_orderBy': ['_id_asc'],
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {
-      offset: 0,
-      first: -1,
-      title: 'River Runs Through It, A',
-      '1_orderBy': ['datetime_asc'],
-      cypherParams: CYPHER_PARAMS
-    }
+    expectedParams
   );
 });
 
@@ -2597,16 +2977,20 @@ test('query reflexive relation nested in non-reflexive relation', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` { .movieId , .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .userId , .name ,friends: {from: [(\`movie_ratings_User\`)<-[\`movie_ratings_User_from_relation\`:\`FRIEND_OF\`]-(\`movie_ratings_User_from\`:\`User\`) | movie_ratings_User_from_relation { .since ,User: movie_ratings_User_from { .name ,friends: {from: [(\`movie_ratings_User_from\`)<-[\`movie_ratings_User_from_from_relation\`:\`FRIEND_OF\`]-(\`movie_ratings_User_from_from\`:\`User\`) | movie_ratings_User_from_from_relation { .since ,User: movie_ratings_User_from_from { .name } }] ,to: [(\`movie_ratings_User_from\`)-[\`movie_ratings_User_from_to_relation\`:\`FRIEND_OF\`]->(\`movie_ratings_User_from_to\`:\`User\`) | movie_ratings_User_from_to_relation { .since ,User: movie_ratings_User_from_to { .name } }] } } }] ,to: [(\`movie_ratings_User\`)-[\`movie_ratings_User_to_relation\`:\`FRIEND_OF\`]->(\`movie_ratings_User_to\`:\`User\`) | movie_ratings_User_to_relation { .since ,User: movie_ratings_User_to { .name ,friends: {from: [(\`movie_ratings_User_to\`)<-[\`movie_ratings_User_to_from_relation\`:\`FRIEND_OF\`]-(\`movie_ratings_User_to_from\`:\`User\`) | movie_ratings_User_to_from_relation { .since ,User: movie_ratings_User_to_from { .name } }] ,to: [(\`movie_ratings_User_to\`)-[\`movie_ratings_User_to_to_relation\`:\`FRIEND_OF\`]->(\`movie_ratings_User_to_to\`:\`User\`) | movie_ratings_User_to_to_relation { .since ,User: movie_ratings_User_to_to { .name } }] } } }] } }]) }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` { .movieId , .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .userId , .name ,friends: {from: [(\`movie_ratings_User\`)<-[\`movie_ratings_User_from_relation\`:\`FRIEND_OF\`]-(\`movie_ratings_User_from\`:\`User\`) | movie_ratings_User_from_relation { .since ,User: movie_ratings_User_from { .name ,friends: {from: [(\`movie_ratings_User_from\`)<-[\`movie_ratings_User_from_from_relation\`:\`FRIEND_OF\`]-(\`movie_ratings_User_from_from\`:\`User\`) | movie_ratings_User_from_from_relation { .since ,User: movie_ratings_User_from_from { .name } }] ,to: [(\`movie_ratings_User_from\`)-[\`movie_ratings_User_from_to_relation\`:\`FRIEND_OF\`]->(\`movie_ratings_User_from_to\`:\`User\`) | movie_ratings_User_from_to_relation { .since ,User: movie_ratings_User_from_to { .name } }] } } }] ,to: [(\`movie_ratings_User\`)-[\`movie_ratings_User_to_relation\`:\`FRIEND_OF\`]->(\`movie_ratings_User_to\`:\`User\`) | movie_ratings_User_to_relation { .since ,User: movie_ratings_User_to { .name ,friends: {from: [(\`movie_ratings_User_to\`)<-[\`movie_ratings_User_to_from_relation\`:\`FRIEND_OF\`]-(\`movie_ratings_User_to_from\`:\`User\`) | movie_ratings_User_to_from_relation { .since ,User: movie_ratings_User_to_from { .name } }] ,to: [(\`movie_ratings_User_to\`)-[\`movie_ratings_User_to_to_relation\`:\`FRIEND_OF\`]->(\`movie_ratings_User_to_to\`:\`User\`) | movie_ratings_User_to_to_relation { .since ,User: movie_ratings_User_to_to { .name } }] } } }] } }]) }] } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -2665,16 +3049,20 @@ test('query non-reflexive relation nested in reflexive relation', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {_id: ID(\`user\`), .name ,friends: {from: [(\`user\`)<-[\`user_from_relation\`:\`FRIEND_OF\`]-(\`user_from\`:\`User\`) | user_from_relation { .since ,User: user_from {_id: ID(\`user_from\`), .name ,rated: [(\`user_from\`)-[\`user_from_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_relation { .rating ,Movie: head([(:\`User\`)-[\`user_from_rated_relation\`]->(\`user_from_rated_Movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_Movie {_id: ID(\`user_from_rated_Movie\`),ratings: [(\`user_from_rated_Movie\`)<-[\`user_from_rated_Movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | user_from_rated_Movie_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`user_from_rated_Movie_ratings_relation\`]-(\`user_from_rated_Movie_ratings_User\`:\`User\`) | user_from_rated_Movie_ratings_User {_id: ID(\`user_from_rated_Movie_ratings_User\`),friends: {from: [(\`user_from_rated_Movie_ratings_User\`)<-[\`user_from_rated_Movie_ratings_User_from_relation\`:\`FRIEND_OF\`]-(\`user_from_rated_Movie_ratings_User_from\`:\`User\`) | user_from_rated_Movie_ratings_User_from_relation { .since ,User: user_from_rated_Movie_ratings_User_from {_id: ID(\`user_from_rated_Movie_ratings_User_from\`)} }] ,to: [(\`user_from_rated_Movie_ratings_User\`)-[\`user_from_rated_Movie_ratings_User_to_relation\`:\`FRIEND_OF\`]->(\`user_from_rated_Movie_ratings_User_to\`:\`User\`) | user_from_rated_Movie_ratings_User_to_relation { .since ,User: user_from_rated_Movie_ratings_User_to {_id: ID(\`user_from_rated_Movie_ratings_User_to\`)} }] } }]) }] }]) }] } }] ,to: [(\`user\`)-[\`user_to_relation\`:\`FRIEND_OF\`]->(\`user_to\`:\`User\`) | user_to_relation { .since ,User: user_to {_id: ID(\`user_to\`), .name ,rated: [(\`user_to\`)-[\`user_to_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_to_rated_relation { .rating ,Movie: head([(:\`User\`)-[\`user_to_rated_relation\`]->(\`user_to_rated_Movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_to_rated_Movie {_id: ID(\`user_to_rated_Movie\`)}]) }] } }] } } AS \`user\``;
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {_id: ID(\`user\`), .name ,friends: {from: [(\`user\`)<-[\`user_from_relation\`:\`FRIEND_OF\`]-(\`user_from\`:\`User\`) | user_from_relation { .since ,User: user_from {_id: ID(\`user_from\`), .name ,rated: [(\`user_from\`)-[\`user_from_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_relation { .rating ,Movie: head([(:\`User\`)-[\`user_from_rated_relation\`]->(\`user_from_rated_Movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_Movie {_id: ID(\`user_from_rated_Movie\`),ratings: [(\`user_from_rated_Movie\`)<-[\`user_from_rated_Movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | user_from_rated_Movie_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`user_from_rated_Movie_ratings_relation\`]-(\`user_from_rated_Movie_ratings_User\`:\`User\`) | user_from_rated_Movie_ratings_User {_id: ID(\`user_from_rated_Movie_ratings_User\`),friends: {from: [(\`user_from_rated_Movie_ratings_User\`)<-[\`user_from_rated_Movie_ratings_User_from_relation\`:\`FRIEND_OF\`]-(\`user_from_rated_Movie_ratings_User_from\`:\`User\`) | user_from_rated_Movie_ratings_User_from_relation { .since ,User: user_from_rated_Movie_ratings_User_from {_id: ID(\`user_from_rated_Movie_ratings_User_from\`)} }] ,to: [(\`user_from_rated_Movie_ratings_User\`)-[\`user_from_rated_Movie_ratings_User_to_relation\`:\`FRIEND_OF\`]->(\`user_from_rated_Movie_ratings_User_to\`:\`User\`) | user_from_rated_Movie_ratings_User_to_relation { .since ,User: user_from_rated_Movie_ratings_User_to {_id: ID(\`user_from_rated_Movie_ratings_User_to\`)} }] } }]) }] }]) }] } }] ,to: [(\`user\`)-[\`user_to_relation\`:\`FRIEND_OF\`]->(\`user_to\`:\`User\`) | user_to_relation { .since ,User: user_to {_id: ID(\`user_to\`), .name ,rated: [(\`user_to\`)-[\`user_to_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_to_rated_relation { .rating ,Movie: head([(:\`User\`)-[\`user_to_rated_relation\`]->(\`user_to_rated_Movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_to_rated_Movie {_id: ID(\`user_to_rated_Movie\`)}]) }] } }] } } AS \`user\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -2691,16 +3079,21 @@ test('query relation type with argument', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {_id: ID(\`user\`), .name ,rated: [(\`user\`)-[\`user_rated_relation\`:\`RATED\`{rating:$1_rating}]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_rated_relation { .rating ,Movie: head([(:\`User\`)-[\`user_rated_relation\`]->(\`user_rated_Movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_rated_Movie { .title }]) }] } AS \`user\``;
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {_id: ID(\`user\`), .name ,rated: [(\`user\`)-[\`user_rated_relation\`:\`RATED\`{rating:$1_rating}]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_rated_relation { .rating ,Movie: head([(:\`User\`)-[\`user_rated_relation\`]->(\`user_rated_Movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_rated_Movie { .title }]) }] } AS \`user\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_rating': 5,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -2726,16 +3119,22 @@ test('query reflexive relation type with arguments', t => {
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId , .name ,friends: {from: [(\`user\`)<-[\`user_from_relation\`:\`FRIEND_OF\`{since:$1_since}]-(\`user_from\`:\`User\`) | user_from_relation { .since ,User: user_from { .name } }] ,to: [(\`user\`)-[\`user_to_relation\`:\`FRIEND_OF\`{since:$3_since}]->(\`user_to\`:\`User\`) | user_to_relation { .since ,User: user_to { .name } }] } } AS \`user\``;
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId , .name ,friends: {from: [(\`user\`)<-[\`user_from_relation\`:\`FRIEND_OF\`{since:$1_since}]-(\`user_from\`:\`User\`) | user_from_relation { .since ,User: user_from { .name } }] ,to: [(\`user\`)-[\`user_to_relation\`:\`FRIEND_OF\`{since:$3_since}]->(\`user_to\`:\`User\`) | user_to_relation { .since ,User: user_to { .name } }] } } AS \`user\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      '1_since': 3,
+      '3_since': 5
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -2757,16 +3156,21 @@ test('query using inline fragment on object type - including cypherParams', t =>
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .name , .userId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: movie_ratings_User, cypherParams: $cypherParams, strArg: "Neo4j"}, false)}]) }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {title:$title}) RETURN \`movie\` { .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .name , .userId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: movie_ratings_User, cypherParams: $cypherParams, strArg: "Neo4j"}, false)}]) }] } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      title: 'River Runs Through It, A',
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -2788,16 +3192,22 @@ test('query interfaced relation using inline fragment and pagination', t => {
       year
     }
   }`,
-    expectedCypherQuery = `MATCH (\`actor\`:\`Actor\`) RETURN \`actor\` { .name ,knows: [(\`actor\`)-[:\`KNOWS\`]->(\`actor_knows\`:\`Person\`) WHERE ("User" IN labels(\`actor_knows\`)) | head([\`actor_knows\` IN [\`actor_knows\`] WHERE "User" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "User",  .name ,favorites: [(\`actor_knows\`)-[:\`FAVORITED\`]->(\`actor_knows_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`actor_knows_favorites\` { .movieId , .title , .year }]  }])][1..1] } AS \`actor\``;
+    expectedCypherQuery = `MATCH (\`actor\`:\`Actor\`) RETURN \`actor\` { .name ,knows: [(\`actor\`)-[:\`KNOWS\`]->(\`actor_knows\`:\`Person\`) WHERE ("User" IN labels(\`actor_knows\`)) | head([\`actor_knows\` IN [\`actor_knows\`] WHERE "User" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "User",  .name ,favorites: [(\`actor_knows\`)-[:\`FAVORITED\`]->(\`actor_knows_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`actor_knows_favorites\` { .movieId , .title , .year }]  }])][1..1] } AS \`actor\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_first': 0,
+      '1_offset': 1,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -2819,21 +3229,21 @@ test('order interfaced relation using inline fragment', t => {
     }
   }
 `,
-    expectedCypherQuery = `MATCH (\`actor\`:\`Actor\`) RETURN \`actor\` { .name ,knows: apoc.coll.sortMulti([(\`actor\`)-[:\`KNOWS\`]->(\`actor_knows\`:\`Person\`) WHERE ("Actor" IN labels(\`actor_knows\`) OR "CameraMan" IN labels(\`actor_knows\`) OR "User" IN labels(\`actor_knows\`)) | head([\`actor_knows\` IN [\`actor_knows\`] WHERE "Actor" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "Actor",  .name , .userId  }] + [\`actor_knows\` IN [\`actor_knows\`] WHERE "CameraMan" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "CameraMan",  .name , .userId  }] + [\`actor_knows\` IN [\`actor_knows\`] WHERE "User" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "User",  .userId ,favorites: [(\`actor_knows\`)-[:\`FAVORITED\`]->(\`actor_knows_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`actor_knows_favorites\` { .movieId , .title , .year }] , .name  }])], ['^userId']) } AS \`actor\``;
+    expectedCypherQuery = `MATCH (\`actor\`:\`Actor\`) RETURN \`actor\` { .name ,knows: apoc.coll.sortMulti([(\`actor\`)-[:\`KNOWS\`]->(\`actor_knows\`:\`Person\`) WHERE ("Actor" IN labels(\`actor_knows\`) OR "CameraMan" IN labels(\`actor_knows\`) OR "User" IN labels(\`actor_knows\`)) | head([\`actor_knows\` IN [\`actor_knows\`] WHERE "Actor" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "Actor",  .name , .userId  }] + [\`actor_knows\` IN [\`actor_knows\`] WHERE "CameraMan" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "CameraMan",  .name , .userId  }] + [\`actor_knows\` IN [\`actor_knows\`] WHERE "User" IN labels(\`actor_knows\`) | \`actor_knows\` { FRAGMENT_TYPE: "User",  .userId ,favorites: [(\`actor_knows\`)-[:\`FAVORITED\`]->(\`actor_knows_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`actor_knows_favorites\` { .movieId , .title , .year }] , .name  }])], ['^userId']) } AS \`actor\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_orderBy': 'userId_asc',
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {
-      offset: 0,
-      first: -1,
-      '1_orderBy': 'userId_asc',
-      cypherParams: CYPHER_PARAMS
-    }
+    expectedParams
   );
 });
 
@@ -2855,22 +3265,25 @@ test('query interfaced relationship type using inline fragment and pagination', 
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE ("Actor" IN labels(\`person\`) OR "CameraMan" IN labels(\`person\`) OR "User" IN labels(\`person\`)) RETURN head([\`person\` IN [\`person\`] WHERE "Actor" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "Actor",  .userId ,interfacedRelationshipType: [(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }][1..1] , .name  }] + [\`person\` IN [\`person\`] WHERE "CameraMan" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "CameraMan",  .name  }] + [\`person\` IN [\`person\`] WHERE "User" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "User",  .name  }]) AS \`person\``;
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE ("Actor" IN labels(\`person\`) OR "CameraMan" IN labels(\`person\`) OR "User" IN labels(\`person\`)) RETURN head([\`person\` IN [\`person\`] WHERE "Actor" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "Actor",  .userId ,interfacedRelationshipType: [(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }][1..1] , .name  }] + [\`person\` IN [\`person\`] WHERE "CameraMan" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "CameraMan",  .name  }] + [\`person\` IN [\`person\`] WHERE "User" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "User",  .name  }]) AS \`person\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_first': 0,
+      '1_offset': 1,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {
-      offset: 0,
-      first: -1,
-      cypherParams: CYPHER_PARAMS
-    }
+    expectedParams
   );
 });
+
 test('order interfaced relationship type using inline fragment', t => {
   const graphQLQuery = `query {
     Person {
@@ -2889,21 +3302,21 @@ test('order interfaced relationship type using inline fragment', t => {
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE ("Actor" IN labels(\`person\`) OR "CameraMan" IN labels(\`person\`) OR "User" IN labels(\`person\`)) RETURN head([\`person\` IN [\`person\`] WHERE "Actor" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "Actor",  .userId ,interfacedRelationshipType: apoc.coll.sortMulti([(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }], ['string']) , .name  }] + [\`person\` IN [\`person\`] WHERE "CameraMan" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "CameraMan",  .name  }] + [\`person\` IN [\`person\`] WHERE "User" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "User",  .name  }]) AS \`person\``;
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE ("Actor" IN labels(\`person\`) OR "CameraMan" IN labels(\`person\`) OR "User" IN labels(\`person\`)) RETURN head([\`person\` IN [\`person\`] WHERE "Actor" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "Actor",  .userId ,interfacedRelationshipType: apoc.coll.sortMulti([(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }], ['string']) , .name  }] + [\`person\` IN [\`person\`] WHERE "CameraMan" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "CameraMan",  .name  }] + [\`person\` IN [\`person\`] WHERE "User" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "User",  .name  }]) AS \`person\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_orderBy': ['string_desc'],
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {
-      offset: 0,
-      first: -1,
-      '1_orderBy': ['string_desc'],
-      cypherParams: CYPHER_PARAMS
-    }
+    expectedParams
   );
 });
 
@@ -2920,21 +3333,21 @@ test('query interfaced relationship type field for outgoing object type nodes', 
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: [(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }] } AS \`person\``;
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: [(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }] } AS \`person\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {
-      offset: 0,
-      first: -1,
-      cypherParams: CYPHER_PARAMS,
-      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    }
+    expectedParams
   );
 });
 
@@ -2951,22 +3364,22 @@ test('order interfaced relationship type field for outgoing object type nodes', 
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: apoc.coll.sortMulti([(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }], ['^string']) } AS \`person\``;
-
-  t.plan(1);
-
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery,
-    {
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: apoc.coll.sortMulti([(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }], ['^string']) } AS \`person\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       '1_orderBy': ['string_asc'],
       cypherParams: CYPHER_PARAMS,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    }
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -2991,16 +3404,8 @@ test('fliter interfaced relationship type field for outgoing object type nodes',
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE (EXISTS((\`person\`)-[:INTERFACED_RELATIONSHIP_TYPE]->(:Genre)) AND ALL(\`person_filter_genre\` IN [(\`person\`)-[\`_person_filter_genre\`:INTERFACED_RELATIONSHIP_TYPE]->(:Genre) | \`_person_filter_genre\`] WHERE (ALL(\`genre\` IN [(\`person\`)-[\`person_filter_genre\`]->(\`_genre\`:Genre) | \`_genre\`] WHERE (\`genre\`.name = $filter.interfacedRelationshipType.Genre.name))))) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: [(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) WHERE (\`person_interfacedRelationshipType_relation\`.string = $1_filter.string) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }] } AS \`person\``;
-
-  t.plan(1);
-
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery,
-    {
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE (EXISTS((\`person\`)-[:INTERFACED_RELATIONSHIP_TYPE]->(:Genre)) AND ALL(\`person_filter_genre\` IN [(\`person\`)-[\`_person_filter_genre\`:INTERFACED_RELATIONSHIP_TYPE]->(:Genre) | \`_person_filter_genre\`] WHERE (ALL(\`genre\` IN [(\`person\`)-[\`person_filter_genre\`]->(\`_genre\`:Genre) | \`_genre\`] WHERE (\`genre\`.name = $filter.interfacedRelationshipType.Genre.name))))) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: [(\`person\`)-[\`person_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) WHERE (\`person_interfacedRelationshipType_relation\`.string = $1_filter.string) | person_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_interfacedRelationshipType_relation\`]->(\`person_interfacedRelationshipType_Genre\`:\`Genre\`) | person_interfacedRelationshipType_Genre { .name }]) }] } AS \`person\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       filter: {
@@ -3015,7 +3420,15 @@ test('fliter interfaced relationship type field for outgoing object type nodes',
       },
       cypherParams: CYPHER_PARAMS,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    }
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -3032,21 +3445,21 @@ test('query interfaced relationship type field for incoming interface type nodes
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) | genre_interfacedRelationshipType_Person {FRAGMENT_TYPE: head( [ label IN labels(genre_interfacedRelationshipType_Person) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]) }] } AS \`genre\``;
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) | genre_interfacedRelationshipType_Person {FRAGMENT_TYPE: head( [ label IN labels(genre_interfacedRelationshipType_Person) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]) }] } AS \`genre\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {
-      offset: 0,
-      first: -1,
-      Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
-      cypherParams: CYPHER_PARAMS
-    }
+    expectedParams
   );
 });
 
@@ -3063,22 +3476,22 @@ test('order interfaced relationship type field for incoming interface type nodes
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: apoc.coll.sortMulti([(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) | genre_interfacedRelationshipType_Person {FRAGMENT_TYPE: head( [ label IN labels(genre_interfacedRelationshipType_Person) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]) }], ['string']) } AS \`genre\``;
-
-  t.plan(1);
-
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery,
-    {
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: apoc.coll.sortMulti([(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) | genre_interfacedRelationshipType_Person {FRAGMENT_TYPE: head( [ label IN labels(genre_interfacedRelationshipType_Person) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]) }], ['string']) } AS \`genre\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       '1_orderBy': 'string_desc',
       Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
       cypherParams: CYPHER_PARAMS
-    }
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -3106,16 +3519,8 @@ test('fliter interfaced relationship type field for incoming interface type node
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) WHERE (EXISTS((\`genre\`)<-[:INTERFACED_RELATIONSHIP_TYPE]-(:Person)) AND ALL(\`genre_filter_person\` IN [(\`genre\`)<-[\`_genre_filter_person\`:INTERFACED_RELATIONSHIP_TYPE]-(:Person) | \`_genre_filter_person\`] WHERE (ALL(\`person\` IN [(\`genre\`)<-[\`genre_filter_person\`]-(\`_person\`:Person) | \`_person\`] WHERE (\`person\`.userId = $filter.interfacedRelationshipType.Person.userId))))) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) WHERE (\`genre_interfacedRelationshipType_relation\`.string = $1_filter.string) AND (ALL(\`genre_filter_person\` IN [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`_person\`:Person) | \`_person\`] WHERE (\`genre_filter_person\`.name IN $1_filter.Person.name_in))) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) | genre_interfacedRelationshipType_Person {FRAGMENT_TYPE: head( [ label IN labels(genre_interfacedRelationshipType_Person) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]) }] } AS \`genre\``;
-
-  t.plan(1);
-
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery,
-    {
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) WHERE (EXISTS((\`genre\`)<-[:INTERFACED_RELATIONSHIP_TYPE]-(:Person)) AND ALL(\`genre_filter_person\` IN [(\`genre\`)<-[\`_genre_filter_person\`:INTERFACED_RELATIONSHIP_TYPE]-(:Person) | \`_genre_filter_person\`] WHERE (ALL(\`person\` IN [(\`genre\`)<-[\`genre_filter_person\`]-(\`_person\`:Person) | \`_person\`] WHERE (\`person\`.userId = $filter.interfacedRelationshipType.Person.userId))))) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) WHERE (\`genre_interfacedRelationshipType_relation\`.string = $1_filter.string) AND (ALL(\`genre_filter_person\` IN [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`_person\`:Person) | \`_person\`] WHERE (\`genre_filter_person\`.name IN $1_filter.Person.name_in))) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) | genre_interfacedRelationshipType_Person {FRAGMENT_TYPE: head( [ label IN labels(genre_interfacedRelationshipType_Person) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]) }] } AS \`genre\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       filter: {
@@ -3133,7 +3538,15 @@ test('fliter interfaced relationship type field for incoming interface type node
       },
       Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
       cypherParams: CYPHER_PARAMS
-    }
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -3157,20 +3570,20 @@ test('query incoming interface type nodes using fragments in relationship type f
   fragment UserFragment on User {
     userId
   }`,
-    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) WHERE ("User" IN labels(genre_interfacedRelationshipType_Person)) | head([\`genre_interfacedRelationshipType_Person\` IN [\`genre_interfacedRelationshipType_Person\`] WHERE "User" IN labels(\`genre_interfacedRelationshipType_Person\`) | \`genre_interfacedRelationshipType_Person\` { FRAGMENT_TYPE: "User",  .name , .userId  }])]) }] } AS \`genre\``;
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) WHERE ("User" IN labels(genre_interfacedRelationshipType_Person)) | head([\`genre_interfacedRelationshipType_Person\` IN [\`genre_interfacedRelationshipType_Person\`] WHERE "User" IN labels(\`genre_interfacedRelationshipType_Person\`) | \`genre_interfacedRelationshipType_Person\` { FRAGMENT_TYPE: "User",  .name , .userId  }])]) }] } AS \`genre\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {
-      offset: 0,
-      first: -1,
-      cypherParams: CYPHER_PARAMS
-    }
+    expectedParams
   );
 });
 
@@ -3194,21 +3607,21 @@ test('order incoming interface type nodes using fragments in relationship type f
   fragment UserFragment on User {
     userId
   }`,
-    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: apoc.coll.sortMulti([(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) WHERE ("User" IN labels(genre_interfacedRelationshipType_Person)) | head([\`genre_interfacedRelationshipType_Person\` IN [\`genre_interfacedRelationshipType_Person\`] WHERE "User" IN labels(\`genre_interfacedRelationshipType_Person\`) | \`genre_interfacedRelationshipType_Person\` { FRAGMENT_TYPE: "User",  .name , .userId  }])]) }], ['^string']) } AS \`genre\``;
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: apoc.coll.sortMulti([(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) WHERE ("User" IN labels(genre_interfacedRelationshipType_Person)) | head([\`genre_interfacedRelationshipType_Person\` IN [\`genre_interfacedRelationshipType_Person\`] WHERE "User" IN labels(\`genre_interfacedRelationshipType_Person\`) | \`genre_interfacedRelationshipType_Person\` { FRAGMENT_TYPE: "User",  .name , .userId  }])]) }], ['^string']) } AS \`genre\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_orderBy': 'string_asc',
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {
-      offset: 0,
-      first: -1,
-      '1_orderBy': 'string_asc',
-      cypherParams: CYPHER_PARAMS
-    }
+    expectedParams
   );
 });
 
@@ -3228,16 +3641,8 @@ test('filter incoming interface type nodes using only fragments in relationship 
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) WHERE (ALL(\`genre_filter_person\` IN [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`_person\`:Person) | \`_person\`] WHERE (NOT \`genre_filter_person\`.name IN $1_filter.Person.name_not_in))) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) WHERE ("User" IN labels(genre_interfacedRelationshipType_Person)) | head([\`genre_interfacedRelationshipType_Person\` IN [\`genre_interfacedRelationshipType_Person\`] WHERE "User" IN labels(\`genre_interfacedRelationshipType_Person\`) | \`genre_interfacedRelationshipType_Person\` { FRAGMENT_TYPE: "User",  .userId  }])]) }] } AS \`genre\``;
-
-  t.plan(1);
-
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery,
-    {
+    expectedCypherQuery = `MATCH (\`genre\`:\`Genre\`) RETURN \`genre\` { .name ,interfacedRelationshipType: [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]-(:\`Person\`) WHERE (ALL(\`genre_filter_person\` IN [(\`genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`_person\`:Person) | \`_person\`] WHERE (NOT \`genre_filter_person\`.name IN $1_filter.Person.name_not_in))) | genre_interfacedRelationshipType_relation { .string ,Person: head([(:\`Genre\`)<-[\`genre_interfacedRelationshipType_relation\`]-(\`genre_interfacedRelationshipType_Person\`:\`Person\`) WHERE ("User" IN labels(genre_interfacedRelationshipType_Person)) | head([\`genre_interfacedRelationshipType_Person\` IN [\`genre_interfacedRelationshipType_Person\`] WHERE "User" IN labels(\`genre_interfacedRelationshipType_Person\`) | \`genre_interfacedRelationshipType_Person\` { FRAGMENT_TYPE: "User",  .userId  }])]) }] } AS \`genre\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       '1_filter': {
@@ -3246,7 +3651,15 @@ test('filter incoming interface type nodes using only fragments in relationship 
         }
       },
       cypherParams: CYPHER_PARAMS
-    }
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -3281,21 +3694,21 @@ test('query reflexive interfaced relationship type field using fragments', t => 
     name
     userId
   }`,
-    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,reflexiveInterfacedRelationshipType: {from: [(\`person\`)<-[\`person_from_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]-(\`person_from\`:\`Person\`) | person_from_relation { .boolean ,Person: head([\`person_from\` IN [\`person_from\`] WHERE "User" IN labels(\`person_from\`) | \`person_from\` { FRAGMENT_TYPE: "User",  .name , .userId  }]) }] ,to: [(\`person\`)-[\`person_to_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]->(\`person_to\`:\`Person\`) | person_to_relation { .boolean ,Person: head([\`person_to\` IN [\`person_to\`] WHERE "Actor" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "Actor",  .name , .userId  }] + [\`person_to\` IN [\`person_to\`] WHERE "CameraMan" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "CameraMan",  .userId  }] + [\`person_to\` IN [\`person_to\`] WHERE "User" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "User",  .userId  }]) }] } } AS \`person\``;
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,reflexiveInterfacedRelationshipType: {from: [(\`person\`)<-[\`person_from_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]-(\`person_from\`:\`Person\`) | person_from_relation { .boolean ,Person: head([\`person_from\` IN [\`person_from\`] WHERE "User" IN labels(\`person_from\`) | \`person_from\` { FRAGMENT_TYPE: "User",  .name , .userId  }]) }] ,to: [(\`person\`)-[\`person_to_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]->(\`person_to\`:\`Person\`) | person_to_relation { .boolean ,Person: head([\`person_to\` IN [\`person_to\`] WHERE "Actor" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "Actor",  .name , .userId  }] + [\`person_to\` IN [\`person_to\`] WHERE "CameraMan" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "CameraMan",  .userId  }] + [\`person_to\` IN [\`person_to\`] WHERE "User" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "User",  .userId  }]) }] } } AS \`person\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {
-      offset: 0,
-      first: -1,
-      cypherParams: CYPHER_PARAMS,
-      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    }
+    expectedParams
   );
 });
 
@@ -3315,23 +3728,23 @@ test('order incoming and outgoing nodes of reflexive interfaced relationship typ
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,reflexiveInterfacedRelationshipType: {from: apoc.coll.sortMulti([(\`person\`)<-[\`person_from_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]-(\`person_from\`:\`Person\`) | person_from_relation { .boolean }], ['boolean']) ,to: apoc.coll.sortMulti([(\`person\`)-[\`person_to_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]->(\`person_to\`:\`Person\`) | person_to_relation { .boolean }], ['^boolean']) } } AS \`person\``;
-
-  t.plan(1);
-
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery,
-    {
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,reflexiveInterfacedRelationshipType: {from: apoc.coll.sortMulti([(\`person\`)<-[\`person_from_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]-(\`person_from\`:\`Person\`) | person_from_relation { .boolean }], ['boolean']) ,to: apoc.coll.sortMulti([(\`person\`)-[\`person_to_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]->(\`person_to\`:\`Person\`) | person_to_relation { .boolean }], ['^boolean']) } } AS \`person\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       '1_orderBy': 'boolean_desc',
       '3_orderBy': 'boolean_asc',
       cypherParams: CYPHER_PARAMS,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    }
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -3370,16 +3783,8 @@ test('filter reflexive interfaced relationship type field', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE (\`person\`.name IN $filter.name_in) AND ((EXISTS((\`person\`)-[:REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE]->(:Person)) AND ALL(\`person_filter_person\` IN [(\`person\`)-[\`_person_filter_person\`:REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE]->(:Person) | \`_person_filter_person\`] WHERE (ALL(\`person\` IN [(\`person\`)-[\`person_filter_person\`]->(\`_person\`:Person) | \`_person\`] WHERE (\`person\`.name IN $filter.reflexiveInterfacedRelationshipType.to.Person.name_in)))))) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,reflexiveInterfacedRelationshipType: {to: [(\`person\`)-[\`person_to_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]->(\`person_to\`:\`Person\`) WHERE (\`person_to_relation\`.boolean = $1_filter.boolean) | person_to_relation { .boolean ,Person: person_to {FRAGMENT_TYPE: head( [ label IN labels(person_to) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: [(\`person_to\`)-[\`person_to_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_to_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_to_interfacedRelationshipType_relation\`]->(\`person_to_interfacedRelationshipType_Genre\`:\`Genre\`) | person_to_interfacedRelationshipType_Genre { .name }]) }][..1] } }][0..1] } } AS \`person\``;
-
-  t.plan(1);
-
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery,
-    {
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE (\`person\`.name IN $filter.name_in) AND ((EXISTS((\`person\`)-[:REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE]->(:Person)) AND ALL(\`person_filter_person\` IN [(\`person\`)-[\`_person_filter_person\`:REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE]->(:Person) | \`_person_filter_person\`] WHERE (ALL(\`person\` IN [(\`person\`)-[\`person_filter_person\`]->(\`_person\`:Person) | \`_person\`] WHERE (\`person\`.name IN $filter.reflexiveInterfacedRelationshipType.to.Person.name_in)))))) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,reflexiveInterfacedRelationshipType: {to: [(\`person\`)-[\`person_to_relation\`:\`REFLEXIVE_INTERFACED_RELATIONSHIP_TYPE\`]->(\`person_to\`:\`Person\`) WHERE (\`person_to_relation\`.boolean = $1_filter.boolean) | person_to_relation { .boolean ,Person: person_to {FRAGMENT_TYPE: head( [ label IN labels(person_to) WHERE label IN $Person_derivedTypes ] ), .userId , .name ,interfacedRelationshipType: [(\`person_to\`)-[\`person_to_interfacedRelationshipType_relation\`:\`INTERFACED_RELATIONSHIP_TYPE\`]->(:\`Genre\`) | person_to_interfacedRelationshipType_relation { .string ,Genre: head([(:\`Person\`)-[\`person_to_interfacedRelationshipType_relation\`]->(\`person_to_interfacedRelationshipType_Genre\`:\`Genre\`) | person_to_interfacedRelationshipType_Genre { .name }]) }][..1] } }][0..1] } } AS \`person\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       filter: {
@@ -3395,9 +3800,20 @@ test('filter reflexive interfaced relationship type field', t => {
       '1_filter': {
         boolean: true
       },
+      '1_first': 1,
+      '1_offset': 0,
+      '2_first': 1,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
       cypherParams: CYPHER_PARAMS
-    }
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -3507,16 +3923,139 @@ test('Create node with temporal properties', t => {
     expectedCypherQuery = `
     CREATE (\`temporalNode\`:\`TemporalNode\` {datetime: datetime($params.datetime),time: time($params.time),date: date($params.date),localtime: localtime($params.localtime),localdatetime: localdatetime($params.localdatetime)})
     RETURN \`temporalNode\` {_id: ID(\`temporalNode\`),time: { hour: \`temporalNode\`.time.hour , minute: \`temporalNode\`.time.minute , second: \`temporalNode\`.time.second , millisecond: \`temporalNode\`.time.millisecond , microsecond: \`temporalNode\`.time.microsecond , nanosecond: \`temporalNode\`.time.nanosecond , timezone: \`temporalNode\`.time.timezone , formatted: toString(\`temporalNode\`.time) },date: { year: \`temporalNode\`.date.year , month: \`temporalNode\`.date.month , day: \`temporalNode\`.date.day , formatted: toString(\`temporalNode\`.date) },datetime: { year: \`temporalNode\`.datetime.year , month: \`temporalNode\`.datetime.month , day: \`temporalNode\`.datetime.day , hour: \`temporalNode\`.datetime.hour , minute: \`temporalNode\`.datetime.minute , second: \`temporalNode\`.datetime.second , millisecond: \`temporalNode\`.datetime.millisecond , microsecond: \`temporalNode\`.datetime.microsecond , nanosecond: \`temporalNode\`.datetime.nanosecond , timezone: \`temporalNode\`.datetime.timezone , formatted: toString(\`temporalNode\`.datetime) },localtime: { hour: \`temporalNode\`.localtime.hour , minute: \`temporalNode\`.localtime.minute , second: \`temporalNode\`.localtime.second , millisecond: \`temporalNode\`.localtime.millisecond , microsecond: \`temporalNode\`.localtime.microsecond , nanosecond: \`temporalNode\`.localtime.nanosecond , formatted: toString(\`temporalNode\`.localtime) },localdatetime: { year: \`temporalNode\`.localdatetime.year , month: \`temporalNode\`.localdatetime.month , day: \`temporalNode\`.localdatetime.day , hour: \`temporalNode\`.localdatetime.hour , minute: \`temporalNode\`.localdatetime.minute , second: \`temporalNode\`.localdatetime.second , millisecond: \`temporalNode\`.localdatetime.millisecond , microsecond: \`temporalNode\`.localdatetime.microsecond , nanosecond: \`temporalNode\`.localdatetime.nanosecond , formatted: toString(\`temporalNode\`.localdatetime) }} AS \`temporalNode\`
-  `;
+  `,
+    expectedParams = {
+      params: {
+        datetime: {
+          year: {
+            low: 2018,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 23,
+            high: 0
+          },
+          hour: {
+            low: 10,
+            high: 0
+          },
+          minute: {
+            low: 30,
+            high: 0
+          },
+          second: {
+            low: 1,
+            high: 0
+          },
+          millisecond: {
+            low: 2,
+            high: 0
+          },
+          microsecond: {
+            low: 3,
+            high: 0
+          },
+          nanosecond: {
+            low: 4,
+            high: 0
+          },
+          timezone: 'America/Los_Angeles'
+        },
+        time: '10:30:01.002003004-08:00',
+        date: {
+          year: {
+            low: 2018,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 23,
+            high: 0
+          }
+        },
+        localtime: {
+          hour: {
+            low: 10,
+            high: 0
+          },
+          minute: {
+            low: 30,
+            high: 0
+          },
+          second: {
+            low: 1,
+            high: 0
+          },
+          millisecond: {
+            low: 2,
+            high: 0
+          },
+          microsecond: {
+            low: 3,
+            high: 0
+          },
+          nanosecond: {
+            low: 4,
+            high: 0
+          }
+        },
+        localdatetime: {
+          year: {
+            low: 2018,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 23,
+            high: 0
+          },
+          hour: {
+            low: 10,
+            high: 0
+          },
+          minute: {
+            low: 30,
+            high: 0
+          },
+          second: {
+            low: 1,
+            high: 0
+          },
+          millisecond: {
+            low: 2,
+            high: 0
+          },
+          microsecond: {
+            low: 3,
+            high: 0
+          },
+          nanosecond: {
+            low: 4,
+            high: 0
+          }
+        }
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -3538,16 +4077,27 @@ test('Create node with spatial properties', t => {
     expectedCypherQuery = `
     CREATE (\`spatialNode\`:\`SpatialNode\` {id:$params.id,point: point($params.point)})
     RETURN \`spatialNode\` { .id ,point: { longitude: \`spatialNode\`.point.longitude , latitude: \`spatialNode\`.point.latitude , height: \`spatialNode\`.point.height , crs: \`spatialNode\`.point.crs }} AS \`spatialNode\`
-  `;
+  `,
+    expectedParams = {
+      params: {
+        id: 'xyz',
+        point: {
+          longitude: 40,
+          latitude: 50,
+          height: 60
+        }
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -3655,16 +4205,66 @@ test('Query node with temporal properties using temporal arguments', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`temporalNode\`:\`TemporalNode\`) WHERE \`temporalNode\`.datetime.year = $datetime.year AND \`temporalNode\`.datetime.month = $datetime.month AND \`temporalNode\`.datetime.day = $datetime.day AND \`temporalNode\`.datetime.hour = $datetime.hour AND \`temporalNode\`.datetime.minute = $datetime.minute AND \`temporalNode\`.datetime.second = $datetime.second AND \`temporalNode\`.datetime.millisecond = $datetime.millisecond AND \`temporalNode\`.datetime.microsecond = $datetime.microsecond AND \`temporalNode\`.datetime.nanosecond = $datetime.nanosecond AND \`temporalNode\`.datetime.timezone = $datetime.timezone AND \`temporalNode\`.time = time($time.formatted) AND \`temporalNode\`.date.year = $date.year AND \`temporalNode\`.date.month = $date.month AND \`temporalNode\`.date.day = $date.day AND \`temporalNode\`.localtime.hour = $localtime.hour AND \`temporalNode\`.localtime.minute = $localtime.minute AND \`temporalNode\`.localtime.second = $localtime.second AND \`temporalNode\`.localtime.millisecond = $localtime.millisecond AND \`temporalNode\`.localtime.microsecond = $localtime.microsecond AND \`temporalNode\`.localtime.nanosecond = $localtime.nanosecond AND \`temporalNode\`.localdatetime = localdatetime($localdatetime.formatted) RETURN \`temporalNode\` {_id: ID(\`temporalNode\`),time: { hour: \`temporalNode\`.time.hour , minute: \`temporalNode\`.time.minute , second: \`temporalNode\`.time.second , millisecond: \`temporalNode\`.time.millisecond , microsecond: \`temporalNode\`.time.microsecond , nanosecond: \`temporalNode\`.time.nanosecond , timezone: \`temporalNode\`.time.timezone , formatted: toString(\`temporalNode\`.time) },date: { year: \`temporalNode\`.date.year , month: \`temporalNode\`.date.month , day: \`temporalNode\`.date.day , formatted: toString(\`temporalNode\`.date) },datetime: { year: \`temporalNode\`.datetime.year , month: \`temporalNode\`.datetime.month , day: \`temporalNode\`.datetime.day , hour: \`temporalNode\`.datetime.hour , minute: \`temporalNode\`.datetime.minute , second: \`temporalNode\`.datetime.second , millisecond: \`temporalNode\`.datetime.millisecond , microsecond: \`temporalNode\`.datetime.microsecond , nanosecond: \`temporalNode\`.datetime.nanosecond , timezone: \`temporalNode\`.datetime.timezone , formatted: toString(\`temporalNode\`.datetime) },localtime: { hour: \`temporalNode\`.localtime.hour , minute: \`temporalNode\`.localtime.minute , second: \`temporalNode\`.localtime.second , millisecond: \`temporalNode\`.localtime.millisecond , microsecond: \`temporalNode\`.localtime.microsecond , nanosecond: \`temporalNode\`.localtime.nanosecond , formatted: toString(\`temporalNode\`.localtime) },localdatetime: { year: \`temporalNode\`.localdatetime.year , month: \`temporalNode\`.localdatetime.month , day: \`temporalNode\`.localdatetime.day , hour: \`temporalNode\`.localdatetime.hour , minute: \`temporalNode\`.localdatetime.minute , second: \`temporalNode\`.localdatetime.second , millisecond: \`temporalNode\`.localdatetime.millisecond , microsecond: \`temporalNode\`.localdatetime.microsecond , nanosecond: \`temporalNode\`.localdatetime.nanosecond , formatted: toString(\`temporalNode\`.localdatetime) }} AS \`temporalNode\``;
+    expectedCypherQuery = `MATCH (\`temporalNode\`:\`TemporalNode\`) WHERE \`temporalNode\`.datetime.year = $datetime.year AND \`temporalNode\`.datetime.month = $datetime.month AND \`temporalNode\`.datetime.day = $datetime.day AND \`temporalNode\`.datetime.hour = $datetime.hour AND \`temporalNode\`.datetime.minute = $datetime.minute AND \`temporalNode\`.datetime.second = $datetime.second AND \`temporalNode\`.datetime.millisecond = $datetime.millisecond AND \`temporalNode\`.datetime.microsecond = $datetime.microsecond AND \`temporalNode\`.datetime.nanosecond = $datetime.nanosecond AND \`temporalNode\`.datetime.timezone = $datetime.timezone AND \`temporalNode\`.time = time($time.formatted) AND \`temporalNode\`.date.year = $date.year AND \`temporalNode\`.date.month = $date.month AND \`temporalNode\`.date.day = $date.day AND \`temporalNode\`.localtime.hour = $localtime.hour AND \`temporalNode\`.localtime.minute = $localtime.minute AND \`temporalNode\`.localtime.second = $localtime.second AND \`temporalNode\`.localtime.millisecond = $localtime.millisecond AND \`temporalNode\`.localtime.microsecond = $localtime.microsecond AND \`temporalNode\`.localtime.nanosecond = $localtime.nanosecond AND \`temporalNode\`.localdatetime = localdatetime($localdatetime.formatted) RETURN \`temporalNode\` {_id: ID(\`temporalNode\`),time: { hour: \`temporalNode\`.time.hour , minute: \`temporalNode\`.time.minute , second: \`temporalNode\`.time.second , millisecond: \`temporalNode\`.time.millisecond , microsecond: \`temporalNode\`.time.microsecond , nanosecond: \`temporalNode\`.time.nanosecond , timezone: \`temporalNode\`.time.timezone , formatted: toString(\`temporalNode\`.time) },date: { year: \`temporalNode\`.date.year , month: \`temporalNode\`.date.month , day: \`temporalNode\`.date.day , formatted: toString(\`temporalNode\`.date) },datetime: { year: \`temporalNode\`.datetime.year , month: \`temporalNode\`.datetime.month , day: \`temporalNode\`.datetime.day , hour: \`temporalNode\`.datetime.hour , minute: \`temporalNode\`.datetime.minute , second: \`temporalNode\`.datetime.second , millisecond: \`temporalNode\`.datetime.millisecond , microsecond: \`temporalNode\`.datetime.microsecond , nanosecond: \`temporalNode\`.datetime.nanosecond , timezone: \`temporalNode\`.datetime.timezone , formatted: toString(\`temporalNode\`.datetime) },localtime: { hour: \`temporalNode\`.localtime.hour , minute: \`temporalNode\`.localtime.minute , second: \`temporalNode\`.localtime.second , millisecond: \`temporalNode\`.localtime.millisecond , microsecond: \`temporalNode\`.localtime.microsecond , nanosecond: \`temporalNode\`.localtime.nanosecond , formatted: toString(\`temporalNode\`.localtime) },localdatetime: { year: \`temporalNode\`.localdatetime.year , month: \`temporalNode\`.localdatetime.month , day: \`temporalNode\`.localdatetime.day , hour: \`temporalNode\`.localdatetime.hour , minute: \`temporalNode\`.localdatetime.minute , second: \`temporalNode\`.localdatetime.second , millisecond: \`temporalNode\`.localdatetime.millisecond , microsecond: \`temporalNode\`.localdatetime.microsecond , nanosecond: \`temporalNode\`.localdatetime.nanosecond , formatted: toString(\`temporalNode\`.localdatetime) }} AS \`temporalNode\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      datetime: {
+        year: 2018,
+        month: 11,
+        day: 23,
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004,
+        timezone: 'America/Los_Angeles'
+      },
+      time: {
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004,
+        timezone: '-08:00',
+        formatted: '10:30:01.002003004-08:00'
+      },
+      date: {
+        year: 2018,
+        month: 11,
+        day: 23
+      },
+      localtime: {
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004
+      },
+      localdatetime: {
+        year: 2018,
+        month: 11,
+        day: 23,
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004,
+        formatted: '2018-11-23T10:30:01.002003004'
+      }
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -3684,16 +4284,25 @@ test('Query node with spatial properties', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`spatialNode\`:\`SpatialNode\`) WHERE \`spatialNode\`.point.longitude = $point.longitude AND \`spatialNode\`.point.latitude = $point.latitude AND \`spatialNode\`.point.height = $point.height RETURN \`spatialNode\` { .id ,point: { longitude: \`spatialNode\`.point.longitude , latitude: \`spatialNode\`.point.latitude , height: \`spatialNode\`.point.height , crs: \`spatialNode\`.point.crs }} AS \`spatialNode\``;
+    expectedCypherQuery = `MATCH (\`spatialNode\`:\`SpatialNode\`) WHERE \`spatialNode\`.point.longitude = $point.longitude AND \`spatialNode\`.point.latitude = $point.latitude AND \`spatialNode\`.point.height = $point.height RETURN \`spatialNode\` { .id ,point: { longitude: \`spatialNode\`.point.longitude , latitude: \`spatialNode\`.point.latitude , height: \`spatialNode\`.point.height , crs: \`spatialNode\`.point.crs }} AS \`spatialNode\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      point: {
+        longitude: 40,
+        latitude: 50,
+        height: 60
+      }
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -3844,16 +4453,55 @@ test('Nested Query with temporal property arguments', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`temporalNode\`:\`TemporalNode\`) WHERE \`temporalNode\`.datetime.year = $datetime.year AND \`temporalNode\`.datetime.month = $datetime.month AND \`temporalNode\`.datetime.day = $datetime.day AND \`temporalNode\`.datetime.hour = $datetime.hour AND \`temporalNode\`.datetime.minute = $datetime.minute AND \`temporalNode\`.datetime.second = $datetime.second AND \`temporalNode\`.datetime.millisecond = $datetime.millisecond AND \`temporalNode\`.datetime.microsecond = $datetime.microsecond AND \`temporalNode\`.datetime.nanosecond = $datetime.nanosecond AND \`temporalNode\`.datetime.timezone = $datetime.timezone RETURN \`temporalNode\` {_id: ID(\`temporalNode\`),time: { hour: \`temporalNode\`.time.hour , minute: \`temporalNode\`.time.minute , second: \`temporalNode\`.time.second , millisecond: \`temporalNode\`.time.millisecond , microsecond: \`temporalNode\`.time.microsecond , nanosecond: \`temporalNode\`.time.nanosecond , timezone: \`temporalNode\`.time.timezone , formatted: toString(\`temporalNode\`.time) },date: { year: \`temporalNode\`.date.year , month: \`temporalNode\`.date.month , day: \`temporalNode\`.date.day , formatted: toString(\`temporalNode\`.date) },datetime: { year: \`temporalNode\`.datetime.year , month: \`temporalNode\`.datetime.month , day: \`temporalNode\`.datetime.day , hour: \`temporalNode\`.datetime.hour , minute: \`temporalNode\`.datetime.minute , second: \`temporalNode\`.datetime.second , millisecond: \`temporalNode\`.datetime.millisecond , microsecond: \`temporalNode\`.datetime.microsecond , nanosecond: \`temporalNode\`.datetime.nanosecond , timezone: \`temporalNode\`.datetime.timezone , formatted: toString(\`temporalNode\`.datetime) },localtime: { hour: \`temporalNode\`.localtime.hour , minute: \`temporalNode\`.localtime.minute , second: \`temporalNode\`.localtime.second , millisecond: \`temporalNode\`.localtime.millisecond , microsecond: \`temporalNode\`.localtime.microsecond , nanosecond: \`temporalNode\`.localtime.nanosecond , formatted: toString(\`temporalNode\`.localtime) },localdatetime: { year: \`temporalNode\`.localdatetime.year , month: \`temporalNode\`.localdatetime.month , day: \`temporalNode\`.localdatetime.day , hour: \`temporalNode\`.localdatetime.hour , minute: \`temporalNode\`.localdatetime.minute , second: \`temporalNode\`.localdatetime.second , millisecond: \`temporalNode\`.localdatetime.millisecond , microsecond: \`temporalNode\`.localdatetime.microsecond , nanosecond: \`temporalNode\`.localdatetime.nanosecond , formatted: toString(\`temporalNode\`.localdatetime) },temporalNodes: [(\`temporalNode\`)-[:\`TEMPORAL\`]->(\`temporalNode_temporalNodes\`:\`TemporalNode\`) WHERE temporalNode_temporalNodes.datetime.year = $1_datetime.year AND temporalNode_temporalNodes.datetime.month = $1_datetime.month AND temporalNode_temporalNodes.datetime.day = $1_datetime.day AND temporalNode_temporalNodes.datetime.hour = $1_datetime.hour AND temporalNode_temporalNodes.datetime.minute = $1_datetime.minute AND temporalNode_temporalNodes.datetime.second = $1_datetime.second AND temporalNode_temporalNodes.datetime.millisecond = $1_datetime.millisecond AND temporalNode_temporalNodes.datetime.microsecond = $1_datetime.microsecond AND temporalNode_temporalNodes.datetime.nanosecond = $1_datetime.nanosecond AND temporalNode_temporalNodes.datetime.timezone = $1_datetime.timezone AND temporalNode_temporalNodes.localdatetime = localdatetime($1_localdatetime.formatted) | \`temporalNode_temporalNodes\` {_id: ID(\`temporalNode_temporalNodes\`),time: { hour: \`temporalNode_temporalNodes\`.time.hour , minute: \`temporalNode_temporalNodes\`.time.minute , second: \`temporalNode_temporalNodes\`.time.second , millisecond: \`temporalNode_temporalNodes\`.time.millisecond , microsecond: \`temporalNode_temporalNodes\`.time.microsecond , nanosecond: \`temporalNode_temporalNodes\`.time.nanosecond , timezone: \`temporalNode_temporalNodes\`.time.timezone , formatted: toString(\`temporalNode_temporalNodes\`.time) },date: { year: \`temporalNode_temporalNodes\`.date.year , month: \`temporalNode_temporalNodes\`.date.month , day: \`temporalNode_temporalNodes\`.date.day , formatted: toString(\`temporalNode_temporalNodes\`.date) },datetime: { year: \`temporalNode_temporalNodes\`.datetime.year , month: \`temporalNode_temporalNodes\`.datetime.month , day: \`temporalNode_temporalNodes\`.datetime.day , hour: \`temporalNode_temporalNodes\`.datetime.hour , minute: \`temporalNode_temporalNodes\`.datetime.minute , second: \`temporalNode_temporalNodes\`.datetime.second , millisecond: \`temporalNode_temporalNodes\`.datetime.millisecond , microsecond: \`temporalNode_temporalNodes\`.datetime.microsecond , nanosecond: \`temporalNode_temporalNodes\`.datetime.nanosecond , timezone: \`temporalNode_temporalNodes\`.datetime.timezone , formatted: toString(\`temporalNode_temporalNodes\`.datetime) },localtime: { hour: \`temporalNode_temporalNodes\`.localtime.hour , minute: \`temporalNode_temporalNodes\`.localtime.minute , second: \`temporalNode_temporalNodes\`.localtime.second , millisecond: \`temporalNode_temporalNodes\`.localtime.millisecond , microsecond: \`temporalNode_temporalNodes\`.localtime.microsecond , nanosecond: \`temporalNode_temporalNodes\`.localtime.nanosecond , formatted: toString(\`temporalNode_temporalNodes\`.localtime) },localdatetime: { year: \`temporalNode_temporalNodes\`.localdatetime.year , month: \`temporalNode_temporalNodes\`.localdatetime.month , day: \`temporalNode_temporalNodes\`.localdatetime.day , hour: \`temporalNode_temporalNodes\`.localdatetime.hour , minute: \`temporalNode_temporalNodes\`.localdatetime.minute , second: \`temporalNode_temporalNodes\`.localdatetime.second , millisecond: \`temporalNode_temporalNodes\`.localdatetime.millisecond , microsecond: \`temporalNode_temporalNodes\`.localdatetime.microsecond , nanosecond: \`temporalNode_temporalNodes\`.localdatetime.nanosecond , formatted: toString(\`temporalNode_temporalNodes\`.localdatetime) }}] } AS \`temporalNode\``;
+    expectedCypherQuery = `MATCH (\`temporalNode\`:\`TemporalNode\`) WHERE \`temporalNode\`.datetime.year = $datetime.year AND \`temporalNode\`.datetime.month = $datetime.month AND \`temporalNode\`.datetime.day = $datetime.day AND \`temporalNode\`.datetime.hour = $datetime.hour AND \`temporalNode\`.datetime.minute = $datetime.minute AND \`temporalNode\`.datetime.second = $datetime.second AND \`temporalNode\`.datetime.millisecond = $datetime.millisecond AND \`temporalNode\`.datetime.microsecond = $datetime.microsecond AND \`temporalNode\`.datetime.nanosecond = $datetime.nanosecond AND \`temporalNode\`.datetime.timezone = $datetime.timezone RETURN \`temporalNode\` {_id: ID(\`temporalNode\`),time: { hour: \`temporalNode\`.time.hour , minute: \`temporalNode\`.time.minute , second: \`temporalNode\`.time.second , millisecond: \`temporalNode\`.time.millisecond , microsecond: \`temporalNode\`.time.microsecond , nanosecond: \`temporalNode\`.time.nanosecond , timezone: \`temporalNode\`.time.timezone , formatted: toString(\`temporalNode\`.time) },date: { year: \`temporalNode\`.date.year , month: \`temporalNode\`.date.month , day: \`temporalNode\`.date.day , formatted: toString(\`temporalNode\`.date) },datetime: { year: \`temporalNode\`.datetime.year , month: \`temporalNode\`.datetime.month , day: \`temporalNode\`.datetime.day , hour: \`temporalNode\`.datetime.hour , minute: \`temporalNode\`.datetime.minute , second: \`temporalNode\`.datetime.second , millisecond: \`temporalNode\`.datetime.millisecond , microsecond: \`temporalNode\`.datetime.microsecond , nanosecond: \`temporalNode\`.datetime.nanosecond , timezone: \`temporalNode\`.datetime.timezone , formatted: toString(\`temporalNode\`.datetime) },localtime: { hour: \`temporalNode\`.localtime.hour , minute: \`temporalNode\`.localtime.minute , second: \`temporalNode\`.localtime.second , millisecond: \`temporalNode\`.localtime.millisecond , microsecond: \`temporalNode\`.localtime.microsecond , nanosecond: \`temporalNode\`.localtime.nanosecond , formatted: toString(\`temporalNode\`.localtime) },localdatetime: { year: \`temporalNode\`.localdatetime.year , month: \`temporalNode\`.localdatetime.month , day: \`temporalNode\`.localdatetime.day , hour: \`temporalNode\`.localdatetime.hour , minute: \`temporalNode\`.localdatetime.minute , second: \`temporalNode\`.localdatetime.second , millisecond: \`temporalNode\`.localdatetime.millisecond , microsecond: \`temporalNode\`.localdatetime.microsecond , nanosecond: \`temporalNode\`.localdatetime.nanosecond , formatted: toString(\`temporalNode\`.localdatetime) },temporalNodes: [(\`temporalNode\`)-[:\`TEMPORAL\`]->(\`temporalNode_temporalNodes\`:\`TemporalNode\`) WHERE temporalNode_temporalNodes.datetime.year = $1_datetime.year AND temporalNode_temporalNodes.datetime.month = $1_datetime.month AND temporalNode_temporalNodes.datetime.day = $1_datetime.day AND temporalNode_temporalNodes.datetime.hour = $1_datetime.hour AND temporalNode_temporalNodes.datetime.minute = $1_datetime.minute AND temporalNode_temporalNodes.datetime.second = $1_datetime.second AND temporalNode_temporalNodes.datetime.millisecond = $1_datetime.millisecond AND temporalNode_temporalNodes.datetime.microsecond = $1_datetime.microsecond AND temporalNode_temporalNodes.datetime.nanosecond = $1_datetime.nanosecond AND temporalNode_temporalNodes.datetime.timezone = $1_datetime.timezone AND temporalNode_temporalNodes.localdatetime = localdatetime($1_localdatetime.formatted) | \`temporalNode_temporalNodes\` {_id: ID(\`temporalNode_temporalNodes\`),time: { hour: \`temporalNode_temporalNodes\`.time.hour , minute: \`temporalNode_temporalNodes\`.time.minute , second: \`temporalNode_temporalNodes\`.time.second , millisecond: \`temporalNode_temporalNodes\`.time.millisecond , microsecond: \`temporalNode_temporalNodes\`.time.microsecond , nanosecond: \`temporalNode_temporalNodes\`.time.nanosecond , timezone: \`temporalNode_temporalNodes\`.time.timezone , formatted: toString(\`temporalNode_temporalNodes\`.time) },date: { year: \`temporalNode_temporalNodes\`.date.year , month: \`temporalNode_temporalNodes\`.date.month , day: \`temporalNode_temporalNodes\`.date.day , formatted: toString(\`temporalNode_temporalNodes\`.date) },datetime: { year: \`temporalNode_temporalNodes\`.datetime.year , month: \`temporalNode_temporalNodes\`.datetime.month , day: \`temporalNode_temporalNodes\`.datetime.day , hour: \`temporalNode_temporalNodes\`.datetime.hour , minute: \`temporalNode_temporalNodes\`.datetime.minute , second: \`temporalNode_temporalNodes\`.datetime.second , millisecond: \`temporalNode_temporalNodes\`.datetime.millisecond , microsecond: \`temporalNode_temporalNodes\`.datetime.microsecond , nanosecond: \`temporalNode_temporalNodes\`.datetime.nanosecond , timezone: \`temporalNode_temporalNodes\`.datetime.timezone , formatted: toString(\`temporalNode_temporalNodes\`.datetime) },localtime: { hour: \`temporalNode_temporalNodes\`.localtime.hour , minute: \`temporalNode_temporalNodes\`.localtime.minute , second: \`temporalNode_temporalNodes\`.localtime.second , millisecond: \`temporalNode_temporalNodes\`.localtime.millisecond , microsecond: \`temporalNode_temporalNodes\`.localtime.microsecond , nanosecond: \`temporalNode_temporalNodes\`.localtime.nanosecond , formatted: toString(\`temporalNode_temporalNodes\`.localtime) },localdatetime: { year: \`temporalNode_temporalNodes\`.localdatetime.year , month: \`temporalNode_temporalNodes\`.localdatetime.month , day: \`temporalNode_temporalNodes\`.localdatetime.day , hour: \`temporalNode_temporalNodes\`.localdatetime.hour , minute: \`temporalNode_temporalNodes\`.localdatetime.minute , second: \`temporalNode_temporalNodes\`.localdatetime.second , millisecond: \`temporalNode_temporalNodes\`.localdatetime.millisecond , microsecond: \`temporalNode_temporalNodes\`.localdatetime.microsecond , nanosecond: \`temporalNode_temporalNodes\`.localdatetime.nanosecond , formatted: toString(\`temporalNode_temporalNodes\`.localdatetime) }}] } AS \`temporalNode\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      datetime: {
+        year: 2018,
+        month: 11,
+        day: 23,
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004,
+        timezone: 'America/Los_Angeles'
+      },
+      '1_datetime': {
+        year: 2020,
+        month: 11,
+        day: 23,
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004,
+        timezone: 'America/Los_Angeles'
+      },
+      '1_localdatetime': {
+        year: 2018,
+        month: 11,
+        day: 23,
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004,
+        formatted: '2018-11-23T10:30:01.002003004'
+      }
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -3874,16 +4522,26 @@ test('Nested Query with spatial property arguments', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`spatialNode\`:\`SpatialNode\`) WHERE \`spatialNode\`.point.longitude = $point.longitude RETURN \`spatialNode\` {point: { longitude: \`spatialNode\`.point.longitude , latitude: \`spatialNode\`.point.latitude , height: \`spatialNode\`.point.height },spatialNodes: [(\`spatialNode\`)-[:\`SPATIAL\`]->(\`spatialNode_spatialNodes\`:\`SpatialNode\`) WHERE spatialNode_spatialNodes.point.longitude = $1_point.longitude | \`spatialNode_spatialNodes\` {point: { longitude: \`spatialNode_spatialNodes\`.point.longitude , latitude: \`spatialNode_spatialNodes\`.point.latitude , height: \`spatialNode_spatialNodes\`.point.height }}] } AS \`spatialNode\``;
+    expectedCypherQuery = `MATCH (\`spatialNode\`:\`SpatialNode\`) WHERE \`spatialNode\`.point.longitude = $point.longitude RETURN \`spatialNode\` {point: { longitude: \`spatialNode\`.point.longitude , latitude: \`spatialNode\`.point.latitude , height: \`spatialNode\`.point.height },spatialNodes: [(\`spatialNode\`)-[:\`SPATIAL\`]->(\`spatialNode_spatialNodes\`:\`SpatialNode\`) WHERE spatialNode_spatialNodes.point.longitude = $1_point.longitude | \`spatialNode_spatialNodes\` {point: { longitude: \`spatialNode_spatialNodes\`.point.longitude , latitude: \`spatialNode_spatialNodes\`.point.latitude , height: \`spatialNode_spatialNodes\`.point.height }}] } AS \`spatialNode\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      point: {
+        longitude: 1.5
+      },
+      '1_point': {
+        longitude: 40
+      },
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -3905,16 +4563,27 @@ test('Update node spatial property', t => {
     }
   }`,
     expectedCypherQuery = `MATCH (\`spatialNode\`:\`SpatialNode\`{id: $params.id})
-  SET \`spatialNode\` += {point: point($params.point)} RETURN \`spatialNode\` {point: { longitude: \`spatialNode\`.point.longitude , latitude: \`spatialNode\`.point.latitude , height: \`spatialNode\`.point.height }} AS \`spatialNode\``;
+  SET \`spatialNode\` += {point: point($params.point)} RETURN \`spatialNode\` {point: { longitude: \`spatialNode\`.point.longitude , latitude: \`spatialNode\`.point.latitude , height: \`spatialNode\`.point.height }} AS \`spatialNode\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      params: {
+        id: 'xyz',
+        point: {
+          longitude: 100,
+          latitude: 200,
+          height: 300
+        }
+      }
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -3935,16 +4604,20 @@ test('Query relationship with temporal properties', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` {_id: ID(\`movie\`), .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,datetime: { year: \`movie_ratings_relation\`.datetime.year },User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User {_id: ID(\`movie_ratings_User\`), .name }]) }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` {_id: ID(\`movie\`), .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating ,datetime: { year: \`movie_ratings_relation\`.datetime.year },User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User {_id: ID(\`movie_ratings_User\`), .name }]) }] } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -4085,16 +4758,112 @@ test('Add relationship mutation with temporal properties', t => {
       MATCH (\`movie_to\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId: $to.movieId})
       CREATE (\`user_from\`)-[\`rated_relation\`:\`RATED\` {rating:$data.rating,time: time($data.time),date: date($data.date),datetime: datetime($data.datetime),localtime: localtime($data.localtime),localdatetime: localdatetime($data.localdatetime)}]->(\`movie_to\`)
       RETURN \`rated_relation\` { time: { hour: \`rated_relation\`.time.hour , minute: \`rated_relation\`.time.minute , second: \`rated_relation\`.time.second , millisecond: \`rated_relation\`.time.millisecond , microsecond: \`rated_relation\`.time.microsecond , nanosecond: \`rated_relation\`.time.nanosecond , timezone: \`rated_relation\`.time.timezone , formatted: toString(\`rated_relation\`.time) },date: { year: \`rated_relation\`.date.year , month: \`rated_relation\`.date.month , day: \`rated_relation\`.date.day , formatted: toString(\`rated_relation\`.date) },datetime: { year: \`rated_relation\`.datetime.year , month: \`rated_relation\`.datetime.month , day: \`rated_relation\`.datetime.day , hour: \`rated_relation\`.datetime.hour , minute: \`rated_relation\`.datetime.minute , second: \`rated_relation\`.datetime.second , millisecond: \`rated_relation\`.datetime.millisecond , microsecond: \`rated_relation\`.datetime.microsecond , nanosecond: \`rated_relation\`.datetime.nanosecond , timezone: \`rated_relation\`.datetime.timezone , formatted: toString(\`rated_relation\`.datetime) },localtime: { hour: \`rated_relation\`.localtime.hour , minute: \`rated_relation\`.localtime.minute , second: \`rated_relation\`.localtime.second , millisecond: \`rated_relation\`.localtime.millisecond , microsecond: \`rated_relation\`.localtime.microsecond , nanosecond: \`rated_relation\`.localtime.nanosecond , formatted: toString(\`rated_relation\`.localtime) },localdatetime: { year: \`rated_relation\`.localdatetime.year , month: \`rated_relation\`.localdatetime.month , day: \`rated_relation\`.localdatetime.day , hour: \`rated_relation\`.localdatetime.hour , minute: \`rated_relation\`.localdatetime.minute , second: \`rated_relation\`.localdatetime.second , millisecond: \`rated_relation\`.localdatetime.millisecond , microsecond: \`rated_relation\`.localdatetime.microsecond , nanosecond: \`rated_relation\`.localdatetime.nanosecond , formatted: toString(\`rated_relation\`.localdatetime) },from: \`user_from\` {_id: ID(\`user_from\`), .userId , .name ,rated: [(\`user_from\`)-[\`user_from_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_relation {datetime: { year: \`user_from_rated_relation\`.datetime.year }}] } ,to: \`movie_to\` {_id: ID(\`movie_to\`), .movieId , .title ,ratings: [(\`movie_to\`)<-[\`movie_to_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_to_ratings_relation {datetime: { year: \`movie_to_ratings_relation\`.datetime.year }}] }  } AS \`_AddUserRatedPayload\`;
-    `;
+    `,
+    expectedParams = {
+      from: {
+        userId: 'fa547ca6-f44d-4a6c-8c86-45050227181f'
+      },
+      to: {
+        movieId: '04b85fa3-7c78-4e65-9830-97dad60aa746'
+      },
+      data: {
+        rating: {
+          low: 5,
+          high: 0
+        },
+        time: '10:30:01.002003004-08:00',
+        date: {
+          year: {
+            low: 2017,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 23,
+            high: 0
+          }
+        },
+        datetime: {
+          year: {
+            low: 2020,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 23,
+            high: 0
+          },
+          hour: {
+            low: 10,
+            high: 0
+          },
+          minute: {
+            low: 30,
+            high: 0
+          },
+          second: {
+            low: 1,
+            high: 0
+          },
+          millisecond: {
+            low: 2,
+            high: 0
+          },
+          microsecond: {
+            low: 3,
+            high: 0
+          },
+          nanosecond: {
+            low: 4,
+            high: 0
+          },
+          timezone: 'America/Los_Angeles'
+        },
+        localtime: {
+          hour: {
+            low: 10,
+            high: 0
+          },
+          minute: {
+            low: 30,
+            high: 0
+          },
+          second: {
+            low: 1,
+            high: 0
+          },
+          millisecond: {
+            low: 2,
+            high: 0
+          },
+          microsecond: {
+            low: 3,
+            high: 0
+          },
+          nanosecond: {
+            low: 4,
+            high: 0
+          }
+        },
+        localdatetime: '2018-11-23T10:30:01.002003004'
+      },
+      offset: 0,
+      first: -1
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -4130,16 +4899,32 @@ test('Add relationship mutation with spatial properties', t => {
       MATCH (\`movie_to\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\` {movieId: $to.movieId})
       CREATE (\`user_from\`)-[\`rated_relation\`:\`RATED\` {rating:$data.rating,location: point($data.location)}]->(\`movie_to\`)
       RETURN \`rated_relation\` { location: { longitude: \`rated_relation\`.location.longitude , latitude: \`rated_relation\`.location.latitude , height: \`rated_relation\`.location.height },from: \`user_from\` {_id: ID(\`user_from\`)} ,to: \`movie_to\` {_id: ID(\`movie_to\`)}  } AS \`_AddUserRatedPayload\`;
-    `;
+    `,
+    expectedParams = {
+      from: { userId: '123' },
+      to: { movieId: '2kljghd' },
+      data: {
+        rating: {
+          high: 0,
+          low: 10
+        },
+        location: {
+          longitude: 10,
+          latitude: 20.3,
+          height: 30.2
+        }
+      },
+      offset: 0,
+      first: -1
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -4156,16 +4941,20 @@ test('Query relationship with spatial properties', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {rated: [(\`user\`)-[\`user_rated_relation\`:\`RATED\`]->(:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | user_rated_relation {location: { longitude: \`user_rated_relation\`.location.longitude , latitude: \`user_rated_relation\`.location.latitude , height: \`user_rated_relation\`.location.height , srid: \`user_rated_relation\`.location.srid }}] } AS \`user\``;
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {rated: [(\`user\`)-[\`user_rated_relation\`:\`RATED\`]->(:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | user_rated_relation {location: { longitude: \`user_rated_relation\`.location.longitude , latitude: \`user_rated_relation\`.location.latitude , height: \`user_rated_relation\`.location.height , srid: \`user_rated_relation\`.location.srid }}] } AS \`user\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -4236,16 +5025,83 @@ test('Add relationship mutation with list properties', t => {
       MATCH (\`movie_to\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS} {movieId: $to.movieId})
       CREATE (\`user_from\`)-[\`rated_relation\`:\`RATED\` {ratings:$data.ratings,datetimes: [value IN $data.datetimes | datetime(value)]}]->(\`movie_to\`)
       RETURN \`rated_relation\` {  .ratings ,datetimes: reduce(a = [], INSTANCE IN rated_relation.datetimes | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , hour: INSTANCE.hour , minute: INSTANCE.minute , second: INSTANCE.second , millisecond: INSTANCE.millisecond , microsecond: INSTANCE.microsecond , nanosecond: INSTANCE.nanosecond , timezone: INSTANCE.timezone , formatted: toString(INSTANCE) }),from: \`user_from\` {_id: ID(\`user_from\`), .userId , .name ,rated: [(\`user_from\`)-[\`user_from_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_relation {datetime: { year: \`user_from_rated_relation\`.datetime.year }}] } ,to: \`movie_to\` {_id: ID(\`movie_to\`), .movieId , .title ,ratings: [(\`movie_to\`)<-[\`movie_to_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_to_ratings_relation {datetime: { year: \`movie_to_ratings_relation\`.datetime.year }}] }  } AS \`_AddUserRatedPayload\`;
-    `;
+    `,
+    expectedParams = {
+      from: {
+        userId: 'fa547ca6-f44d-4a6c-8c86-45050227181f'
+      },
+      to: {
+        movieId: '04b85fa3-7c78-4e65-9830-97dad60aa746'
+      },
+      data: {
+        ratings: [
+          {
+            low: 5,
+            high: 0
+          },
+          {
+            low: 9,
+            high: 0
+          },
+          {
+            low: 10,
+            high: 0
+          }
+        ],
+        datetimes: [
+          {
+            year: {
+              low: 2020,
+              high: 0
+            },
+            month: {
+              low: 11,
+              high: 0
+            },
+            day: {
+              low: 23,
+              high: 0
+            },
+            hour: {
+              low: 10,
+              high: 0
+            },
+            minute: {
+              low: 30,
+              high: 0
+            },
+            second: {
+              low: 1,
+              high: 0
+            },
+            millisecond: {
+              low: 2,
+              high: 0
+            },
+            microsecond: {
+              low: 3,
+              high: 0
+            },
+            nanosecond: {
+              low: 4,
+              high: 0
+            },
+            timezone: 'America/Los_Angeles'
+          },
+          '2018-11-23T10:30:01.002003004-08:00[America/Los_Angeles]'
+        ]
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -4448,14 +5304,191 @@ test('Add reflexive relationship mutation with temporal properties', t => {
       MATCH (\`user_to\`:\`User\` {userId: $to.userId})
       CREATE (\`user_from\`)-[\`friend_of_relation\`:\`FRIEND_OF\` {since:$data.since,time: time($data.time),date: date($data.date),datetime: datetime($data.datetime),datetimes: [value IN $data.datetimes | datetime(value)],localtime: localtime($data.localtime),localdatetime: localdatetime($data.localdatetime)}]->(\`user_to\`)
       RETURN \`friend_of_relation\` { from: \`user_from\` {_id: ID(\`user_from\`), .userId , .name ,friends: {from: [(\`user_from\`)<-[\`user_from_from_relation\`:\`FRIEND_OF\`]-(\`user_from_from\`:\`User\`) | user_from_from_relation { .since ,User: user_from_from {_id: ID(\`user_from_from\`), .name ,friends: {from: [(\`user_from_from\`)<-[\`user_from_from_from_relation\`:\`FRIEND_OF\`]-(\`user_from_from_from\`:\`User\`) | user_from_from_from_relation { .since ,User: user_from_from_from {_id: ID(\`user_from_from_from\`), .name } }] ,to: [(\`user_from_from\`)-[\`user_from_from_to_relation\`:\`FRIEND_OF\`]->(\`user_from_from_to\`:\`User\`) | user_from_from_to_relation { .since ,User: user_from_from_to {_id: ID(\`user_from_from_to\`), .name } }] } } }] ,to: [(\`user_from\`)-[\`user_from_to_relation\`:\`FRIEND_OF\`]->(\`user_from_to\`:\`User\`) | user_from_to_relation { .since ,datetime: { year: \`user_from_to_relation\`.datetime.year },User: user_from_to {_id: ID(\`user_from_to\`), .name } }] } } ,to: \`user_to\` {_id: ID(\`user_to\`), .name ,friends: {from: [(\`user_to\`)<-[\`user_to_from_relation\`:\`FRIEND_OF\`]-(\`user_to_from\`:\`User\`) | user_to_from_relation { .since ,User: user_to_from {_id: ID(\`user_to_from\`), .name } }] ,to: [(\`user_to\`)-[\`user_to_to_relation\`:\`FRIEND_OF\`]->(\`user_to_to\`:\`User\`) | user_to_to_relation { .since ,User: user_to_to {_id: ID(\`user_to_to\`), .name } }] } } , .since ,time: { hour: \`friend_of_relation\`.time.hour , minute: \`friend_of_relation\`.time.minute , second: \`friend_of_relation\`.time.second , millisecond: \`friend_of_relation\`.time.millisecond , microsecond: \`friend_of_relation\`.time.microsecond , nanosecond: \`friend_of_relation\`.time.nanosecond , timezone: \`friend_of_relation\`.time.timezone , formatted: toString(\`friend_of_relation\`.time) },date: { year: \`friend_of_relation\`.date.year , month: \`friend_of_relation\`.date.month , day: \`friend_of_relation\`.date.day , formatted: toString(\`friend_of_relation\`.date) },datetime: { year: \`friend_of_relation\`.datetime.year , month: \`friend_of_relation\`.datetime.month , day: \`friend_of_relation\`.datetime.day , hour: \`friend_of_relation\`.datetime.hour , minute: \`friend_of_relation\`.datetime.minute , second: \`friend_of_relation\`.datetime.second , millisecond: \`friend_of_relation\`.datetime.millisecond , microsecond: \`friend_of_relation\`.datetime.microsecond , nanosecond: \`friend_of_relation\`.datetime.nanosecond , timezone: \`friend_of_relation\`.datetime.timezone , formatted: toString(\`friend_of_relation\`.datetime) },datetimes: reduce(a = [], INSTANCE IN friend_of_relation.datetimes | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , hour: INSTANCE.hour , minute: INSTANCE.minute , second: INSTANCE.second , millisecond: INSTANCE.millisecond , microsecond: INSTANCE.microsecond , nanosecond: INSTANCE.nanosecond , timezone: INSTANCE.timezone , formatted: toString(INSTANCE) }),localtime: { hour: \`friend_of_relation\`.localtime.hour , minute: \`friend_of_relation\`.localtime.minute , second: \`friend_of_relation\`.localtime.second , millisecond: \`friend_of_relation\`.localtime.millisecond , microsecond: \`friend_of_relation\`.localtime.microsecond , nanosecond: \`friend_of_relation\`.localtime.nanosecond , formatted: toString(\`friend_of_relation\`.localtime) },localdatetime: { year: \`friend_of_relation\`.localdatetime.year , month: \`friend_of_relation\`.localdatetime.month , day: \`friend_of_relation\`.localdatetime.day , hour: \`friend_of_relation\`.localdatetime.hour , minute: \`friend_of_relation\`.localdatetime.minute , second: \`friend_of_relation\`.localdatetime.second , millisecond: \`friend_of_relation\`.localdatetime.millisecond , microsecond: \`friend_of_relation\`.localdatetime.microsecond , nanosecond: \`friend_of_relation\`.localdatetime.nanosecond , formatted: toString(\`friend_of_relation\`.localdatetime) } } AS \`_AddUserFriendsPayload\`;
-    `;
+    `,
+    expectedParams = {
+      from: {
+        userId: '4451fa0a-5dcf-4a84-b950-56b7ad332627'
+      },
+      to: {
+        userId: 'fa547ca6-f44d-4a6c-8c86-45050227181f'
+      },
+      first: -1,
+      offset: 0,
+      data: {
+        since: {
+          low: 11,
+          high: 0
+        },
+        time: '10:30:01.002003004-08:00',
+        date: {
+          year: {
+            low: 2018,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 23,
+            high: 0
+          }
+        },
+        datetime: {
+          year: {
+            low: 2018,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 23,
+            high: 0
+          },
+          hour: {
+            low: 10,
+            high: 0
+          },
+          minute: {
+            low: 30,
+            high: 0
+          },
+          second: {
+            low: 1,
+            high: 0
+          },
+          millisecond: {
+            low: 2,
+            high: 0
+          },
+          microsecond: {
+            low: 3,
+            high: 0
+          },
+          nanosecond: {
+            low: 4,
+            high: 0
+          },
+          timezone: 'America/Los_Angeles'
+        },
+        datetimes: [
+          {
+            year: {
+              low: 2020,
+              high: 0
+            },
+            month: {
+              low: 11,
+              high: 0
+            },
+            day: {
+              low: 23,
+              high: 0
+            },
+            hour: {
+              low: 10,
+              high: 0
+            },
+            minute: {
+              low: 30,
+              high: 0
+            },
+            second: {
+              low: 1,
+              high: 0
+            },
+            millisecond: {
+              low: 2,
+              high: 0
+            },
+            microsecond: {
+              low: 3,
+              high: 0
+            },
+            nanosecond: {
+              low: 4,
+              high: 0
+            },
+            timezone: 'America/Los_Angeles'
+          },
+          '2018-11-23T10:30:01.002003004-08:00[America/Los_Angeles]'
+        ],
+        localtime: {
+          hour: {
+            low: 10,
+            high: 0
+          },
+          minute: {
+            low: 30,
+            high: 0
+          },
+          second: {
+            low: 1,
+            high: 0
+          },
+          millisecond: {
+            low: 2,
+            high: 0
+          },
+          microsecond: {
+            low: 3,
+            high: 0
+          },
+          nanosecond: {
+            low: 4,
+            high: 0
+          }
+        },
+        localdatetime: {
+          year: {
+            low: 2018,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 23,
+            high: 0
+          },
+          hour: {
+            low: 10,
+            high: 0
+          },
+          minute: {
+            low: 30,
+            high: 0
+          },
+          second: {
+            low: 1,
+            high: 0
+          },
+          millisecond: {
+            low: 2,
+            high: 0
+          },
+          microsecond: {
+            low: 3,
+            high: 0
+          },
+          nanosecond: {
+            low: 4,
+            high: 0
+          }
+        }
+      }
+    };
 
-  t.plan(1);
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
-    expectedCypherQuery
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -4497,16 +5530,25 @@ test('Remove relationship mutation for relation type field', t => {
       DELETE \`user_frommovie_to\`
       WITH COUNT(*) AS scope, \`user_from\` AS \`_user_from\`, \`movie_to\` AS \`_movie_to\`
       RETURN {from: \`_user_from\` {_id: ID(\`_user_from\`), .userId , .name ,rated: [(\`_user_from\`)-[\`_user_from_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | _user_from_rated_relation {datetime: { year: \`_user_from_rated_relation\`.datetime.year },Movie: head([(:\`User\`)-[\`_user_from_rated_relation\`]->(\`_user_from_rated_Movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | _user_from_rated_Movie { .title }]) }] } ,to: \`_movie_to\` {_id: ID(\`_movie_to\`), .movieId , .title ,ratings: [(\`_movie_to\`)<-[\`_movie_to_ratings_relation\`:\`RATED\`]-(:\`User\`) | _movie_to_ratings_relation {datetime: { year: \`_movie_to_ratings_relation\`.datetime.year }}] } } AS \`_RemoveUserRatedPayload\`;
-    `;
+    `,
+    expectedParams = {
+      from: {
+        userId: 'fa547ca6-f44d-4a6c-8c86-45050227181f'
+      },
+      to: {
+        movieId: '04b85fa3-7c78-4e65-9830-97dad60aa746'
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(1);
-
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
     expectedCypherQuery,
-    {}
+    expectedParams
   );
 });
 
@@ -4742,14 +5784,112 @@ test('Query nested temporal properties on reflexive relationship using temporal 
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId , .name ,friends: {from: [(\`user\`)<-[\`user_from_relation\`:\`FRIEND_OF\`]-(\`user_from\`:\`User\`) WHERE user_from_relation.time = time($1_time.formatted) AND user_from_relation.date.year = $1_date.year AND user_from_relation.date.month = $1_date.month AND user_from_relation.date.day = $1_date.day AND user_from_relation.datetime.year = $1_datetime.year AND user_from_relation.datetime.month = $1_datetime.month AND user_from_relation.datetime.day = $1_datetime.day AND user_from_relation.datetime.hour = $1_datetime.hour AND user_from_relation.datetime.minute = $1_datetime.minute AND user_from_relation.datetime.second = $1_datetime.second AND user_from_relation.datetime.millisecond = $1_datetime.millisecond AND user_from_relation.datetime.microsecond = $1_datetime.microsecond AND user_from_relation.datetime.nanosecond = $1_datetime.nanosecond AND user_from_relation.datetime.timezone = $1_datetime.timezone AND user_from_relation.localtime.hour = $1_localtime.hour AND user_from_relation.localtime.minute = $1_localtime.minute AND user_from_relation.localtime.second = $1_localtime.second AND user_from_relation.localtime.millisecond = $1_localtime.millisecond AND user_from_relation.localtime.microsecond = $1_localtime.microsecond AND user_from_relation.localtime.nanosecond = $1_localtime.nanosecond AND user_from_relation.localdatetime.year = $1_localdatetime.year AND user_from_relation.localdatetime.month = $1_localdatetime.month AND user_from_relation.localdatetime.day = $1_localdatetime.day AND user_from_relation.localdatetime.hour = $1_localdatetime.hour AND user_from_relation.localdatetime.minute = $1_localdatetime.minute AND user_from_relation.localdatetime.second = $1_localdatetime.second AND user_from_relation.localdatetime.millisecond = $1_localdatetime.millisecond AND user_from_relation.localdatetime.microsecond = $1_localdatetime.microsecond AND user_from_relation.localdatetime.nanosecond = $1_localdatetime.nanosecond | user_from_relation { .since ,time: { hour: \`user_from_relation\`.time.hour , minute: \`user_from_relation\`.time.minute , second: \`user_from_relation\`.time.second , millisecond: \`user_from_relation\`.time.millisecond , microsecond: \`user_from_relation\`.time.microsecond , nanosecond: \`user_from_relation\`.time.nanosecond , timezone: \`user_from_relation\`.time.timezone , formatted: toString(\`user_from_relation\`.time) },date: { year: \`user_from_relation\`.date.year , month: \`user_from_relation\`.date.month , day: \`user_from_relation\`.date.day , formatted: toString(\`user_from_relation\`.date) },datetime: { year: \`user_from_relation\`.datetime.year , month: \`user_from_relation\`.datetime.month , day: \`user_from_relation\`.datetime.day , hour: \`user_from_relation\`.datetime.hour , minute: \`user_from_relation\`.datetime.minute , second: \`user_from_relation\`.datetime.second , millisecond: \`user_from_relation\`.datetime.millisecond , microsecond: \`user_from_relation\`.datetime.microsecond , nanosecond: \`user_from_relation\`.datetime.nanosecond , timezone: \`user_from_relation\`.datetime.timezone , formatted: toString(\`user_from_relation\`.datetime) },datetimes: reduce(a = [], INSTANCE IN user_from_relation.datetimes | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , hour: INSTANCE.hour , minute: INSTANCE.minute , second: INSTANCE.second , millisecond: INSTANCE.millisecond , microsecond: INSTANCE.microsecond , nanosecond: INSTANCE.nanosecond , timezone: INSTANCE.timezone , formatted: toString(INSTANCE) }),localtime: { hour: \`user_from_relation\`.localtime.hour , minute: \`user_from_relation\`.localtime.minute , second: \`user_from_relation\`.localtime.second , millisecond: \`user_from_relation\`.localtime.millisecond , microsecond: \`user_from_relation\`.localtime.microsecond , nanosecond: \`user_from_relation\`.localtime.nanosecond , formatted: toString(\`user_from_relation\`.localtime) },localdatetime: { year: \`user_from_relation\`.localdatetime.year , month: \`user_from_relation\`.localdatetime.month , day: \`user_from_relation\`.localdatetime.day , hour: \`user_from_relation\`.localdatetime.hour , minute: \`user_from_relation\`.localdatetime.minute , second: \`user_from_relation\`.localdatetime.second , millisecond: \`user_from_relation\`.localdatetime.millisecond , microsecond: \`user_from_relation\`.localdatetime.microsecond , nanosecond: \`user_from_relation\`.localdatetime.nanosecond , formatted: toString(\`user_from_relation\`.localdatetime) },User: user_from {_id: ID(\`user_from\`), .userId ,rated: [(\`user_from\`)-[\`user_from_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_relation {datetime: { year: \`user_from_rated_relation\`.datetime.year }}] } }] ,to: [(\`user\`)-[\`user_to_relation\`:\`FRIEND_OF\`]->(\`user_to\`:\`User\`) WHERE user_to_relation.time = time($3_time.formatted) AND user_to_relation.date.year = $3_date.year AND user_to_relation.date.month = $3_date.month AND user_to_relation.date.day = $3_date.day AND user_to_relation.datetime.year = $3_datetime.year AND user_to_relation.datetime.month = $3_datetime.month AND user_to_relation.datetime.day = $3_datetime.day AND user_to_relation.datetime.hour = $3_datetime.hour AND user_to_relation.datetime.minute = $3_datetime.minute AND user_to_relation.datetime.second = $3_datetime.second AND user_to_relation.datetime.millisecond = $3_datetime.millisecond AND user_to_relation.datetime.microsecond = $3_datetime.microsecond AND user_to_relation.datetime.nanosecond = $3_datetime.nanosecond AND user_to_relation.datetime.timezone = $3_datetime.timezone AND user_to_relation.localtime.hour = $3_localtime.hour AND user_to_relation.localtime.minute = $3_localtime.minute AND user_to_relation.localtime.second = $3_localtime.second AND user_to_relation.localtime.millisecond = $3_localtime.millisecond AND user_to_relation.localtime.microsecond = $3_localtime.microsecond AND user_to_relation.localtime.nanosecond = $3_localtime.nanosecond AND user_to_relation.localdatetime.year = $3_localdatetime.year AND user_to_relation.localdatetime.month = $3_localdatetime.month AND user_to_relation.localdatetime.day = $3_localdatetime.day AND user_to_relation.localdatetime.hour = $3_localdatetime.hour AND user_to_relation.localdatetime.minute = $3_localdatetime.minute AND user_to_relation.localdatetime.second = $3_localdatetime.second AND user_to_relation.localdatetime.millisecond = $3_localdatetime.millisecond AND user_to_relation.localdatetime.microsecond = $3_localdatetime.microsecond AND user_to_relation.localdatetime.nanosecond = $3_localdatetime.nanosecond | user_to_relation { .since ,time: { hour: \`user_to_relation\`.time.hour , minute: \`user_to_relation\`.time.minute , second: \`user_to_relation\`.time.second , millisecond: \`user_to_relation\`.time.millisecond , microsecond: \`user_to_relation\`.time.microsecond , nanosecond: \`user_to_relation\`.time.nanosecond , timezone: \`user_to_relation\`.time.timezone , formatted: toString(\`user_to_relation\`.time) },date: { year: \`user_to_relation\`.date.year , month: \`user_to_relation\`.date.month , day: \`user_to_relation\`.date.day , formatted: toString(\`user_to_relation\`.date) },datetime: { year: \`user_to_relation\`.datetime.year , month: \`user_to_relation\`.datetime.month , day: \`user_to_relation\`.datetime.day , hour: \`user_to_relation\`.datetime.hour , minute: \`user_to_relation\`.datetime.minute , second: \`user_to_relation\`.datetime.second , millisecond: \`user_to_relation\`.datetime.millisecond , microsecond: \`user_to_relation\`.datetime.microsecond , nanosecond: \`user_to_relation\`.datetime.nanosecond , timezone: \`user_to_relation\`.datetime.timezone , formatted: toString(\`user_to_relation\`.datetime) },localtime: { hour: \`user_to_relation\`.localtime.hour , minute: \`user_to_relation\`.localtime.minute , second: \`user_to_relation\`.localtime.second , millisecond: \`user_to_relation\`.localtime.millisecond , microsecond: \`user_to_relation\`.localtime.microsecond , nanosecond: \`user_to_relation\`.localtime.nanosecond , formatted: toString(\`user_to_relation\`.localtime) },localdatetime: { year: \`user_to_relation\`.localdatetime.year , month: \`user_to_relation\`.localdatetime.month , day: \`user_to_relation\`.localdatetime.day , hour: \`user_to_relation\`.localdatetime.hour , minute: \`user_to_relation\`.localdatetime.minute , second: \`user_to_relation\`.localdatetime.second , millisecond: \`user_to_relation\`.localdatetime.millisecond , microsecond: \`user_to_relation\`.localdatetime.microsecond , nanosecond: \`user_to_relation\`.localdatetime.nanosecond , formatted: toString(\`user_to_relation\`.localdatetime) },User: user_to {_id: ID(\`user_to\`), .userId ,rated: [(\`user_to\`)-[\`user_to_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_to_rated_relation {datetime: { year: \`user_to_rated_relation\`.datetime.year }}] } }] } } AS \`user\``;
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId , .name ,friends: {from: [(\`user\`)<-[\`user_from_relation\`:\`FRIEND_OF\`]-(\`user_from\`:\`User\`) WHERE user_from_relation.time = time($1_time.formatted) AND user_from_relation.date.year = $1_date.year AND user_from_relation.date.month = $1_date.month AND user_from_relation.date.day = $1_date.day AND user_from_relation.datetime.year = $1_datetime.year AND user_from_relation.datetime.month = $1_datetime.month AND user_from_relation.datetime.day = $1_datetime.day AND user_from_relation.datetime.hour = $1_datetime.hour AND user_from_relation.datetime.minute = $1_datetime.minute AND user_from_relation.datetime.second = $1_datetime.second AND user_from_relation.datetime.millisecond = $1_datetime.millisecond AND user_from_relation.datetime.microsecond = $1_datetime.microsecond AND user_from_relation.datetime.nanosecond = $1_datetime.nanosecond AND user_from_relation.datetime.timezone = $1_datetime.timezone AND user_from_relation.localtime.hour = $1_localtime.hour AND user_from_relation.localtime.minute = $1_localtime.minute AND user_from_relation.localtime.second = $1_localtime.second AND user_from_relation.localtime.millisecond = $1_localtime.millisecond AND user_from_relation.localtime.microsecond = $1_localtime.microsecond AND user_from_relation.localtime.nanosecond = $1_localtime.nanosecond AND user_from_relation.localdatetime.year = $1_localdatetime.year AND user_from_relation.localdatetime.month = $1_localdatetime.month AND user_from_relation.localdatetime.day = $1_localdatetime.day AND user_from_relation.localdatetime.hour = $1_localdatetime.hour AND user_from_relation.localdatetime.minute = $1_localdatetime.minute AND user_from_relation.localdatetime.second = $1_localdatetime.second AND user_from_relation.localdatetime.millisecond = $1_localdatetime.millisecond AND user_from_relation.localdatetime.microsecond = $1_localdatetime.microsecond AND user_from_relation.localdatetime.nanosecond = $1_localdatetime.nanosecond | user_from_relation { .since ,time: { hour: \`user_from_relation\`.time.hour , minute: \`user_from_relation\`.time.minute , second: \`user_from_relation\`.time.second , millisecond: \`user_from_relation\`.time.millisecond , microsecond: \`user_from_relation\`.time.microsecond , nanosecond: \`user_from_relation\`.time.nanosecond , timezone: \`user_from_relation\`.time.timezone , formatted: toString(\`user_from_relation\`.time) },date: { year: \`user_from_relation\`.date.year , month: \`user_from_relation\`.date.month , day: \`user_from_relation\`.date.day , formatted: toString(\`user_from_relation\`.date) },datetime: { year: \`user_from_relation\`.datetime.year , month: \`user_from_relation\`.datetime.month , day: \`user_from_relation\`.datetime.day , hour: \`user_from_relation\`.datetime.hour , minute: \`user_from_relation\`.datetime.minute , second: \`user_from_relation\`.datetime.second , millisecond: \`user_from_relation\`.datetime.millisecond , microsecond: \`user_from_relation\`.datetime.microsecond , nanosecond: \`user_from_relation\`.datetime.nanosecond , timezone: \`user_from_relation\`.datetime.timezone , formatted: toString(\`user_from_relation\`.datetime) },datetimes: reduce(a = [], INSTANCE IN user_from_relation.datetimes | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , hour: INSTANCE.hour , minute: INSTANCE.minute , second: INSTANCE.second , millisecond: INSTANCE.millisecond , microsecond: INSTANCE.microsecond , nanosecond: INSTANCE.nanosecond , timezone: INSTANCE.timezone , formatted: toString(INSTANCE) }),localtime: { hour: \`user_from_relation\`.localtime.hour , minute: \`user_from_relation\`.localtime.minute , second: \`user_from_relation\`.localtime.second , millisecond: \`user_from_relation\`.localtime.millisecond , microsecond: \`user_from_relation\`.localtime.microsecond , nanosecond: \`user_from_relation\`.localtime.nanosecond , formatted: toString(\`user_from_relation\`.localtime) },localdatetime: { year: \`user_from_relation\`.localdatetime.year , month: \`user_from_relation\`.localdatetime.month , day: \`user_from_relation\`.localdatetime.day , hour: \`user_from_relation\`.localdatetime.hour , minute: \`user_from_relation\`.localdatetime.minute , second: \`user_from_relation\`.localdatetime.second , millisecond: \`user_from_relation\`.localdatetime.millisecond , microsecond: \`user_from_relation\`.localdatetime.microsecond , nanosecond: \`user_from_relation\`.localdatetime.nanosecond , formatted: toString(\`user_from_relation\`.localdatetime) },User: user_from {_id: ID(\`user_from\`), .userId ,rated: [(\`user_from\`)-[\`user_from_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_from_rated_relation {datetime: { year: \`user_from_rated_relation\`.datetime.year }}] } }] ,to: [(\`user\`)-[\`user_to_relation\`:\`FRIEND_OF\`]->(\`user_to\`:\`User\`) WHERE user_to_relation.time = time($3_time.formatted) AND user_to_relation.date.year = $3_date.year AND user_to_relation.date.month = $3_date.month AND user_to_relation.date.day = $3_date.day AND user_to_relation.datetime.year = $3_datetime.year AND user_to_relation.datetime.month = $3_datetime.month AND user_to_relation.datetime.day = $3_datetime.day AND user_to_relation.datetime.hour = $3_datetime.hour AND user_to_relation.datetime.minute = $3_datetime.minute AND user_to_relation.datetime.second = $3_datetime.second AND user_to_relation.datetime.millisecond = $3_datetime.millisecond AND user_to_relation.datetime.microsecond = $3_datetime.microsecond AND user_to_relation.datetime.nanosecond = $3_datetime.nanosecond AND user_to_relation.datetime.timezone = $3_datetime.timezone AND user_to_relation.localtime.hour = $3_localtime.hour AND user_to_relation.localtime.minute = $3_localtime.minute AND user_to_relation.localtime.second = $3_localtime.second AND user_to_relation.localtime.millisecond = $3_localtime.millisecond AND user_to_relation.localtime.microsecond = $3_localtime.microsecond AND user_to_relation.localtime.nanosecond = $3_localtime.nanosecond AND user_to_relation.localdatetime.year = $3_localdatetime.year AND user_to_relation.localdatetime.month = $3_localdatetime.month AND user_to_relation.localdatetime.day = $3_localdatetime.day AND user_to_relation.localdatetime.hour = $3_localdatetime.hour AND user_to_relation.localdatetime.minute = $3_localdatetime.minute AND user_to_relation.localdatetime.second = $3_localdatetime.second AND user_to_relation.localdatetime.millisecond = $3_localdatetime.millisecond AND user_to_relation.localdatetime.microsecond = $3_localdatetime.microsecond AND user_to_relation.localdatetime.nanosecond = $3_localdatetime.nanosecond | user_to_relation { .since ,time: { hour: \`user_to_relation\`.time.hour , minute: \`user_to_relation\`.time.minute , second: \`user_to_relation\`.time.second , millisecond: \`user_to_relation\`.time.millisecond , microsecond: \`user_to_relation\`.time.microsecond , nanosecond: \`user_to_relation\`.time.nanosecond , timezone: \`user_to_relation\`.time.timezone , formatted: toString(\`user_to_relation\`.time) },date: { year: \`user_to_relation\`.date.year , month: \`user_to_relation\`.date.month , day: \`user_to_relation\`.date.day , formatted: toString(\`user_to_relation\`.date) },datetime: { year: \`user_to_relation\`.datetime.year , month: \`user_to_relation\`.datetime.month , day: \`user_to_relation\`.datetime.day , hour: \`user_to_relation\`.datetime.hour , minute: \`user_to_relation\`.datetime.minute , second: \`user_to_relation\`.datetime.second , millisecond: \`user_to_relation\`.datetime.millisecond , microsecond: \`user_to_relation\`.datetime.microsecond , nanosecond: \`user_to_relation\`.datetime.nanosecond , timezone: \`user_to_relation\`.datetime.timezone , formatted: toString(\`user_to_relation\`.datetime) },localtime: { hour: \`user_to_relation\`.localtime.hour , minute: \`user_to_relation\`.localtime.minute , second: \`user_to_relation\`.localtime.second , millisecond: \`user_to_relation\`.localtime.millisecond , microsecond: \`user_to_relation\`.localtime.microsecond , nanosecond: \`user_to_relation\`.localtime.nanosecond , formatted: toString(\`user_to_relation\`.localtime) },localdatetime: { year: \`user_to_relation\`.localdatetime.year , month: \`user_to_relation\`.localdatetime.month , day: \`user_to_relation\`.localdatetime.day , hour: \`user_to_relation\`.localdatetime.hour , minute: \`user_to_relation\`.localdatetime.minute , second: \`user_to_relation\`.localdatetime.second , millisecond: \`user_to_relation\`.localdatetime.millisecond , microsecond: \`user_to_relation\`.localdatetime.microsecond , nanosecond: \`user_to_relation\`.localdatetime.nanosecond , formatted: toString(\`user_to_relation\`.localdatetime) },User: user_to {_id: ID(\`user_to\`), .userId ,rated: [(\`user_to\`)-[\`user_to_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_to_rated_relation {datetime: { year: \`user_to_rated_relation\`.datetime.year }}] } }] } } AS \`user\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_time': {
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004,
+        timezone: '-08:00',
+        formatted: '10:30:01.002003004-08:00'
+      },
+      '1_date': {
+        year: 2018,
+        month: 11,
+        day: 23
+      },
+      '1_datetime': {
+        year: 2018,
+        month: 11,
+        day: 23,
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004,
+        timezone: 'America/Los_Angeles'
+      },
+      '1_localtime': {
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004
+      },
+      '1_localdatetime': {
+        year: 2018,
+        month: 11,
+        day: 23,
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004
+      },
+      '3_time': {
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004,
+        timezone: '-08:00',
+        formatted: '10:30:01.002003004-08:00'
+      },
+      '3_date': {
+        year: 2018,
+        month: 11,
+        day: 23
+      },
+      '3_datetime': {
+        year: 2018,
+        month: 11,
+        day: 23,
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004,
+        timezone: 'America/Los_Angeles'
+      },
+      '3_localtime': {
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004
+      },
+      '3_localdatetime': {
+        year: 2018,
+        month: 11,
+        day: 23,
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004
+      },
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
-    expectedCypherQuery
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -4922,14 +6062,74 @@ test('Query nested temporal properties on relationships using temporal arguments
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` {_id: ID(\`movie\`), .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`{rating:$1_rating}]-(:\`User\`) WHERE movie_ratings_relation.time = time($1_time.formatted) AND movie_ratings_relation.date.year = $1_date.year AND movie_ratings_relation.date.month = $1_date.month AND movie_ratings_relation.date.day = $1_date.day AND movie_ratings_relation.datetime.year = $1_datetime.year AND movie_ratings_relation.datetime.month = $1_datetime.month AND movie_ratings_relation.datetime.day = $1_datetime.day AND movie_ratings_relation.datetime.hour = $1_datetime.hour AND movie_ratings_relation.datetime.minute = $1_datetime.minute AND movie_ratings_relation.datetime.second = $1_datetime.second AND movie_ratings_relation.datetime.millisecond = $1_datetime.millisecond AND movie_ratings_relation.datetime.microsecond = $1_datetime.microsecond AND movie_ratings_relation.datetime.nanosecond = $1_datetime.nanosecond AND movie_ratings_relation.datetime.timezone = $1_datetime.timezone AND movie_ratings_relation.localtime.hour = $1_localtime.hour AND movie_ratings_relation.localtime.minute = $1_localtime.minute AND movie_ratings_relation.localtime.second = $1_localtime.second AND movie_ratings_relation.localtime.millisecond = $1_localtime.millisecond AND movie_ratings_relation.localtime.microsecond = $1_localtime.microsecond AND movie_ratings_relation.localtime.nanosecond = $1_localtime.nanosecond AND movie_ratings_relation.localdatetime.year = $1_localdatetime.year AND movie_ratings_relation.localdatetime.month = $1_localdatetime.month AND movie_ratings_relation.localdatetime.day = $1_localdatetime.day AND movie_ratings_relation.localdatetime.hour = $1_localdatetime.hour AND movie_ratings_relation.localdatetime.minute = $1_localdatetime.minute AND movie_ratings_relation.localdatetime.second = $1_localdatetime.second AND movie_ratings_relation.localdatetime.millisecond = $1_localdatetime.millisecond AND movie_ratings_relation.localdatetime.microsecond = $1_localdatetime.microsecond AND movie_ratings_relation.localdatetime.nanosecond = $1_localdatetime.nanosecond | movie_ratings_relation { .rating ,time: { hour: \`movie_ratings_relation\`.time.hour , minute: \`movie_ratings_relation\`.time.minute , second: \`movie_ratings_relation\`.time.second , millisecond: \`movie_ratings_relation\`.time.millisecond , microsecond: \`movie_ratings_relation\`.time.microsecond , nanosecond: \`movie_ratings_relation\`.time.nanosecond , timezone: \`movie_ratings_relation\`.time.timezone , formatted: toString(\`movie_ratings_relation\`.time) },date: { year: \`movie_ratings_relation\`.date.year , month: \`movie_ratings_relation\`.date.month , day: \`movie_ratings_relation\`.date.day , formatted: toString(\`movie_ratings_relation\`.date) },datetime: { year: \`movie_ratings_relation\`.datetime.year , month: \`movie_ratings_relation\`.datetime.month , day: \`movie_ratings_relation\`.datetime.day , hour: \`movie_ratings_relation\`.datetime.hour , minute: \`movie_ratings_relation\`.datetime.minute , second: \`movie_ratings_relation\`.datetime.second , millisecond: \`movie_ratings_relation\`.datetime.millisecond , microsecond: \`movie_ratings_relation\`.datetime.microsecond , nanosecond: \`movie_ratings_relation\`.datetime.nanosecond , timezone: \`movie_ratings_relation\`.datetime.timezone , formatted: toString(\`movie_ratings_relation\`.datetime) },localtime: { hour: \`movie_ratings_relation\`.localtime.hour , minute: \`movie_ratings_relation\`.localtime.minute , second: \`movie_ratings_relation\`.localtime.second , millisecond: \`movie_ratings_relation\`.localtime.millisecond , microsecond: \`movie_ratings_relation\`.localtime.microsecond , nanosecond: \`movie_ratings_relation\`.localtime.nanosecond , formatted: toString(\`movie_ratings_relation\`.localtime) },localdatetime: { year: \`movie_ratings_relation\`.localdatetime.year , month: \`movie_ratings_relation\`.localdatetime.month , day: \`movie_ratings_relation\`.localdatetime.day , hour: \`movie_ratings_relation\`.localdatetime.hour , minute: \`movie_ratings_relation\`.localdatetime.minute , second: \`movie_ratings_relation\`.localdatetime.second , millisecond: \`movie_ratings_relation\`.localdatetime.millisecond , microsecond: \`movie_ratings_relation\`.localdatetime.microsecond , nanosecond: \`movie_ratings_relation\`.localdatetime.nanosecond , formatted: toString(\`movie_ratings_relation\`.localdatetime) },User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User {_id: ID(\`movie_ratings_User\`), .name ,rated: [(\`movie_ratings_User\`)-[\`movie_ratings_User_rated_relation\`:\`RATED\`{rating:$2_rating}]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE movie_ratings_User_rated_relation.time = time($2_time.formatted) AND movie_ratings_User_rated_relation.datetime.year = $2_datetime.year | movie_ratings_User_rated_relation { .rating ,time: { hour: \`movie_ratings_User_rated_relation\`.time.hour , minute: \`movie_ratings_User_rated_relation\`.time.minute , second: \`movie_ratings_User_rated_relation\`.time.second , millisecond: \`movie_ratings_User_rated_relation\`.time.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.time.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.time.nanosecond , timezone: \`movie_ratings_User_rated_relation\`.time.timezone , formatted: toString(\`movie_ratings_User_rated_relation\`.time) },date: { year: \`movie_ratings_User_rated_relation\`.date.year , month: \`movie_ratings_User_rated_relation\`.date.month , day: \`movie_ratings_User_rated_relation\`.date.day , formatted: toString(\`movie_ratings_User_rated_relation\`.date) },datetime: { year: \`movie_ratings_User_rated_relation\`.datetime.year , month: \`movie_ratings_User_rated_relation\`.datetime.month , day: \`movie_ratings_User_rated_relation\`.datetime.day , hour: \`movie_ratings_User_rated_relation\`.datetime.hour , minute: \`movie_ratings_User_rated_relation\`.datetime.minute , second: \`movie_ratings_User_rated_relation\`.datetime.second , millisecond: \`movie_ratings_User_rated_relation\`.datetime.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.datetime.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.datetime.nanosecond , timezone: \`movie_ratings_User_rated_relation\`.datetime.timezone , formatted: toString(\`movie_ratings_User_rated_relation\`.datetime) },localtime: { hour: \`movie_ratings_User_rated_relation\`.localtime.hour , minute: \`movie_ratings_User_rated_relation\`.localtime.minute , second: \`movie_ratings_User_rated_relation\`.localtime.second , millisecond: \`movie_ratings_User_rated_relation\`.localtime.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.localtime.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.localtime.nanosecond , formatted: toString(\`movie_ratings_User_rated_relation\`.localtime) },localdatetime: { year: \`movie_ratings_User_rated_relation\`.localdatetime.year , month: \`movie_ratings_User_rated_relation\`.localdatetime.month , day: \`movie_ratings_User_rated_relation\`.localdatetime.day , hour: \`movie_ratings_User_rated_relation\`.localdatetime.hour , minute: \`movie_ratings_User_rated_relation\`.localdatetime.minute , second: \`movie_ratings_User_rated_relation\`.localdatetime.second , millisecond: \`movie_ratings_User_rated_relation\`.localdatetime.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.localdatetime.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.localdatetime.nanosecond , formatted: toString(\`movie_ratings_User_rated_relation\`.localdatetime) }}] }]) }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` {_id: ID(\`movie\`), .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`{rating:$1_rating}]-(:\`User\`) WHERE movie_ratings_relation.time = time($1_time.formatted) AND movie_ratings_relation.date.year = $1_date.year AND movie_ratings_relation.date.month = $1_date.month AND movie_ratings_relation.date.day = $1_date.day AND movie_ratings_relation.datetime.year = $1_datetime.year AND movie_ratings_relation.datetime.month = $1_datetime.month AND movie_ratings_relation.datetime.day = $1_datetime.day AND movie_ratings_relation.datetime.hour = $1_datetime.hour AND movie_ratings_relation.datetime.minute = $1_datetime.minute AND movie_ratings_relation.datetime.second = $1_datetime.second AND movie_ratings_relation.datetime.millisecond = $1_datetime.millisecond AND movie_ratings_relation.datetime.microsecond = $1_datetime.microsecond AND movie_ratings_relation.datetime.nanosecond = $1_datetime.nanosecond AND movie_ratings_relation.datetime.timezone = $1_datetime.timezone AND movie_ratings_relation.localtime.hour = $1_localtime.hour AND movie_ratings_relation.localtime.minute = $1_localtime.minute AND movie_ratings_relation.localtime.second = $1_localtime.second AND movie_ratings_relation.localtime.millisecond = $1_localtime.millisecond AND movie_ratings_relation.localtime.microsecond = $1_localtime.microsecond AND movie_ratings_relation.localtime.nanosecond = $1_localtime.nanosecond AND movie_ratings_relation.localdatetime.year = $1_localdatetime.year AND movie_ratings_relation.localdatetime.month = $1_localdatetime.month AND movie_ratings_relation.localdatetime.day = $1_localdatetime.day AND movie_ratings_relation.localdatetime.hour = $1_localdatetime.hour AND movie_ratings_relation.localdatetime.minute = $1_localdatetime.minute AND movie_ratings_relation.localdatetime.second = $1_localdatetime.second AND movie_ratings_relation.localdatetime.millisecond = $1_localdatetime.millisecond AND movie_ratings_relation.localdatetime.microsecond = $1_localdatetime.microsecond AND movie_ratings_relation.localdatetime.nanosecond = $1_localdatetime.nanosecond | movie_ratings_relation { .rating ,time: { hour: \`movie_ratings_relation\`.time.hour , minute: \`movie_ratings_relation\`.time.minute , second: \`movie_ratings_relation\`.time.second , millisecond: \`movie_ratings_relation\`.time.millisecond , microsecond: \`movie_ratings_relation\`.time.microsecond , nanosecond: \`movie_ratings_relation\`.time.nanosecond , timezone: \`movie_ratings_relation\`.time.timezone , formatted: toString(\`movie_ratings_relation\`.time) },date: { year: \`movie_ratings_relation\`.date.year , month: \`movie_ratings_relation\`.date.month , day: \`movie_ratings_relation\`.date.day , formatted: toString(\`movie_ratings_relation\`.date) },datetime: { year: \`movie_ratings_relation\`.datetime.year , month: \`movie_ratings_relation\`.datetime.month , day: \`movie_ratings_relation\`.datetime.day , hour: \`movie_ratings_relation\`.datetime.hour , minute: \`movie_ratings_relation\`.datetime.minute , second: \`movie_ratings_relation\`.datetime.second , millisecond: \`movie_ratings_relation\`.datetime.millisecond , microsecond: \`movie_ratings_relation\`.datetime.microsecond , nanosecond: \`movie_ratings_relation\`.datetime.nanosecond , timezone: \`movie_ratings_relation\`.datetime.timezone , formatted: toString(\`movie_ratings_relation\`.datetime) },localtime: { hour: \`movie_ratings_relation\`.localtime.hour , minute: \`movie_ratings_relation\`.localtime.minute , second: \`movie_ratings_relation\`.localtime.second , millisecond: \`movie_ratings_relation\`.localtime.millisecond , microsecond: \`movie_ratings_relation\`.localtime.microsecond , nanosecond: \`movie_ratings_relation\`.localtime.nanosecond , formatted: toString(\`movie_ratings_relation\`.localtime) },localdatetime: { year: \`movie_ratings_relation\`.localdatetime.year , month: \`movie_ratings_relation\`.localdatetime.month , day: \`movie_ratings_relation\`.localdatetime.day , hour: \`movie_ratings_relation\`.localdatetime.hour , minute: \`movie_ratings_relation\`.localdatetime.minute , second: \`movie_ratings_relation\`.localdatetime.second , millisecond: \`movie_ratings_relation\`.localdatetime.millisecond , microsecond: \`movie_ratings_relation\`.localdatetime.microsecond , nanosecond: \`movie_ratings_relation\`.localdatetime.nanosecond , formatted: toString(\`movie_ratings_relation\`.localdatetime) },User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User {_id: ID(\`movie_ratings_User\`), .name ,rated: [(\`movie_ratings_User\`)-[\`movie_ratings_User_rated_relation\`:\`RATED\`{rating:$2_rating}]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE movie_ratings_User_rated_relation.time = time($2_time.formatted) AND movie_ratings_User_rated_relation.datetime.year = $2_datetime.year | movie_ratings_User_rated_relation { .rating ,time: { hour: \`movie_ratings_User_rated_relation\`.time.hour , minute: \`movie_ratings_User_rated_relation\`.time.minute , second: \`movie_ratings_User_rated_relation\`.time.second , millisecond: \`movie_ratings_User_rated_relation\`.time.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.time.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.time.nanosecond , timezone: \`movie_ratings_User_rated_relation\`.time.timezone , formatted: toString(\`movie_ratings_User_rated_relation\`.time) },date: { year: \`movie_ratings_User_rated_relation\`.date.year , month: \`movie_ratings_User_rated_relation\`.date.month , day: \`movie_ratings_User_rated_relation\`.date.day , formatted: toString(\`movie_ratings_User_rated_relation\`.date) },datetime: { year: \`movie_ratings_User_rated_relation\`.datetime.year , month: \`movie_ratings_User_rated_relation\`.datetime.month , day: \`movie_ratings_User_rated_relation\`.datetime.day , hour: \`movie_ratings_User_rated_relation\`.datetime.hour , minute: \`movie_ratings_User_rated_relation\`.datetime.minute , second: \`movie_ratings_User_rated_relation\`.datetime.second , millisecond: \`movie_ratings_User_rated_relation\`.datetime.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.datetime.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.datetime.nanosecond , timezone: \`movie_ratings_User_rated_relation\`.datetime.timezone , formatted: toString(\`movie_ratings_User_rated_relation\`.datetime) },localtime: { hour: \`movie_ratings_User_rated_relation\`.localtime.hour , minute: \`movie_ratings_User_rated_relation\`.localtime.minute , second: \`movie_ratings_User_rated_relation\`.localtime.second , millisecond: \`movie_ratings_User_rated_relation\`.localtime.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.localtime.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.localtime.nanosecond , formatted: toString(\`movie_ratings_User_rated_relation\`.localtime) },localdatetime: { year: \`movie_ratings_User_rated_relation\`.localdatetime.year , month: \`movie_ratings_User_rated_relation\`.localdatetime.month , day: \`movie_ratings_User_rated_relation\`.localdatetime.day , hour: \`movie_ratings_User_rated_relation\`.localdatetime.hour , minute: \`movie_ratings_User_rated_relation\`.localdatetime.minute , second: \`movie_ratings_User_rated_relation\`.localdatetime.second , millisecond: \`movie_ratings_User_rated_relation\`.localdatetime.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.localdatetime.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.localdatetime.nanosecond , formatted: toString(\`movie_ratings_User_rated_relation\`.localdatetime) }}] }]) }] } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_rating': 5,
+      '1_time': {
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004,
+        timezone: '-08:00',
+        formatted: '10:30:01.002003004-08:00'
+      },
+      '1_date': {
+        year: 2017,
+        month: 11,
+        day: 23
+      },
+      '1_datetime': {
+        year: 2020,
+        month: 11,
+        day: 23,
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004,
+        timezone: 'America/Los_Angeles'
+      },
+      '1_localtime': {
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004
+      },
+      '1_localdatetime': {
+        year: 2018,
+        month: 11,
+        day: 23,
+        hour: 10,
+        minute: 30,
+        second: 1,
+        millisecond: 2,
+        microsecond: 2003,
+        nanosecond: 2003004
+      },
+      '2_rating': 5,
+      '2_time': {
+        formatted: '10:30:01.002003004-08:00'
+      },
+      '2_datetime': {
+        year: 2020
+      },
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
-    expectedCypherQuery
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -5077,14 +6277,20 @@ test('Query nested list properties on relationship', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` {_id: ID(\`movie\`), .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating , .ratings ,time: { hour: \`movie_ratings_relation\`.time.hour , minute: \`movie_ratings_relation\`.time.minute , second: \`movie_ratings_relation\`.time.second , millisecond: \`movie_ratings_relation\`.time.millisecond , microsecond: \`movie_ratings_relation\`.time.microsecond , nanosecond: \`movie_ratings_relation\`.time.nanosecond , timezone: \`movie_ratings_relation\`.time.timezone , formatted: toString(\`movie_ratings_relation\`.time) },date: { year: \`movie_ratings_relation\`.date.year , month: \`movie_ratings_relation\`.date.month , day: \`movie_ratings_relation\`.date.day , formatted: toString(\`movie_ratings_relation\`.date) },datetime: { year: \`movie_ratings_relation\`.datetime.year , month: \`movie_ratings_relation\`.datetime.month , day: \`movie_ratings_relation\`.datetime.day , hour: \`movie_ratings_relation\`.datetime.hour , minute: \`movie_ratings_relation\`.datetime.minute , second: \`movie_ratings_relation\`.datetime.second , millisecond: \`movie_ratings_relation\`.datetime.millisecond , microsecond: \`movie_ratings_relation\`.datetime.microsecond , nanosecond: \`movie_ratings_relation\`.datetime.nanosecond , timezone: \`movie_ratings_relation\`.datetime.timezone , formatted: toString(\`movie_ratings_relation\`.datetime) },datetimes: reduce(a = [], INSTANCE IN movie_ratings_relation.datetimes | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , hour: INSTANCE.hour , minute: INSTANCE.minute , second: INSTANCE.second , millisecond: INSTANCE.millisecond , microsecond: INSTANCE.microsecond , nanosecond: INSTANCE.nanosecond , timezone: INSTANCE.timezone , formatted: toString(INSTANCE) }),localtime: { hour: \`movie_ratings_relation\`.localtime.hour , minute: \`movie_ratings_relation\`.localtime.minute , second: \`movie_ratings_relation\`.localtime.second , millisecond: \`movie_ratings_relation\`.localtime.millisecond , microsecond: \`movie_ratings_relation\`.localtime.microsecond , nanosecond: \`movie_ratings_relation\`.localtime.nanosecond , formatted: toString(\`movie_ratings_relation\`.localtime) },localdatetime: { year: \`movie_ratings_relation\`.localdatetime.year , month: \`movie_ratings_relation\`.localdatetime.month , day: \`movie_ratings_relation\`.localdatetime.day , hour: \`movie_ratings_relation\`.localdatetime.hour , minute: \`movie_ratings_relation\`.localdatetime.minute , second: \`movie_ratings_relation\`.localdatetime.second , millisecond: \`movie_ratings_relation\`.localdatetime.millisecond , microsecond: \`movie_ratings_relation\`.localdatetime.microsecond , nanosecond: \`movie_ratings_relation\`.localdatetime.nanosecond , formatted: toString(\`movie_ratings_relation\`.localdatetime) },User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User {_id: ID(\`movie_ratings_User\`), .name ,rated: [(\`movie_ratings_User\`)-[\`movie_ratings_User_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | movie_ratings_User_rated_relation { .rating ,time: { hour: \`movie_ratings_User_rated_relation\`.time.hour , minute: \`movie_ratings_User_rated_relation\`.time.minute , second: \`movie_ratings_User_rated_relation\`.time.second , millisecond: \`movie_ratings_User_rated_relation\`.time.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.time.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.time.nanosecond , timezone: \`movie_ratings_User_rated_relation\`.time.timezone , formatted: toString(\`movie_ratings_User_rated_relation\`.time) },date: { year: \`movie_ratings_User_rated_relation\`.date.year , month: \`movie_ratings_User_rated_relation\`.date.month , day: \`movie_ratings_User_rated_relation\`.date.day , formatted: toString(\`movie_ratings_User_rated_relation\`.date) },datetime: { year: \`movie_ratings_User_rated_relation\`.datetime.year , month: \`movie_ratings_User_rated_relation\`.datetime.month , day: \`movie_ratings_User_rated_relation\`.datetime.day , hour: \`movie_ratings_User_rated_relation\`.datetime.hour , minute: \`movie_ratings_User_rated_relation\`.datetime.minute , second: \`movie_ratings_User_rated_relation\`.datetime.second , millisecond: \`movie_ratings_User_rated_relation\`.datetime.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.datetime.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.datetime.nanosecond , timezone: \`movie_ratings_User_rated_relation\`.datetime.timezone , formatted: toString(\`movie_ratings_User_rated_relation\`.datetime) },datetimes: reduce(a = [], INSTANCE IN movie_ratings_User_rated_relation.datetimes | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , hour: INSTANCE.hour , minute: INSTANCE.minute , second: INSTANCE.second , millisecond: INSTANCE.millisecond , microsecond: INSTANCE.microsecond , nanosecond: INSTANCE.nanosecond , timezone: INSTANCE.timezone , formatted: toString(INSTANCE) }),localtime: { hour: \`movie_ratings_User_rated_relation\`.localtime.hour , minute: \`movie_ratings_User_rated_relation\`.localtime.minute , second: \`movie_ratings_User_rated_relation\`.localtime.second , millisecond: \`movie_ratings_User_rated_relation\`.localtime.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.localtime.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.localtime.nanosecond , formatted: toString(\`movie_ratings_User_rated_relation\`.localtime) },localdatetime: { year: \`movie_ratings_User_rated_relation\`.localdatetime.year , month: \`movie_ratings_User_rated_relation\`.localdatetime.month , day: \`movie_ratings_User_rated_relation\`.localdatetime.day , hour: \`movie_ratings_User_rated_relation\`.localdatetime.hour , minute: \`movie_ratings_User_rated_relation\`.localdatetime.minute , second: \`movie_ratings_User_rated_relation\`.localdatetime.second , millisecond: \`movie_ratings_User_rated_relation\`.localdatetime.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.localdatetime.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.localdatetime.nanosecond , formatted: toString(\`movie_ratings_User_rated_relation\`.localdatetime) }}] }]) }] } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` {_id: ID(\`movie\`), .title ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation { .rating , .ratings ,time: { hour: \`movie_ratings_relation\`.time.hour , minute: \`movie_ratings_relation\`.time.minute , second: \`movie_ratings_relation\`.time.second , millisecond: \`movie_ratings_relation\`.time.millisecond , microsecond: \`movie_ratings_relation\`.time.microsecond , nanosecond: \`movie_ratings_relation\`.time.nanosecond , timezone: \`movie_ratings_relation\`.time.timezone , formatted: toString(\`movie_ratings_relation\`.time) },date: { year: \`movie_ratings_relation\`.date.year , month: \`movie_ratings_relation\`.date.month , day: \`movie_ratings_relation\`.date.day , formatted: toString(\`movie_ratings_relation\`.date) },datetime: { year: \`movie_ratings_relation\`.datetime.year , month: \`movie_ratings_relation\`.datetime.month , day: \`movie_ratings_relation\`.datetime.day , hour: \`movie_ratings_relation\`.datetime.hour , minute: \`movie_ratings_relation\`.datetime.minute , second: \`movie_ratings_relation\`.datetime.second , millisecond: \`movie_ratings_relation\`.datetime.millisecond , microsecond: \`movie_ratings_relation\`.datetime.microsecond , nanosecond: \`movie_ratings_relation\`.datetime.nanosecond , timezone: \`movie_ratings_relation\`.datetime.timezone , formatted: toString(\`movie_ratings_relation\`.datetime) },datetimes: reduce(a = [], INSTANCE IN movie_ratings_relation.datetimes | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , hour: INSTANCE.hour , minute: INSTANCE.minute , second: INSTANCE.second , millisecond: INSTANCE.millisecond , microsecond: INSTANCE.microsecond , nanosecond: INSTANCE.nanosecond , timezone: INSTANCE.timezone , formatted: toString(INSTANCE) }),localtime: { hour: \`movie_ratings_relation\`.localtime.hour , minute: \`movie_ratings_relation\`.localtime.minute , second: \`movie_ratings_relation\`.localtime.second , millisecond: \`movie_ratings_relation\`.localtime.millisecond , microsecond: \`movie_ratings_relation\`.localtime.microsecond , nanosecond: \`movie_ratings_relation\`.localtime.nanosecond , formatted: toString(\`movie_ratings_relation\`.localtime) },localdatetime: { year: \`movie_ratings_relation\`.localdatetime.year , month: \`movie_ratings_relation\`.localdatetime.month , day: \`movie_ratings_relation\`.localdatetime.day , hour: \`movie_ratings_relation\`.localdatetime.hour , minute: \`movie_ratings_relation\`.localdatetime.minute , second: \`movie_ratings_relation\`.localdatetime.second , millisecond: \`movie_ratings_relation\`.localdatetime.millisecond , microsecond: \`movie_ratings_relation\`.localdatetime.microsecond , nanosecond: \`movie_ratings_relation\`.localdatetime.nanosecond , formatted: toString(\`movie_ratings_relation\`.localdatetime) },User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User {_id: ID(\`movie_ratings_User\`), .name ,rated: [(\`movie_ratings_User\`)-[\`movie_ratings_User_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | movie_ratings_User_rated_relation { .rating ,time: { hour: \`movie_ratings_User_rated_relation\`.time.hour , minute: \`movie_ratings_User_rated_relation\`.time.minute , second: \`movie_ratings_User_rated_relation\`.time.second , millisecond: \`movie_ratings_User_rated_relation\`.time.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.time.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.time.nanosecond , timezone: \`movie_ratings_User_rated_relation\`.time.timezone , formatted: toString(\`movie_ratings_User_rated_relation\`.time) },date: { year: \`movie_ratings_User_rated_relation\`.date.year , month: \`movie_ratings_User_rated_relation\`.date.month , day: \`movie_ratings_User_rated_relation\`.date.day , formatted: toString(\`movie_ratings_User_rated_relation\`.date) },datetime: { year: \`movie_ratings_User_rated_relation\`.datetime.year , month: \`movie_ratings_User_rated_relation\`.datetime.month , day: \`movie_ratings_User_rated_relation\`.datetime.day , hour: \`movie_ratings_User_rated_relation\`.datetime.hour , minute: \`movie_ratings_User_rated_relation\`.datetime.minute , second: \`movie_ratings_User_rated_relation\`.datetime.second , millisecond: \`movie_ratings_User_rated_relation\`.datetime.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.datetime.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.datetime.nanosecond , timezone: \`movie_ratings_User_rated_relation\`.datetime.timezone , formatted: toString(\`movie_ratings_User_rated_relation\`.datetime) },datetimes: reduce(a = [], INSTANCE IN movie_ratings_User_rated_relation.datetimes | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , hour: INSTANCE.hour , minute: INSTANCE.minute , second: INSTANCE.second , millisecond: INSTANCE.millisecond , microsecond: INSTANCE.microsecond , nanosecond: INSTANCE.nanosecond , timezone: INSTANCE.timezone , formatted: toString(INSTANCE) }),localtime: { hour: \`movie_ratings_User_rated_relation\`.localtime.hour , minute: \`movie_ratings_User_rated_relation\`.localtime.minute , second: \`movie_ratings_User_rated_relation\`.localtime.second , millisecond: \`movie_ratings_User_rated_relation\`.localtime.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.localtime.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.localtime.nanosecond , formatted: toString(\`movie_ratings_User_rated_relation\`.localtime) },localdatetime: { year: \`movie_ratings_User_rated_relation\`.localdatetime.year , month: \`movie_ratings_User_rated_relation\`.localdatetime.month , day: \`movie_ratings_User_rated_relation\`.localdatetime.day , hour: \`movie_ratings_User_rated_relation\`.localdatetime.hour , minute: \`movie_ratings_User_rated_relation\`.localdatetime.minute , second: \`movie_ratings_User_rated_relation\`.localdatetime.second , millisecond: \`movie_ratings_User_rated_relation\`.localdatetime.millisecond , microsecond: \`movie_ratings_User_rated_relation\`.localdatetime.microsecond , nanosecond: \`movie_ratings_User_rated_relation\`.localdatetime.nanosecond , formatted: toString(\`movie_ratings_User_rated_relation\`.localdatetime) }}] }]) }] } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
-    expectedCypherQuery
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -5097,14 +6303,36 @@ test('UUID value generated if no id value provided', t => {
     expectedCypherQuery = `
     CREATE (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}:\`MovieSearch\` {movieId: apoc.create.uuid(),title:$params.title,released: datetime($params.released)})
     RETURN \`movie\` { .title } AS \`movie\`
-  `;
+  `,
+    expectedParams = {
+      params: {
+        title: 'Yo Dawg',
+        released: {
+          year: {
+            low: 2009,
+            high: 0
+          },
+          month: {
+            low: 6,
+            high: 0
+          },
+          day: {
+            low: 9,
+            high: 0
+          }
+        }
+      },
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(1);
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
-    expectedCypherQuery
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
@@ -5115,6 +6343,9 @@ test('Create node with list arguments', t => {
       titles: ["A", "B"]
       imdbRatings: [5.5, 8.95]
       years: [2004, 2018]
+      booleans: [false, true]
+      enums: [Science]
+      year: 2020
       released: {year: 1992, month: 10, day: 9}
       releases: [
         {
@@ -5167,41 +6398,459 @@ test('Create node with list arguments', t => {
     }
   }`,
     expectedCypherQuery = `
-    CREATE (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}:\`MovieSearch\` {movieId: apoc.create.uuid(),title:$params.title,released: datetime($params.released),locations: [value IN $params.locations | point(value)],years:$params.years,titles:$params.titles,imdbRatings:$params.imdbRatings,releases: [value IN $params.releases | datetime(value)]})
+    CREATE (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}:\`MovieSearch\` {movieId: apoc.create.uuid(),title:$params.title,year:$params.year,released: datetime($params.released),locations: [value IN $params.locations | point(value)],years:$params.years,titles:$params.titles,imdbRatings:$params.imdbRatings,releases: [value IN $params.releases | datetime(value)],booleans:$params.booleans,enums:$params.enums})
     RETURN \`movie\` { .movieId , .title , .titles , .imdbRatings , .years ,releases: reduce(a = [], INSTANCE IN movie.releases | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , hour: INSTANCE.hour , second: INSTANCE.second , formatted: toString(INSTANCE) }),locations: reduce(a = [], INSTANCE IN movie.locations | a + { x: INSTANCE.x , y: INSTANCE.y , z: INSTANCE.z })} AS \`movie\`
-  `;
+  `,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      params: {
+        title: 'River Runs Through It, A',
+        year: {
+          low: 2020,
+          high: 0
+        },
+        released: {
+          year: {
+            low: 1992,
+            high: 0
+          },
+          month: {
+            low: 10,
+            high: 0
+          },
+          day: {
+            low: 9,
+            high: 0
+          }
+        },
+        locations: [
+          {
+            x: 10,
+            y: 20,
+            z: 30
+          },
+          {
+            x: 30,
+            y: 20,
+            z: 10
+          }
+        ],
+        years: [
+          {
+            low: 2004,
+            high: 0
+          },
+          {
+            low: 2018,
+            high: 0
+          }
+        ],
+        titles: ['A', 'B'],
+        imdbRatings: [5.5, 8.95],
+        releases: [
+          {
+            year: {
+              low: 2020,
+              high: 0
+            },
+            month: {
+              low: 11,
+              high: 0
+            },
+            day: {
+              low: 23,
+              high: 0
+            },
+            hour: {
+              low: 10,
+              high: 0
+            },
+            minute: {
+              low: 30,
+              high: 0
+            },
+            second: {
+              low: 1,
+              high: 0
+            },
+            millisecond: {
+              low: 2,
+              high: 0
+            },
+            microsecond: {
+              low: 3,
+              high: 0
+            },
+            nanosecond: {
+              low: 4,
+              high: 0
+            },
+            timezone: 'America/Los_Angeles'
+          },
+          '2020-11-23T10:30:01.002003004-08:00[America/Los_Angeles]'
+        ],
+        booleans: [false, true],
+        enums: ['Science']
+      }
+    };
 
-  t.plan(1);
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Query list properties on node type using list arguments', t => {
+  const graphQLQuery = `query {
+    Movie(
+      titles: ["A"]
+      imdbRatings: [8.95]
+      years: [2004]
+      booleans: true
+      enums: [Mystery, Science]
+      releases: [
+        {
+          year: 2020
+          month: 11
+          day: 23
+        },
+        {
+          formatted: "2030-10-23T10:30:01.002003004-08:00[America/Los_Angeles]"
+        }
+      ],
+      locations: {
+        x: 10
+        y: 20
+        z: 30
+      }
+    ) {
+      _id
+      locations {
+        x
+        y
+        z
+        srid
+      }
+      releases {
+        year
+        month
+        day
+        formatted
+      }
+      titles
+      imdbRatings
+      years
+      booleans
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE [value IN $locations WHERE [prop IN \`movie\`.\`locations\` WHERE ((value.x IS NULL OR prop.x = value.x) AND (value.y IS NULL OR prop.y = value.y) AND (value.z IS NULL OR prop.z = value.z))]] AND [value IN $years WHERE value IN \`movie\`.\`years\`] AND [value IN $titles WHERE value IN \`movie\`.\`titles\`] AND [value IN $imdbRatings WHERE value IN \`movie\`.\`imdbRatings\`] AND [value IN $releases WHERE [prop IN \`movie\`.\`releases\` WHERE ((value.year IS NULL OR prop.year = value.year) AND (value.month IS NULL OR prop.month = value.month) AND (value.day IS NULL OR prop.day = value.day) AND (value.formatted IS NULL OR prop = datetime(value.formatted)))]] AND [value IN $booleans WHERE value IN \`movie\`.\`booleans\`] AND [value IN $enums WHERE value IN \`movie\`.\`enums\`] RETURN \`movie\` {_id: ID(\`movie\`),locations: reduce(a = [], INSTANCE IN movie.locations | a + { x: INSTANCE.x , y: INSTANCE.y , z: INSTANCE.z , srid: INSTANCE.srid }),releases: reduce(a = [], INSTANCE IN movie.releases | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , formatted: toString(INSTANCE) }), .titles , .imdbRatings , .years , .booleans } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      locations: [
+        {
+          x: 10,
+          y: 20,
+          z: 30
+        }
+      ],
+      years: [2004],
+      titles: ['A'],
+      imdbRatings: [8.95],
+      releases: [
+        {
+          year: 2020,
+          month: 11,
+          day: 23
+        },
+        {
+          formatted: '2030-10-23T10:30:01.002003004-08:00[America/Los_Angeles]'
+        }
+      ],
+      booleans: [true],
+      enums: ['Mystery', 'Science'],
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Query list properties on nested node type using list arguments', t => {
+  const graphQLQuery = `query {
+    Movie {
+      _id
+      year
+      actors(
+        strings: ["B"],
+        datetimes: [
+          {
+            year: 2020,
+            month: 11,
+            day: 23,
+          },
+          {
+            formatted: "2018-11-23T10:30:01.002003004-08:00[America/Los_Angeles]"
+          }
+        ]
+      ) {
+        name
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` {_id: ID(\`movie\`), .year ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) WHERE [value IN $1_strings WHERE value IN \`movie_actors\`.\`strings\`] AND [value IN $1_datetimes WHERE [prop IN \`movie_actors\`.\`datetimes\` WHERE ((value.year IS NULL OR prop.year = value.year) AND (value.month IS NULL OR prop.month = value.month) AND (value.day IS NULL OR prop.day = value.day) AND (value.formatted IS NULL OR prop = datetime(value.formatted)))]] | \`movie_actors\` { .name }] } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_strings': ['B'],
+      '1_datetimes': [
+        {
+          year: 2020,
+          month: 11,
+          day: 23
+        },
+        {
+          formatted: '2018-11-23T10:30:01.002003004-08:00[America/Los_Angeles]'
+        }
+      ],
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Query list properties on relationship type field using list arguments', t => {
+  const graphQLQuery = `query {
+    Movie {
+      _id
+      year
+      ratings(
+        ratings: [12, 20]
+        datetimes: [
+          {
+            year: 2019,
+            month: 12,
+            day: 23,
+          },
+          {
+            formatted: "2018-10-23T00:00:00Z"
+          }
+        ]
+      ) {      
+        ratings
+        datetimes {
+          year
+          month
+          day
+          formatted        
+        }
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` {_id: ID(\`movie\`), .year ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) WHERE [value IN $1_ratings WHERE value IN \`movie_ratings_relation\`.\`ratings\`] AND [value IN $1_datetimes WHERE [prop IN \`movie_ratings_relation\`.\`datetimes\` WHERE ((value.year IS NULL OR prop.year = value.year) AND (value.month IS NULL OR prop.month = value.month) AND (value.day IS NULL OR prop.day = value.day) AND (value.formatted IS NULL OR prop = datetime(value.formatted)))]] | movie_ratings_relation { .ratings ,datetimes: reduce(a = [], INSTANCE IN movie_ratings_relation.datetimes | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , formatted: toString(INSTANCE) })}] } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_ratings': [12, 20],
+      '1_datetimes': [
+        {
+          year: 2019,
+          month: 12,
+          day: 23
+        },
+        {
+          formatted: '2018-10-23T00:00:00Z'
+        }
+      ],
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(2);
   return augmentedSchemaCypherTestRunner(
     t,
     graphQLQuery,
     {},
-    expectedCypherQuery
+    expectedCypherQuery,
+    expectedParams
   );
 });
 
-test('Cypher array queries', t => {
-  const graphQLQuery = `
-  {
-    MoviesByYears(year: [1999]) {
-        title
+test('Query list properties on reflexive relationship type field using list arguments', t => {
+  const graphQLQuery = `query {
+    User {
+      friends {
+        to(
+	        ratings: ["B"]
+          datetimes: [
+            {
+              year: 2018,
+              month: 10,
+              day: 23,
+            },
+            {
+              formatted: "2020-11-23T00:00:00Z"
+            }
+          ]
+        ) {
+          _id
+          ratings
+          datetimes {
+            year
+            month
+            day
+            formatted        
+          }          
+        }
+        from(
+	        ratings: ["A"]
+          datetimes: [
+            {
+              year: 2018,
+              month: 10,
+              day: 23,
+            },
+            {
+              formatted: "2020-11-23T00:00:00Z"
+            }
+          ]
+        ) {
+          _id
+          ratings
+          datetimes {
+            year
+            month
+            day
+            formatted        
+          }          
+        }
       }
-    }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE \`movie\`.\`year\` IN $year RETURN \`movie\` { .title } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      year: [1999],
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {friends: {to: [(\`user\`)-[\`user_to_relation\`:\`FRIEND_OF\`]->(\`user_to\`:\`User\`) WHERE [value IN $1_ratings WHERE value IN \`user_to_relation\`.\`ratings\`] AND [value IN $1_datetimes WHERE [prop IN \`user_to_relation\`.\`datetimes\` WHERE ((value.year IS NULL OR prop.year = value.year) AND (value.month IS NULL OR prop.month = value.month) AND (value.day IS NULL OR prop.day = value.day) AND (value.formatted IS NULL OR prop = datetime(value.formatted)))]] | user_to_relation {_id: ID(\`user_to_relation\`), .ratings ,datetimes: reduce(a = [], INSTANCE IN user_to_relation.datetimes | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , formatted: toString(INSTANCE) })}] ,from: [(\`user\`)<-[\`user_from_relation\`:\`FRIEND_OF\`]-(\`user_from\`:\`User\`) WHERE [value IN $3_ratings WHERE value IN \`user_from_relation\`.\`ratings\`] AND [value IN $3_datetimes WHERE [prop IN \`user_from_relation\`.\`datetimes\` WHERE ((value.year IS NULL OR prop.year = value.year) AND (value.month IS NULL OR prop.month = value.month) AND (value.day IS NULL OR prop.day = value.day) AND (value.formatted IS NULL OR prop = datetime(value.formatted)))]] | user_from_relation {_id: ID(\`user_from_relation\`), .ratings ,datetimes: reduce(a = [], INSTANCE IN user_from_relation.datetimes | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , formatted: toString(INSTANCE) })}] } } AS \`user\``,
+    expectedParams = {
+      offset: 0,
       first: -1,
-      cypherParams: CYPHER_PARAMS,
-      offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+      '1_ratings': ['B'],
+      '1_datetimes': [
+        {
+          year: 2018,
+          month: 10,
+          day: 23
+        },
+        {
+          formatted: '2020-11-23T00:00:00Z'
+        }
+      ],
+      '3_ratings': ['A'],
+      '3_datetimes': [
+        {
+          year: 2018,
+          month: 10,
+          day: 23
+        },
+        {
+          formatted: '2020-11-23T00:00:00Z'
+        }
+      ],
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
+  );
+});
+
+test('Custom query for non-list property on node type using list argument', t => {
+  const graphQLQuery = `query {
+      MoviesByYears(
+        year: [2020]
+        released: [
+          {
+            year: 1992
+            month: 10
+            day: 9
+          },
+          {
+            formatted: "2030-10-23T10:30:01.002003004-08:00[America/Los_Angeles]"
+          }
+        ]
+      ) {
+        _id
+        year
+        released {
+          formatted
+        }
+      }
+    }
+    `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE \`movie\`.\`year\` IN $year AND [value IN $released WHERE ((value.year IS NULL OR \`movie\`.\`released\`.year = value.year) AND (value.month IS NULL OR \`movie\`.\`released\`.month = value.month) AND (value.day IS NULL OR \`movie\`.\`released\`.day = value.day) AND (value.formatted IS NULL OR \`movie\`.\`released\` = datetime(value.formatted)))] RETURN \`movie\` {_id: ID(\`movie\`), .year ,released: { formatted: toString(\`movie\`.released) }} AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      year: [2020],
+      released: [
+        {
+          year: 1992,
+          month: 10,
+          day: 9
+        },
+        {
+          formatted: '2030-10-23T10:30:01.002003004-08:00[America/Los_Angeles]'
+        }
+      ],
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
-test('Cypher array sub queries', t => {
+test('Custom query for nested non-list property on node type using list argument (no matching field)', t => {
   const graphQLQuery = `
   {
     MoviesByYears(year: [1998]) {
@@ -5211,19 +6860,733 @@ test('Cypher array sub queries', t => {
         }
       }
     }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE \`movie\`.\`year\` IN $year RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`{names:$1_names}) WHERE \`movie_actors\`.\`names\` IN $1_names | \`movie_actors\` { .name }] } AS \`movie\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE \`movie\`.\`year\` IN $year RETURN \`movie\` { .title ,actors: [(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) WHERE \`movie_actors\`.\`names\` IN $1_names | \`movie_actors\` { .name }] } AS \`movie\``,
+    expectedParams = {
       year: [1998],
       '1_names': ['Jeff Bridges', 'John Goodman'],
       first: -1,
       offset: 0,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
+});
+
+test('Query node type using String type list filters', t => {
+  const graphQLQuery = `query {
+    Movie(
+      filter: {
+        titles: ["A", "B", "C"]
+        titles_not: ["B"]
+        titles_contains: ["C"]
+        titles_ends_with: ["D"]
+        titles_starts_with: ["E"]
+        titles_not_contains: ["F"]
+        titles_not_ends_with: ["G"]
+        titles_not_starts_with: ["H"]
+      }
+    ) {
+      _id
+      titles
+    }
+  }  
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ([value IN $filter.titles WHERE value IN \`movie\`.titles]) AND (NONE(value IN $filter.titles_not WHERE [prop IN \`movie\`.titles WHERE prop = value])) AND ([value IN $filter.titles_contains WHERE [prop IN \`movie\`.titles WHERE prop CONTAINS value]]) AND ([value IN $filter.titles_not_contains WHERE [prop IN \`movie\`.titles WHERE NOT prop CONTAINS value]]) AND ([value IN $filter.titles_starts_with WHERE [prop IN \`movie\`.titles WHERE prop STARTS WITH value]]) AND ([value IN $filter.titles_not_starts_with WHERE [prop IN \`movie\`.titles WHERE NOT prop STARTS WITH value]]) AND ([value IN $filter.titles_ends_with WHERE [prop IN \`movie\`.titles WHERE prop ENDS WITH value]]) AND ([value IN $filter.titles_not_ends_with WHERE [prop IN \`movie\`.titles WHERE NOT prop ENDS WITH value]]) RETURN \`movie\` {_id: ID(\`movie\`), .titles } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      filter: {
+        titles: ['A', 'B', 'C'],
+        titles_not: ['B'],
+        titles_contains: ['C'],
+        titles_not_contains: ['F'],
+        titles_starts_with: ['E'],
+        titles_not_starts_with: ['H'],
+        titles_ends_with: ['D'],
+        titles_not_ends_with: ['G']
+      },
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Query node type using Int type list filters', t => {
+  const graphQLQuery = `query {
+    Movie(
+      filter: {
+        years: [2018, 2004]
+        years_not: [2020]
+        years_lt: [2005],
+        years_gt: [2017],
+        years_lte: [2018],
+        years_gte: [2004]
+      }
+    ) {
+      _id
+      years
+    }
+  }   
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ([value IN $filter.years WHERE value IN \`movie\`.years]) AND (NONE(value IN $filter.years_not WHERE [prop IN \`movie\`.years WHERE prop = value])) AND ([value IN $filter.years_lt WHERE [prop IN \`movie\`.years WHERE prop < value]]) AND ([value IN $filter.years_lte WHERE [prop IN \`movie\`.years WHERE prop <= value]]) AND ([value IN $filter.years_gt WHERE [prop IN \`movie\`.years WHERE prop > value]]) AND ([value IN $filter.years_gte WHERE [prop IN \`movie\`.years WHERE prop >= value]]) RETURN \`movie\` {_id: ID(\`movie\`), .years } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      filter: {
+        years: [2018, 2004],
+        years_not: [2020],
+        years_lt: [2005],
+        years_lte: [2018],
+        years_gt: [2017],
+        years_gte: [2004]
+      },
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Query node type using Float type list filters', t => {
+  const graphQLQuery = `query {
+    Movie(
+      filter: {
+        imdbRatings: [5.5, 8.95]
+        imdbRatings_lt: [5.6, 7, 8.99]
+        imdbRatings_gt: [5.4, 8]
+        imdbRatings_not: [5.55, 8.96]
+        imdbRatings_lte: [5.5]
+        imdbRatings_gte: [8.95]
+      }
+    ) {
+      _id
+      imdbRatings
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ([value IN $filter.imdbRatings WHERE value IN \`movie\`.imdbRatings]) AND (NONE(value IN $filter.imdbRatings_not WHERE [prop IN \`movie\`.imdbRatings WHERE prop = value])) AND ([value IN $filter.imdbRatings_lt WHERE [prop IN \`movie\`.imdbRatings WHERE prop < value]]) AND ([value IN $filter.imdbRatings_lte WHERE [prop IN \`movie\`.imdbRatings WHERE prop <= value]]) AND ([value IN $filter.imdbRatings_gt WHERE [prop IN \`movie\`.imdbRatings WHERE prop > value]]) AND ([value IN $filter.imdbRatings_gte WHERE [prop IN \`movie\`.imdbRatings WHERE prop >= value]]) RETURN \`movie\` {_id: ID(\`movie\`), .imdbRatings } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      filter: {
+        imdbRatings: [5.5, 8.95],
+        imdbRatings_not: [5.55, 8.96],
+        imdbRatings_lt: [5.6, 7, 8.99],
+        imdbRatings_lte: [5.5],
+        imdbRatings_gt: [5.4, 8],
+        imdbRatings_gte: [8.95]
+      },
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Query node type using Boolean and Enum type list filters', t => {
+  const graphQLQuery = `query {
+    Movie(
+      filter: {
+        booleans: [true]
+        booleans_not: false
+        enums: [Science]
+        enums_not: [Mystery]
+      }
+    ) {
+      _id
+      booleans
+      enums
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ([value IN $filter.booleans WHERE value IN \`movie\`.booleans]) AND (NONE(value IN $filter.booleans_not WHERE [prop IN \`movie\`.booleans WHERE prop = value])) AND ([value IN $filter.enums WHERE value IN \`movie\`.enums]) AND (NONE(value IN $filter.enums_not WHERE [prop IN \`movie\`.enums WHERE prop = value])) RETURN \`movie\` {_id: ID(\`movie\`), .booleans , .enums } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      filter: {
+        booleans: [true],
+        booleans_not: [false],
+        enums: ['Science'],
+        enums_not: ['Mystery']
+      },
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Query node type using Temporal type list filters', t => {
+  const graphQLQuery = `query {
+    Movie(
+      filter: {
+        releases: [
+          { year: 2020 }
+          { year: 2018 }
+        ]
+        releases_lt: [
+          {
+            year: 2041,
+            day: 24
+          }
+        ]
+        releases_gt: [
+          {
+            formatted: "2010-10-22T10:30:01.002003004-07:00[America/Los_Angeles]"
+          }
+        ]
+        releases_not: {
+          year: 2041
+        }
+        releases_lte: {
+          year: 2020,
+          day: 23
+        }      
+        releases_gte: {
+          year: 2020,
+          day: 23
+        }
+      }
+    ) {
+      _id
+      releases {
+        year
+        day
+        month
+        hour
+        minute
+        second
+        formatted
+      }
+    }
+  }  
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ([value IN $filter.releases WHERE [prop IN \`movie\`.releases WHERE ((value.year IS NULL OR prop.year = value.year))]]) AND (NONE(value IN $filter.releases_not WHERE [prop IN \`movie\`.releases WHERE ((value.year IS NULL OR prop.year = value.year))])) AND ([value IN $filter.releases_lt WHERE [prop IN \`movie\`.releases WHERE ((value.year IS NULL OR prop.year < value.year) AND (value.day IS NULL OR prop.day < value.day))]]) AND ([value IN $filter.releases_lte WHERE [prop IN \`movie\`.releases WHERE ((value.year IS NULL OR prop.year <= value.year) AND (value.day IS NULL OR prop.day <= value.day))]]) AND ([value IN $filter.releases_gt WHERE [prop IN \`movie\`.releases WHERE ((value.formatted IS NULL OR prop > datetime(value.formatted)))]]) AND ([value IN $filter.releases_gte WHERE [prop IN \`movie\`.releases WHERE ((value.year IS NULL OR prop.year >= value.year) AND (value.day IS NULL OR prop.day >= value.day))]]) RETURN \`movie\` {_id: ID(\`movie\`),releases: reduce(a = [], INSTANCE IN movie.releases | a + { year: INSTANCE.year , day: INSTANCE.day , month: INSTANCE.month , hour: INSTANCE.hour , minute: INSTANCE.minute , second: INSTANCE.second , formatted: toString(INSTANCE) })} AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      filter: {
+        releases: [
+          {
+            year: {
+              low: 2020,
+              high: 0
+            }
+          },
+          {
+            year: {
+              low: 2018,
+              high: 0
+            }
+          }
+        ],
+        releases_not: [
+          {
+            year: {
+              low: 2041,
+              high: 0
+            }
+          }
+        ],
+        releases_lt: [
+          {
+            year: {
+              low: 2041,
+              high: 0
+            },
+            day: {
+              low: 24,
+              high: 0
+            }
+          }
+        ],
+        releases_lte: [
+          {
+            year: {
+              low: 2020,
+              high: 0
+            },
+            day: {
+              low: 23,
+              high: 0
+            }
+          }
+        ],
+        releases_gt: [
+          {
+            formatted:
+              '2010-10-22T10:30:01.002003004-07:00[America/Los_Angeles]'
+          }
+        ],
+        releases_gte: [
+          {
+            year: {
+              low: 2020,
+              high: 0
+            },
+            day: {
+              low: 23,
+              high: 0
+            }
+          }
+        ]
+      },
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Query node type using Spatial type list filters', t => {
+  const graphQLQuery = `query {
+    Movie(
+      filter: {
+        locations: [
+          {
+            x: 10
+          }
+          {
+            x: 30
+          }
+        ]
+        locations_not: [
+          {
+            z: 11
+          }
+        ]
+        locations_distance: [
+          {
+            point: {
+              x: 10
+              y: 20
+              z: 31
+            }
+            distance: 1
+          }
+        ]
+        locations_distance_lt: [
+          {
+            point: {
+              x: 10
+              y: 20
+              z: 31
+            }
+            distance: 2.5
+          }
+        ]      
+        locations_distance_gt: [
+          {
+            point: {
+              x: 10
+              y: 20
+              z: 31
+            }
+            distance: 2.5
+          }
+        ]
+        locations_distance_lte: [
+          {
+            point: {
+              x: 10
+              y: 20
+              z: 31
+            }
+            distance: 2.5
+          }
+        ]
+        locations_distance_gte: [
+          {
+            point: {
+              x: 10
+              y: 20
+              z: 31
+            }
+            distance: 2.5
+          }
+        ]            
+      }
+    ) {
+      _id
+      locations {
+        x
+        y
+        z
+      }
+    }
+  }    
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ([value IN $filter.locations WHERE [prop IN \`movie\`.locations WHERE ((value.x IS NULL OR prop.x = value.x))]]) AND (NONE(value IN $filter.locations_not WHERE [prop IN \`movie\`.locations WHERE ((value.z IS NULL OR prop.z = value.z))])) AND ([value IN $filter.locations_distance WHERE [prop IN \`movie\`.locations WHERE ((distance(prop, point(value.point)) =value.distance))]]) AND ([value IN $filter.locations_distance_lt WHERE [prop IN \`movie\`.locations WHERE ((distance(prop, point(value.point)) <value.distance))]]) AND ([value IN $filter.locations_distance_lte WHERE [prop IN \`movie\`.locations WHERE ((distance(prop, point(value.point)) <=value.distance))]]) AND ([value IN $filter.locations_distance_gt WHERE [prop IN \`movie\`.locations WHERE ((distance(prop, point(value.point)) >value.distance))]]) AND ([value IN $filter.locations_distance_gte WHERE [prop IN \`movie\`.locations WHERE ((distance(prop, point(value.point)) >=value.distance))]]) RETURN \`movie\` {_id: ID(\`movie\`),locations: reduce(a = [], INSTANCE IN movie.locations | a + { x: INSTANCE.x , y: INSTANCE.y , z: INSTANCE.z })} AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      filter: {
+        locations: [
+          {
+            x: 10
+          },
+          {
+            x: 30
+          }
+        ],
+        locations_not: [
+          {
+            z: 11
+          }
+        ],
+        locations_distance: [
+          {
+            point: {
+              x: 10,
+              y: 20,
+              z: 31
+            },
+            distance: 1
+          }
+        ],
+        locations_distance_lt: [
+          {
+            point: {
+              x: 10,
+              y: 20,
+              z: 31
+            },
+            distance: 2.5
+          }
+        ],
+        locations_distance_lte: [
+          {
+            point: {
+              x: 10,
+              y: 20,
+              z: 31
+            },
+            distance: 2.5
+          }
+        ],
+        locations_distance_gt: [
+          {
+            point: {
+              x: 10,
+              y: 20,
+              z: 31
+            },
+            distance: 2.5
+          }
+        ],
+        locations_distance_gte: [
+          {
+            point: {
+              x: 10,
+              y: 20,
+              z: 31
+            },
+            distance: 2.5
+          }
+        ]
+      },
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Query using filters that check for existence of list properties', t => {
+  const graphQLQuery = `query {
+    Movie(
+      filter: {
+        titles: null
+        titles_not: null
+        years: null
+        years_not: null
+        imdbRatings: null
+        imdbRatings_not: null
+        releases: null
+        releases_not: null
+        locations: null
+        locations_not: null
+      }
+    ) {
+      _id
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ($filter._locations_null = TRUE AND NOT EXISTS(\`movie\`.locations)) AND ($filter._locations_not_null = TRUE AND EXISTS(\`movie\`.locations)) AND ($filter._years_null = TRUE AND NOT EXISTS(\`movie\`.years)) AND ($filter._years_not_null = TRUE AND EXISTS(\`movie\`.years)) AND ($filter._titles_null = TRUE AND NOT EXISTS(\`movie\`.titles)) AND ($filter._titles_not_null = TRUE AND EXISTS(\`movie\`.titles)) AND ($filter._imdbRatings_null = TRUE AND NOT EXISTS(\`movie\`.imdbRatings)) AND ($filter._imdbRatings_not_null = TRUE AND EXISTS(\`movie\`.imdbRatings)) AND ($filter._releases_null = TRUE AND NOT EXISTS(\`movie\`.releases)) AND ($filter._releases_not_null = TRUE AND EXISTS(\`movie\`.releases)) RETURN \`movie\` {_id: ID(\`movie\`)} AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      filter: {
+        _locations_null: true,
+        _locations_not_null: true,
+        _years_null: true,
+        _years_not_null: true,
+        _titles_null: true,
+        _titles_not_null: true,
+        _imdbRatings_null: true,
+        _imdbRatings_not_null: true,
+        _releases_null: true,
+        _releases_not_null: true
+      },
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Query using filters that check for emptiness of list properties', t => {
+  const graphQLQuery = `query {
+    Movie(
+      filter: {
+        titles: []
+        titles_not: []
+        years: []
+        years_not: []
+        imdbRatings: []
+        imdbRatings_not: []
+        releases: []
+        releases_not: []
+        locations: []
+        locations_not: []
+      }
+    ) {
+      _id
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ((size(\`movie\`.locations) = 0)) AND ((size(\`movie\`.locations) > 0)) AND ((size(\`movie\`.years) = 0)) AND ((size(\`movie\`.years) > 0)) AND ((size(\`movie\`.titles) = 0)) AND ((size(\`movie\`.titles) > 0)) AND ((size(\`movie\`.imdbRatings) = 0)) AND ((size(\`movie\`.imdbRatings) > 0)) AND ((size(\`movie\`.releases) = 0)) AND ((size(\`movie\`.releases) > 0)) RETURN \`movie\` {_id: ID(\`movie\`)} AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      filter: {
+        locations: [],
+        locations_not: [],
+        years: [],
+        years_not: [],
+        titles: [],
+        titles_not: [],
+        imdbRatings: [],
+        imdbRatings_not: [],
+        releases: [],
+        releases_not: []
+      },
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Query relationship type using list field filters', t => {
+  const graphQLQuery = `query {
+    Movie(filter: { ratings_not: null }) {
+      _id
+      titles
+      ratings(
+        filter: {
+          ratings_not: []
+          ratings: [5]
+          ratings_lt: [6]
+          ratings_gt: [19]
+          ratings_lte: [5]
+          ratings_gte: [20]
+          datetimes: [
+            { year: 2018, hour: 0 }
+            {
+              formatted: "2019-11-23T10:30:01.002003004-08:00[America/Los_Angeles]"
+            }
+          ]
+          datetimes_not: [{ year: 2022 }]
+          datetimes_lt: [{ day: 24 }]
+          datetimes_lte: [{ day: 23 }, { day: 22 }]
+          datetimes_gt: [{ hour: 9 }, { minute: 0 }]
+          datetimes_gte: [{ hour: 10 }]
+        }
+      ) {
+        ratings
+        datetimes {
+          year
+          month
+          day
+          hour
+          minute
+          second
+          formatted
+        }
+      }
+    }
+  }  
+  `,
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WHERE ($filter._ratings_not_null = TRUE AND EXISTS((\`movie\`)<-[:RATED]-(:User))) RETURN \`movie\` {_id: ID(\`movie\`), .titles ,ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) WHERE ((size(\`movie_ratings_relation\`.ratings) > 0)) AND ([value IN $1_filter.ratings WHERE value IN \`movie_ratings_relation\`.ratings]) AND ([value IN $1_filter.ratings_lt WHERE [prop IN \`movie_ratings_relation\`.ratings WHERE prop < value]]) AND ([value IN $1_filter.ratings_gt WHERE [prop IN \`movie_ratings_relation\`.ratings WHERE prop > value]]) AND ([value IN $1_filter.ratings_lte WHERE [prop IN \`movie_ratings_relation\`.ratings WHERE prop <= value]]) AND ([value IN $1_filter.ratings_gte WHERE [prop IN \`movie_ratings_relation\`.ratings WHERE prop >= value]]) AND ([value IN $1_filter.datetimes WHERE [prop IN \`movie_ratings_relation\`.datetimes WHERE ((value.year IS NULL OR prop.year = value.year) AND (value.hour IS NULL OR prop.hour = value.hour) AND (value.formatted IS NULL OR prop = datetime(value.formatted)))]]) AND (NONE(value IN $1_filter.datetimes_not WHERE [prop IN \`movie_ratings_relation\`.datetimes WHERE ((value.year IS NULL OR prop.year = value.year))])) AND ([value IN $1_filter.datetimes_lt WHERE [prop IN \`movie_ratings_relation\`.datetimes WHERE ((value.day IS NULL OR prop.day < value.day))]]) AND ([value IN $1_filter.datetimes_lte WHERE [prop IN \`movie_ratings_relation\`.datetimes WHERE ((value.day IS NULL OR prop.day <= value.day))]]) AND ([value IN $1_filter.datetimes_gt WHERE [prop IN \`movie_ratings_relation\`.datetimes WHERE ((value.hour IS NULL OR prop.hour > value.hour) AND (value.minute IS NULL OR prop.minute > value.minute))]]) AND ([value IN $1_filter.datetimes_gte WHERE [prop IN \`movie_ratings_relation\`.datetimes WHERE ((value.hour IS NULL OR prop.hour >= value.hour))]]) | movie_ratings_relation { .ratings ,datetimes: reduce(a = [], INSTANCE IN movie_ratings_relation.datetimes | a + { year: INSTANCE.year , month: INSTANCE.month , day: INSTANCE.day , hour: INSTANCE.hour , minute: INSTANCE.minute , second: INSTANCE.second , formatted: toString(INSTANCE) })}] } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      filter: {
+        _ratings_not_null: true
+      },
+      '1_filter': {
+        ratings_not: [],
+        ratings: [5],
+        ratings_lt: [6],
+        ratings_gt: [19],
+        ratings_lte: [5],
+        ratings_gte: [20],
+        datetimes: [
+          {
+            year: {
+              low: 2018,
+              high: 0
+            },
+            hour: {
+              low: 0,
+              high: 0
+            }
+          },
+          {
+            formatted:
+              '2019-11-23T10:30:01.002003004-08:00[America/Los_Angeles]'
+          }
+        ],
+        datetimes_not: [
+          {
+            year: {
+              low: 2022,
+              high: 0
+            }
+          }
+        ],
+        datetimes_lt: [
+          {
+            day: {
+              low: 24,
+              high: 0
+            }
+          }
+        ],
+        datetimes_lte: [
+          {
+            day: {
+              low: 23,
+              high: 0
+            }
+          },
+          {
+            day: {
+              low: 22,
+              high: 0
+            }
+          }
+        ],
+        datetimes_gt: [
+          {
+            hour: {
+              low: 9,
+              high: 0
+            }
+          },
+          {
+            minute: {
+              low: 0,
+              high: 0
+            }
+          }
+        ],
+        datetimes_gte: [
+          {
+            hour: {
+              low: 10,
+              high: 0
+            }
+          }
+        ]
+      },
+      cypherParams: CYPHER_PARAMS
+    };
+
+  t.plan(2);
+  return augmentedSchemaCypherTestRunner(
+    t,
+    graphQLQuery,
+    {},
+    expectedCypherQuery,
+    expectedParams
+  );
 });
 
 test('Create node with non-null field', t => {
@@ -5237,18 +7600,25 @@ test('Create node with non-null field', t => {
     expectedCypherQuery = `
     CREATE (\`state\`:\`State\` {name:$params.name})
     RETURN \`state\` { .name } AS \`state\`
-  `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+  `,
+    expectedParams = {
       params: {
         name: 'California'
       },
       first: -1,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5259,16 +7629,23 @@ test('Query node with ignored field', t => {
       customField
     } 
   }`,
-    expectedCypherQuery = `MATCH (\`state\`:\`State\`) RETURN \`state\` { .name } AS \`state\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`state\`:\`State\`) RETURN \`state\` { .name } AS \`state\``,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5304,11 +7681,24 @@ test('Deeply nested orderBy', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WITH \`movie\` ORDER BY movie.title DESC RETURN \`movie\` { .title ,actors: apoc.coll.sortMulti([(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name ,movies: apoc.coll.sortMulti([(\`movie_actors\`)-[:\`ACTED_IN\`]->(\`movie_actors_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`movie_actors_movies\` { .title }], ['^title','title']) }], ['name']) } AS \`movie\``;
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) WITH \`movie\` ORDER BY movie.title DESC RETURN \`movie\` { .title ,actors: apoc.coll.sortMulti([(\`movie\`)<-[:\`ACTED_IN\`]-(\`movie_actors\`:\`Actor\`) | \`movie_actors\` { .name ,movies: apoc.coll.sortMulti([(\`movie_actors\`)-[:\`ACTED_IN\`]->(\`movie_actors_movies\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`movie_actors_movies\` { .title }], ['^title','title']) }], ['name']) } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_orderBy': 'name_desc',
+      '2_orderBy': ['title_asc', 'title_desc'],
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5319,11 +7709,22 @@ test('Optimize performance - not requesting attributes with @cypher directive - 
       name
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) WITH \`user\` ORDER BY user.name DESC RETURN \`user\` {_id: ID(\`user\`), .name } AS \`user\``;
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) WITH \`user\` ORDER BY user.name DESC RETURN \`user\` {_id: ID(\`user\`), .name } AS \`user\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5335,11 +7736,22 @@ test('Optimize performance - attributes with @cypher directive requested - no op
       currentUserId
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {_id: ID(\`user\`), .name ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user, cypherParams: $cypherParams, strArg: "Neo4j"}, false)} AS \`user\` ORDER BY user.currentUserId DESC `;
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {_id: ID(\`user\`), .name ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user, cypherParams: $cypherParams, strArg: "Neo4j"}, false)} AS \`user\` ORDER BY user.currentUserId DESC `,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5351,11 +7763,22 @@ test('Query using enum orderBy', t => {
     }
   }`,
     expectedCypherQuery =
-      'MATCH (`book`:`Book`) WITH `book` ORDER BY book.genre ASC RETURN `book` {_id: ID(`book`), .genre } AS `book`';
+      'MATCH (`book`:`Book`) WITH `book` ORDER BY book.genre ASC RETURN `book` {_id: ID(`book`), .genre } AS `book`',
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5370,11 +7793,21 @@ test('Query using temporal orderBy', t => {
     }
   }`,
     expectedCypherQuery =
-      'MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC , temporalNode.datetime ASC RETURN `temporalNode` {datetime: { formatted: toString(`temporalNode`.datetime) }} AS `temporalNode`';
+      'MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC , temporalNode.datetime ASC RETURN `temporalNode` {datetime: { formatted: toString(`temporalNode`.datetime) }} AS `temporalNode`',
+    expectedParams = {
+      offset: 0,
+      first: -1
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5427,11 +7860,25 @@ test('Deeply nested query using temporal orderBy', t => {
     }
   }`,
     expectedCypherQuery =
-      "MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC RETURN `temporalNode` {_id: ID(`temporalNode`),datetime: { year: `temporalNode`.datetime.year , month: `temporalNode`.datetime.month , day: `temporalNode`.datetime.day , hour: `temporalNode`.datetime.hour , minute: `temporalNode`.datetime.minute , second: `temporalNode`.datetime.second , millisecond: `temporalNode`.datetime.millisecond , microsecond: `temporalNode`.datetime.microsecond , nanosecond: `temporalNode`.datetime.nanosecond , timezone: `temporalNode`.datetime.timezone , formatted: toString(`temporalNode`.datetime) },temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes` {_id: ID(`temporalNode_temporalNodes`),datetime: `temporalNode_temporalNodes`.datetime,time: `temporalNode_temporalNodes`.time,temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode_temporalNodes`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes_temporalNodes` {_id: ID(`temporalNode_temporalNodes_temporalNodes`),datetime: `temporalNode_temporalNodes_temporalNodes`.datetime,time: `temporalNode_temporalNodes_temporalNodes`.time}], ['datetime','time']) | sortedElement { .* ,  datetime: {year: sortedElement.datetime.year,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}][1..3] }], ['^datetime']) | sortedElement { .* ,  datetime: {year: sortedElement.datetime.year,month: sortedElement.datetime.month,day: sortedElement.datetime.day,hour: sortedElement.datetime.hour,minute: sortedElement.datetime.minute,second: sortedElement.datetime.second,millisecond: sortedElement.datetime.millisecond,microsecond: sortedElement.datetime.microsecond,nanosecond: sortedElement.datetime.nanosecond,timezone: sortedElement.datetime.timezone,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}] } AS `temporalNode`";
+      "MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC RETURN `temporalNode` {_id: ID(`temporalNode`),datetime: { year: `temporalNode`.datetime.year , month: `temporalNode`.datetime.month , day: `temporalNode`.datetime.day , hour: `temporalNode`.datetime.hour , minute: `temporalNode`.datetime.minute , second: `temporalNode`.datetime.second , millisecond: `temporalNode`.datetime.millisecond , microsecond: `temporalNode`.datetime.microsecond , nanosecond: `temporalNode`.datetime.nanosecond , timezone: `temporalNode`.datetime.timezone , formatted: toString(`temporalNode`.datetime) },temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes` {_id: ID(`temporalNode_temporalNodes`),datetime: `temporalNode_temporalNodes`.datetime,time: `temporalNode_temporalNodes`.time,temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode_temporalNodes`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes_temporalNodes` {_id: ID(`temporalNode_temporalNodes_temporalNodes`),datetime: `temporalNode_temporalNodes_temporalNodes`.datetime,time: `temporalNode_temporalNodes_temporalNodes`.time}], ['datetime','time']) | sortedElement { .* ,  datetime: {year: sortedElement.datetime.year,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}][1..3] }], ['^datetime']) | sortedElement { .* ,  datetime: {year: sortedElement.datetime.year,month: sortedElement.datetime.month,day: sortedElement.datetime.day,hour: sortedElement.datetime.hour,minute: sortedElement.datetime.minute,second: sortedElement.datetime.second,millisecond: sortedElement.datetime.millisecond,microsecond: sortedElement.datetime.microsecond,nanosecond: sortedElement.datetime.nanosecond,timezone: sortedElement.datetime.timezone,formatted: toString(sortedElement.datetime)},time: {hour: sortedElement.time.hour}}] } AS `temporalNode`",
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_orderBy': 'datetime_asc',
+      '2_first': 2,
+      '2_offset': 1,
+      '2_orderBy': ['datetime_desc', 'time_desc']
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5457,19 +7904,25 @@ test('query nested relationship with differences between selected and ordered fi
   }
   `,
     expectedCypherQuery =
-      "MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC RETURN `temporalNode` {datetime: { year: `temporalNode`.datetime.year , formatted: toString(`temporalNode`.datetime) },temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes` {_id: ID(`temporalNode_temporalNodes`), .name ,time: `temporalNode_temporalNodes`.time,temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode_temporalNodes`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes_temporalNodes` {_id: ID(`temporalNode_temporalNodes_temporalNodes`), .name ,datetime: `temporalNode_temporalNodes_temporalNodes`.datetime}], ['datetime','^name']) | sortedElement { .* }][1..3] ,datetime: `temporalNode_temporalNodes`.datetime}], ['^datetime','datetime']) | sortedElement { .* ,  time: {hour: sortedElement.time.hour}}] } AS `temporalNode`";
-
-  t.plan(1);
-  return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+      "MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC RETURN `temporalNode` {datetime: { year: `temporalNode`.datetime.year , formatted: toString(`temporalNode`.datetime) },temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes` {_id: ID(`temporalNode_temporalNodes`), .name ,time: `temporalNode_temporalNodes`.time,temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode_temporalNodes`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes_temporalNodes` {_id: ID(`temporalNode_temporalNodes_temporalNodes`), .name ,datetime: `temporalNode_temporalNodes_temporalNodes`.datetime}], ['datetime','^name']) | sortedElement { .* }][1..3] ,datetime: `temporalNode_temporalNodes`.datetime}], ['^datetime','datetime']) | sortedElement { .* ,  time: {hour: sortedElement.time.hour}}] } AS `temporalNode`",
+    expectedParams = {
       offset: 0,
       first: -1,
       '1_orderBy': ['datetime_asc', 'datetime_desc'],
       '2_first': 2,
       '2_offset': 1,
-      '2_orderBy': ['datetime_desc', 'name_asc'],
-      cypherParams: CYPHER_PARAMS
-    })
+      '2_orderBy': ['datetime_desc', 'name_asc']
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5483,11 +7936,24 @@ test('Deeply nested query using temporal orderBy without temporal field selectio
     }
   }`,
     expectedCypherQuery =
-      "MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC RETURN `temporalNode` {_id: ID(`temporalNode`),temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes` {_id: ID(`temporalNode_temporalNodes`),datetime: `temporalNode_temporalNodes`.datetime,time: `temporalNode_temporalNodes`.time}], ['datetime','time']) | sortedElement { .* }][1..3] } AS `temporalNode`";
+      "MATCH (`temporalNode`:`TemporalNode`) WITH `temporalNode` ORDER BY temporalNode.datetime DESC RETURN `temporalNode` {_id: ID(`temporalNode`),temporalNodes: [sortedElement IN apoc.coll.sortMulti([(`temporalNode`)-[:`TEMPORAL`]->(`temporalNode_temporalNodes`:`TemporalNode`) | `temporalNode_temporalNodes` {_id: ID(`temporalNode_temporalNodes`),datetime: `temporalNode_temporalNodes`.datetime,time: `temporalNode_temporalNodes`.time}], ['datetime','time']) | sortedElement { .* }][1..3] } AS `temporalNode`",
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_first': 2,
+      '1_offset': 1,
+      '1_orderBy': ['datetime_desc', 'time_desc']
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5499,16 +7965,23 @@ test('Handle @cypher field with String payload using cypherParams', t => {
       name
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user, cypherParams: $cypherParams, strArg: "Neo4j"}, false), .name } AS \`user\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user, cypherParams: $cypherParams, strArg: "Neo4j"}, false), .name } AS \`user\``,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5542,11 +8015,22 @@ test('Handle nested @cypher fields that use cypherParams', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user, cypherParams: $cypherParams, strArg: "Neo4j"}, false), .name ,friends: {to: [(\`user\`)-[\`user_to_relation\`:\`FRIEND_OF\`]->(\`user_to\`:\`User\`) | user_to_relation { .since ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_to_relation, cypherParams: $cypherParams}, false),User: user_to { .name ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_to, cypherParams: $cypherParams, strArg: "Neo4j"}, false)} }] ,from: [(\`user\`)<-[\`user_from_relation\`:\`FRIEND_OF\`]-(\`user_from\`:\`User\`) | user_from_relation { .since ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_from_relation, cypherParams: $cypherParams}, false)}] } ,rated: [(\`user\`)-[\`user_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_rated_relation { .rating ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_rated_relation, cypherParams: $cypherParams}, false)}] ,favorites: [(\`user\`)-[:\`FAVORITED\`]->(\`user_favorites\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`user_favorites\` { .movieId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_favorites, cypherParams: $cypherParams}, false)}] } AS \`user\``;
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user, cypherParams: $cypherParams, strArg: "Neo4j"}, false), .name ,friends: {to: [(\`user\`)-[\`user_to_relation\`:\`FRIEND_OF\`]->(\`user_to\`:\`User\`) | user_to_relation { .since ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_to_relation, cypherParams: $cypherParams}, false),User: user_to { .name ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_to, cypherParams: $cypherParams, strArg: "Neo4j"}, false)} }] ,from: [(\`user\`)<-[\`user_from_relation\`:\`FRIEND_OF\`]-(\`user_from\`:\`User\`) | user_from_relation { .since ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_from_relation, cypherParams: $cypherParams}, false)}] } ,rated: [(\`user\`)-[\`user_rated_relation\`:\`RATED\`]->(:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | user_rated_relation { .rating ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_rated_relation, cypherParams: $cypherParams}, false)}] ,favorites: [(\`user\`)-[:\`FAVORITED\`]->(\`user_favorites\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) | \`user_favorites\` { .movieId ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user_favorites, cypherParams: $cypherParams}, false)}] } AS \`user\``,
+    expectedParams = {
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      offset: 0
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5554,16 +8038,23 @@ test('Handle @cypher query using cypherParams with String payload', t => {
   const graphQLQuery = `query {
     currentUserId
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS currentUserId", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`string\` RETURN \`string\` `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS currentUserId", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`string\` RETURN \`string\` `,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5573,16 +8064,23 @@ test('Handle @cypher query using cypherParams with Object payload', t => {
       userId
     }
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("RETURN { userId: $cypherParams.currentUserId }", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`currentUserId\` RETURN \`currentUserId\` { .userId } AS \`currentUserId\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("RETURN { userId: $cypherParams.currentUserId }", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`currentUserId\` RETURN \`currentUserId\` { .userId } AS \`currentUserId\``,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5590,16 +8088,23 @@ test('Handle @cypher query with Boolean payload', t => {
   const graphQLQuery = `query {
     computedBoolean
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("RETURN true", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`boolean\` RETURN \`boolean\` `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("RETURN true", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`boolean\` RETURN \`boolean\` `,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5607,16 +8112,23 @@ test('Handle @cypher query with Int payload', t => {
   const graphQLQuery = `query {
     computedInt
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("RETURN 1", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`int\` RETURN \`int\` `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("RETURN 1", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`int\` RETURN \`int\` `,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5624,16 +8136,23 @@ test('Handle @cypher query with Float payload', t => {
   const graphQLQuery = `query {
     computedFloat
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("RETURN 3.14", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`float\` RETURN \`float\` `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("RETURN 3.14", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`float\` RETURN \`float\` `,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5641,16 +8160,23 @@ test('Handle @cypher query with String list payload', t => {
   const graphQLQuery = `query {
     computedStringList
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("UNWIND ['hello', 'world'] AS stringList RETURN stringList", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`string\` RETURN \`string\` `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("UNWIND ['hello', 'world'] AS stringList RETURN stringList", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`string\` RETURN \`string\` `,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5658,16 +8184,23 @@ test('Handle @cypher query with Int list payload', t => {
   const graphQLQuery = `query {
     computedIntList
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("UNWIND [1, 2, 3] AS intList RETURN intList", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`int\` RETURN \`int\` `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("UNWIND [1, 2, 3] AS intList RETURN intList", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`int\` RETURN \`int\` `,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5687,16 +8220,23 @@ test('Handle @cypher query with temporal payload', t => {
       formatted
     }
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("WITH datetime() AS now RETURN { year: now.year, month: now.month , day: now.day , hour: now.hour , minute: now.minute , second: now.second , millisecond: now.millisecond , microsecond: now.microsecond , nanosecond: now.nanosecond , timezone: now.timezone , formatted: toString(now) }", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`_Neo4jDateTime\` RETURN \`_Neo4jDateTime\` `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("WITH datetime() AS now RETURN { year: now.year, month: now.month , day: now.day , hour: now.hour , minute: now.minute , second: now.second , millisecond: now.millisecond , microsecond: now.microsecond , nanosecond: now.nanosecond , timezone: now.timezone , formatted: toString(now) }", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`_Neo4jDateTime\` RETURN \`_Neo4jDateTime\` `,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5709,16 +8249,23 @@ test('Handle @cypher query with spatial payload', t => {
       crs
     }
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("WITH point({ x: 10, y: 20, z: 15 }) AS instance RETURN { x: instance.x, y: instance.y, z: instance.z, crs: instance.crs }", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`_Neo4jPoint\` RETURN \`_Neo4jPoint\` `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("WITH point({ x: 10, y: 20, z: 15 }) AS instance RETURN { x: instance.x, y: instance.y, z: instance.z, crs: instance.crs }", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`_Neo4jPoint\` RETURN \`_Neo4jPoint\` `,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5728,16 +8275,23 @@ test('Handle @cypher mutation using cypherParams with String payload', t => {
   }`,
     expectedCypherQuery = `CALL apoc.cypher.doIt("RETURN $cypherParams.currentUserId", {first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
     WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`string\`
-    RETURN \`string\` `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      cypherParams: CYPHER_PARAMS,
+    RETURN \`string\` `,
+    expectedParams = {
       first: -1,
+      cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5749,16 +8303,23 @@ test('Handle @cypher mutation using cypherParams with Object payload', t => {
   }`,
     expectedCypherQuery = `CALL apoc.cypher.doIt("RETURN { userId: $cypherParams.currentUserId }", {first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
     WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`currentUserId\`
-    RETURN \`currentUserId\` { .userId } AS \`currentUserId\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    RETURN \`currentUserId\` { .userId } AS \`currentUserId\``,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5768,16 +8329,23 @@ test('Handle @cypher mutation with String list payload', t => {
   }`,
     expectedCypherQuery = `CALL apoc.cypher.doIt("UNWIND ['hello', 'world'] AS stringList RETURN stringList", {first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
     WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`string\`
-    RETURN \`string\` `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    RETURN \`string\` `,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5799,16 +8367,23 @@ test('Handle @cypher mutation with temporal payload', t => {
   }`,
     expectedCypherQuery = `CALL apoc.cypher.doIt("WITH datetime() AS now RETURN { year: now.year, month: now.month , day: now.day , hour: now.hour , minute: now.minute , second: now.second , millisecond: now.millisecond , microsecond: now.microsecond , nanosecond: now.nanosecond , timezone: now.timezone , formatted: toString(now) }", {first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
     WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`_Neo4jDateTime\`
-    RETURN \`_Neo4jDateTime\` `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    RETURN \`_Neo4jDateTime\` `,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5823,16 +8398,23 @@ test('Handle @cypher mutation with spatial payload', t => {
   }`,
     expectedCypherQuery = `CALL apoc.cypher.doIt("WITH point({ x: 10, y: 20, z: 15 }) AS instance RETURN { x: instance.x, y: instance.y, z: instance.z, crs: instance.crs }", {first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
     WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`_Neo4jPoint\`
-    RETURN \`_Neo4jPoint\` `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    RETURN \`_Neo4jPoint\` `,
+    expectedParams = {
       first: -1,
       cypherParams: CYPHER_PARAMS,
       offset: 0
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5855,23 +8437,36 @@ test('Handle nested @cypher fields using parameterized arguments and cypherParam
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` {_id: ID(\`movie\`),currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: movie, cypherParams: $cypherParams, strArg: $1_strArg}, false),ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation {currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: movie_ratings_relation, cypherParams: $cypherParams, strArg: $2_strArg}, false),User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .name ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: movie_ratings_User, cypherParams: $cypherParams, strArg: $3_strArg, strInputArg: $3_strInputArg}, false)}]) }] } AS \`movie\``;
+    graphqlParams = {
+      strArg1: 'Yo Dawg',
+      strArg2: 'Yoo Dawg',
+      strArg3: 'Yooo Dawg',
+      strInputArg: {
+        strArg: 'Yoooo Dawg'
+      },
+      cypherParams: CYPHER_PARAMS
+    },
+    expectedCypherQuery = `MATCH (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}) RETURN \`movie\` {_id: ID(\`movie\`),currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: movie, cypherParams: $cypherParams, strArg: $1_strArg}, false),ratings: [(\`movie\`)<-[\`movie_ratings_relation\`:\`RATED\`]-(:\`User\`) | movie_ratings_relation {currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: movie_ratings_relation, cypherParams: $cypherParams, strArg: $2_strArg}, false),User: head([(:\`Movie\`${ADDITIONAL_MOVIE_LABELS})<-[\`movie_ratings_relation\`]-(\`movie_ratings_User\`:\`User\`) | movie_ratings_User { .name ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: movie_ratings_User, cypherParams: $cypherParams, strArg: $3_strArg, strInputArg: $3_strInputArg}, false)}]) }] } AS \`movie\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      '1_strArg': 'Yo Dawg',
+      '2_strArg': 'Yoo Dawg',
+      '3_strArg': 'Yooo Dawg',
+      '3_strInputArg': {
+        strArg: 'Yoooo Dawg'
+      },
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
     augmentedSchemaCypherTestRunner(
       t,
       graphQLQuery,
-      {
-        strArg1: 'Yo Dawg',
-        strArg2: 'Yoo Dawg',
-        strArg3: 'Yooo Dawg',
-        strInputArg: {
-          strArg: 'Yoooo Dawg'
-        },
-        cypherParams: CYPHER_PARAMS
-      },
-      expectedCypherQuery
+      graphqlParams,
+      expectedCypherQuery,
+      expectedParams
     )
   ]);
 });
@@ -5880,42 +8475,163 @@ test('Handle @cypher mutation with input type argument', t => {
   const graphQLQuery = `mutation someMutation($strArg: String, $strInputArg: strInput) {
     customWithArguments(strArg: $strArg, strInputArg: $strInputArg )
   }`,
+    graphqlParams = {
+      strArg: 'Hello',
+      strInputArg: {
+        strArg: 'World'
+      }
+    },
     expectedCypherQuery = `CALL apoc.cypher.doIt("RETURN $strInputArg.strArg", {strArg:$strArg, strInputArg:$strInputArg, first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
     WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`string\`
-    RETURN \`string\` `;
+    RETURN \`string\` `,
+    expectedParams = {
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      offset: 0,
+      strArg: 'Hello',
+      strInputArg: {
+        strArg: 'World'
+      }
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
     cypherTestRunner(
       t,
       graphQLQuery,
-      {
-        strArg: 'Hello',
-        strInputArg: {
-          strArg: 'World'
-        }
-      },
+      graphqlParams,
       expectedCypherQuery,
-      {
-        first: -1,
-        cypherParams: CYPHER_PARAMS,
-        offset: 0,
-        strArg: 'Hello',
-        strInputArg: {
-          strArg: 'World'
-        }
-      }
+      expectedParams
     ),
     augmentedSchemaCypherTestRunner(
       t,
       graphQLQuery,
-      {
-        strArg: 'Hello',
-        strInputArg: {
-          strArg: 'World'
+      graphqlParams,
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Handle @cypher mutation with list arguments', t => {
+  const graphQLQuery = `mutation someMutation(
+    $integer: Int
+    $datetime: _Neo4jDateTimeInput
+    $integers: [Int]
+    $datetimes: [_Neo4jDateTimeInput]
+    $point: _Neo4jPointInput
+    $points: [_Neo4jPointInput]
+  ) {
+    customCreateNode(
+      integer: $integer
+      datetime: $datetime
+      integers: $integers
+      datetimes: $datetimes
+      point: $point
+      points: $points
+    )
+  }
+  `,
+    graphqlParams = {
+      integer: 2,
+      datetime: { year: 2020, month: 9, day: 21 },
+      integers: [2, 4, 6],
+      datetimes: [{ year: 2020, month: 9, day: 22 }],
+      point: { x: 10.1, y: 11.2, z: 12.3 },
+      points: [
+        { x: 10.1, y: 11.2, z: 12.3 },
+        { x: 10.2, y: 11.3, z: 12.4 }
+      ]
+    },
+    expectedCypherQuery = `CALL apoc.cypher.doIt("CREATE (n:Node { integer: $integer, datetime: datetime($datetime), point: point($point), integers: $integers, datetimes: [value IN $datetimes | datetime(value)], points: [value IN $points | point(value)] }) RETURN TRUE", {integer:$integer, datetime:$datetime, integers:$integers, datetimes:$datetimes, point:$point, points:$points, first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
+    WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`boolean\`
+    RETURN \`boolean\` `,
+    expectedParams = {
+      first: -1,
+      cypherParams: CYPHER_PARAMS,
+      offset: 0,
+      integer: {
+        low: 2,
+        high: 0
+      },
+      datetime: {
+        year: {
+          low: 2020,
+          high: 0
+        },
+        month: {
+          low: 9,
+          high: 0
+        },
+        day: {
+          low: 21,
+          high: 0
         }
       },
-      expectedCypherQuery
+      integers: [
+        {
+          low: 2,
+          high: 0
+        },
+        {
+          low: 4,
+          high: 0
+        },
+        {
+          low: 6,
+          high: 0
+        }
+      ],
+      datetimes: [
+        {
+          year: {
+            low: 2020,
+            high: 0
+          },
+          month: {
+            low: 9,
+            high: 0
+          },
+          day: {
+            low: 22,
+            high: 0
+          }
+        }
+      ],
+      point: {
+        x: 10.1,
+        y: 11.2,
+        z: 12.3
+      },
+      points: [
+        {
+          x: 10.1,
+          y: 11.2,
+          z: 12.3
+        },
+        {
+          x: 10.2,
+          y: 11.3,
+          z: 12.4
+        }
+      ]
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(
+      t,
+      graphQLQuery,
+      graphqlParams,
+      expectedCypherQuery,
+      expectedParams
+    ),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      graphqlParams,
+      expectedCypherQuery,
+      expectedParams
     )
   ]);
 });
@@ -5924,40 +8640,38 @@ test('Handle @cypher query with parameterized input type argument', t => {
   const graphQLQuery = `query someQuery ($strArg: String, $strInputArg: strInput) {
     customWithArguments(strArg: $strArg, strInputArg: $strInputArg )
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("RETURN $strInputArg.strArg", {offset:$offset, first:$first, strArg:$strArg, strInputArg:$strInputArg, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`string\` RETURN \`string\` `;
+    graphqlParams = {
+      strArg: 'Hello',
+      strInputArg: {
+        strArg: 'World'
+      }
+    },
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("RETURN $strInputArg.strArg", {offset:$offset, first:$first, strArg:$strArg, strInputArg:$strInputArg, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`string\` RETURN \`string\` `,
+    expectedParams = {
+      first: -1,
+      offset: 0,
+      strArg: 'Hello',
+      strInputArg: {
+        strArg: 'World'
+      },
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
     cypherTestRunner(
       t,
       graphQLQuery,
-      {
-        strArg: 'Hello',
-        strInputArg: {
-          strArg: 'World'
-        }
-      },
+      graphqlParams,
       expectedCypherQuery,
-      {
-        first: -1,
-        offset: 0,
-        strArg: 'Hello',
-        strInputArg: {
-          strArg: 'World'
-        },
-        cypherParams: CYPHER_PARAMS
-      }
+      expectedParams
     ),
     augmentedSchemaCypherTestRunner(
       t,
       graphQLQuery,
-      {
-        strArg: 'Hello',
-        strInputArg: {
-          strArg: 'World'
-        }
-      },
-      expectedCypherQuery
+      graphqlParams,
+      expectedCypherQuery,
+      expectedParams
     )
   ]);
 });
@@ -5968,11 +8682,21 @@ test('Handle @cypher field on root query type with scalar payload, no args', t =
       computedTimestamp
     }
   }`,
-    expectedCypherQuery = `MATCH (\`temporalNode\`:\`TemporalNode\`) RETURN \`temporalNode\` {computedTimestamp: apoc.cypher.runFirstColumn("RETURN toString(datetime())", {this: temporalNode}, false)} AS \`temporalNode\``;
+    expectedCypherQuery = `MATCH (\`temporalNode\`:\`TemporalNode\`) RETURN \`temporalNode\` {computedTimestamp: apoc.cypher.runFirstColumn("RETURN toString(datetime())", {this: temporalNode}, false)} AS \`temporalNode\``,
+    expectedParams = {
+      first: -1,
+      offset: 0
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -5987,38 +8711,57 @@ test('Handle @cypher field with parameterized value for field of input type argu
       })
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .name ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user, cypherParams: $cypherParams, strArg: "Neo4j", strInputArg: $1_strInputArg}, false)} AS \`user\``;
+    graphqlParams = {
+      strArg: 'Yo Dawg'
+    },
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .name ,currentUserId: apoc.cypher.runFirstColumn("RETURN $cypherParams.currentUserId AS cypherParamsUserId", {this: user, cypherParams: $cypherParams, strArg: "Neo4j", strInputArg: $1_strInputArg}, false)} AS \`user\``,
+    expectedParams = {
+      '1_strInputArg': {
+        strArg: 'Yo Dawg'
+      },
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
     cypherTestRunner(
       t,
       graphQLQuery,
-      {
-        strArg: 'Yo Dawg'
-      },
+      graphqlParams,
       expectedCypherQuery,
-      {
-        '1_strInputArg': {
-          strArg: 'Yo Dawg'
-        },
-        first: -1,
-        offset: 0,
-        cypherParams: CYPHER_PARAMS
-      }
+      expectedParams
     ),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      graphqlParams,
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
 test('Handle order by field with underscores - root level', t => {
   const graphQLQuery = `{Movie(orderBy: someprefix_title_with_underscores_desc){title}}`,
     expectedCypherQuery =
-      'MATCH (`movie`:`Movie`:`u_user-id`:`newMovieLabel`) WITH `movie` ORDER BY movie.someprefix_title_with_underscores DESC RETURN `movie` { .title } AS `movie`';
+      'MATCH (`movie`:`Movie`:`u_user-id`:`newMovieLabel`) WITH `movie` ORDER BY movie.someprefix_title_with_underscores DESC RETURN `movie` { .title } AS `movie`',
+    expectedParams = {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6033,11 +8776,24 @@ test('Handle order by field with underscores - nested field ', t => {
   }
   `,
     expectedCypherQuery =
-      'WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {offset:$offset, first:$first, substring:$substring, cypherParams: $cypherParams}, True) AS x UNWIND x AS `genre` RETURN `genre` {movies: apoc.coll.sortMulti([(`genre`)<-[:`IN_GENRE`]-(`genre_movies`:`Movie`:`u_user-id`:`newMovieLabel`) | `genre_movies` { .title , .someprefix_title_with_underscores }], [\'someprefix_title_with_underscores\']) } AS `genre`';
+      'WITH apoc.cypher.runFirstColumn("MATCH (g:Genre) WHERE toLower(g.name) CONTAINS toLower($substring) RETURN g", {offset:$offset, first:$first, substring:$substring, cypherParams: $cypherParams}, True) AS x UNWIND x AS `genre` RETURN `genre` {movies: apoc.coll.sortMulti([(`genre`)<-[:`IN_GENRE`]-(`genre_movies`:`Movie`:`u_user-id`:`newMovieLabel`) | `genre_movies` { .title , .someprefix_title_with_underscores }], [\'someprefix_title_with_underscores\']) } AS `genre`',
+    expectedParams = {
+      '1_orderBy': 'someprefix_title_with_underscores_desc',
+      cypherParams: CYPHER_PARAMS,
+      first: -1,
+      offset: 0,
+      substring: 'Foo'
+    };
 
-  t.plan(1);
+  t.plan(2);
   return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6047,17 +8803,24 @@ test('query only an interface field', t => {
       id
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id } AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id } AS \`camera\``,
+    expectedParams = {
       first: -1,
       offset: 0,
       cypherParams: CYPHER_PARAMS,
       Camera_derivedTypes: ['NewCamera', 'OldCamera']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6067,17 +8830,24 @@ test('query only __typename field on interface type', t => {
       __typename
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] )} AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] )} AS \`camera\``,
+    expectedParams = {
       first: -1,
       offset: 0,
       cypherParams: CYPHER_PARAMS,
       Camera_derivedTypes: ['NewCamera', 'OldCamera']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6090,17 +8860,24 @@ test('query only interface fields', t => {
       weight
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight } AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      offset: 0,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight } AS \`camera\``,
+    expectedParams = {
       first: -1,
+      offset: 0,
       cypherParams: CYPHER_PARAMS,
       Camera_derivedTypes: ['NewCamera', 'OldCamera']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6115,17 +8892,24 @@ test('query only interface fields using untyped inline fragment', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight } AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      offset: 0,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight } AS \`camera\``,
+    expectedParams = {
       first: -1,
+      offset: 0,
       cypherParams: CYPHER_PARAMS,
       Camera_derivedTypes: ['NewCamera', 'OldCamera']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6138,17 +8922,24 @@ test('query only computed interface fields', t => {
       weight
     }
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`camera\` RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight } AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      offset: 0,
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`camera\` RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight } AS \`camera\``,
+    expectedParams = {
       first: -1,
+      offset: 0,
       cypherParams: CYPHER_PARAMS,
       Camera_derivedTypes: ['NewCamera', 'OldCamera']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6166,18 +8957,25 @@ test('query interface type relationship field', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }] } AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }] } AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
       cypherParams: CYPHER_PARAMS,
       Camera_derivedTypes: ['NewCamera', 'OldCamera']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6194,22 +8992,24 @@ test('query reflexive interface type relationship field', t => {
     }
   }
   `,
-    expectedCypherQuery = `MATCH (\`newCamera\`:\`NewCamera\`) RETURN \`newCamera\` { .id , .make ,reflexiveInterfaceRelationship: [(\`newCamera\`)-[:\`REFLEXIVE_INTERFACE_RELATIONSHIP\`]->(\`newCamera_reflexiveInterfaceRelationship\`:\`Camera\`) | \`newCamera_reflexiveInterfaceRelationship\` {FRAGMENT_TYPE: head( [ label IN labels(\`newCamera_reflexiveInterfaceRelationship\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .weight }] } AS \`newCamera\``;
-
-  t.plan(1);
-
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery,
-    {
+    expectedCypherQuery = `MATCH (\`newCamera\`:\`NewCamera\`) RETURN \`newCamera\` { .id , .make ,reflexiveInterfaceRelationship: [(\`newCamera\`)-[:\`REFLEXIVE_INTERFACE_RELATIONSHIP\`]->(\`newCamera_reflexiveInterfaceRelationship\`:\`Camera\`) | \`newCamera_reflexiveInterfaceRelationship\` {FRAGMENT_TYPE: head( [ label IN labels(\`newCamera_reflexiveInterfaceRelationship\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .weight }] } AS \`newCamera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       Camera_derivedTypes: ['NewCamera', 'OldCamera'],
       cypherParams: CYPHER_PARAMS
-    }
-  );
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });
 
 test('query reflexive interface type relationship field using fragments', t => {
@@ -6235,21 +9035,23 @@ test('query reflexive interface type relationship field using fragments', t => {
     }
   }  
   `,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .make ,reflexiveInterfaceRelationship: [(\`camera\`)-[:\`REFLEXIVE_INTERFACE_RELATIONSHIP\`]->(\`camera_reflexiveInterfaceRelationship\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`) OR "OldCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`)) | head([\`camera_reflexiveInterfaceRelationship\` IN [\`camera_reflexiveInterfaceRelationship\`] WHERE "NewCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`) | \`camera_reflexiveInterfaceRelationship\` { FRAGMENT_TYPE: "NewCamera",  .id , .type , .weight , .make  }] + [\`camera_reflexiveInterfaceRelationship\` IN [\`camera_reflexiveInterfaceRelationship\`] WHERE "OldCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`) | \`camera_reflexiveInterfaceRelationship\` { FRAGMENT_TYPE: "OldCamera",  .weight , .id , .type , .make  }])] , .id  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id ,reflexiveInterfaceRelationship: [(\`camera\`)-[:\`REFLEXIVE_INTERFACE_RELATIONSHIP\`]->(\`camera_reflexiveInterfaceRelationship\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`)) | head([\`camera_reflexiveInterfaceRelationship\` IN [\`camera_reflexiveInterfaceRelationship\`] WHERE "OldCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`) | \`camera_reflexiveInterfaceRelationship\` { FRAGMENT_TYPE: "OldCamera",  .weight  }])]  }]) AS \`camera\``;
-
-  t.plan(1);
-
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery,
-    {
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .make ,reflexiveInterfaceRelationship: [(\`camera\`)-[:\`REFLEXIVE_INTERFACE_RELATIONSHIP\`]->(\`camera_reflexiveInterfaceRelationship\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`) OR "OldCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`)) | head([\`camera_reflexiveInterfaceRelationship\` IN [\`camera_reflexiveInterfaceRelationship\`] WHERE "NewCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`) | \`camera_reflexiveInterfaceRelationship\` { FRAGMENT_TYPE: "NewCamera",  .id , .type , .weight , .make  }] + [\`camera_reflexiveInterfaceRelationship\` IN [\`camera_reflexiveInterfaceRelationship\`] WHERE "OldCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`) | \`camera_reflexiveInterfaceRelationship\` { FRAGMENT_TYPE: "OldCamera",  .weight , .id , .type , .make  }])] , .id  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id ,reflexiveInterfaceRelationship: [(\`camera\`)-[:\`REFLEXIVE_INTERFACE_RELATIONSHIP\`]->(\`camera_reflexiveInterfaceRelationship\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`)) | head([\`camera_reflexiveInterfaceRelationship\` IN [\`camera_reflexiveInterfaceRelationship\`] WHERE "OldCamera" IN labels(\`camera_reflexiveInterfaceRelationship\`) | \`camera_reflexiveInterfaceRelationship\` { FRAGMENT_TYPE: "OldCamera",  .weight  }])]  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       cypherParams: CYPHER_PARAMS
-    }
-  );
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });
 
 test('query only __typename field on interface type relationship field', t => {
@@ -6261,18 +9063,25 @@ test('query only __typename field on interface type relationship field', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] )}] } AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] )}] } AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
       cypherParams: CYPHER_PARAMS,
       Camera_derivedTypes: ['NewCamera', 'OldCamera']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6290,18 +9099,25 @@ test('query computed interface type relationship field', t => {
       }
     }
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`camera\` RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,computedOperators: [ camera_computedOperators IN apoc.cypher.runFirstColumn("MATCH (this)<-[:cameras]-(p:Person) RETURN p", {this: camera, cypherParams: $cypherParams}, true) | camera_computedOperators {FRAGMENT_TYPE: head( [ label IN labels(camera_computedOperators) WHERE label IN $Person_derivedTypes ] ), .userId , .name }] } AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`camera\` RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,computedOperators: [ camera_computedOperators IN apoc.cypher.runFirstColumn("MATCH (this)<-[:cameras]-(p:Person) RETURN p", {this: camera, cypherParams: $cypherParams}, true) | camera_computedOperators {FRAGMENT_TYPE: head( [ label IN labels(camera_computedOperators) WHERE label IN $Person_derivedTypes ] ), .userId , .name }] } AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
       cypherParams: CYPHER_PARAMS,
       Camera_derivedTypes: ['NewCamera', 'OldCamera']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6320,17 +9136,24 @@ test('query computed interface type relationship field using only an inline frag
       }
     }
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`camera\` RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,computedOperators: [camera_computedOperators IN [ camera_computedOperators IN apoc.cypher.runFirstColumn("MATCH (this)<-[:cameras]-(p:Person) RETURN p", {this: camera, cypherParams: $cypherParams}, true) WHERE ("CameraMan" IN labels(camera_computedOperators)) | camera_computedOperators] | head([\`camera_computedOperators\` IN [\`camera_computedOperators\`] WHERE "CameraMan" IN labels(\`camera_computedOperators\`) | \`camera_computedOperators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }])] } AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x UNWIND x AS \`camera\` RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,computedOperators: [camera_computedOperators IN [ camera_computedOperators IN apoc.cypher.runFirstColumn("MATCH (this)<-[:cameras]-(p:Person) RETURN p", {this: camera, cypherParams: $cypherParams}, true) WHERE ("CameraMan" IN labels(camera_computedOperators)) | camera_computedOperators] | head([\`camera_computedOperators\` IN [\`camera_computedOperators\`] WHERE "CameraMan" IN labels(\`camera_computedOperators\`) | \`camera_computedOperators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }])] } AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       cypherParams: CYPHER_PARAMS,
       Camera_derivedTypes: ['NewCamera', 'OldCamera']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6343,16 +9166,23 @@ test('query only fields on an implementing type using an inline fragment', t => 
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
+      first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6370,22 +9200,24 @@ test('query only interface type fields using fragments', t => {
   fragment Person on Person {
     __typename
   }`,
-    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name } AS \`person\``;
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) RETURN \`person\` {FRAGMENT_TYPE: head( [ label IN labels(\`person\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name } AS \`person\``,
+    expectedParams = {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS,
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
-      offset: 0,
-      cypherParams: CYPHER_PARAMS,
-      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
-      offset: 0,
-      cypherParams: CYPHER_PARAMS,
-      Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    })
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6405,20 +9237,23 @@ test('query fields on interface and implementing object type using only fragment
       name
     }
   }`,
-    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE ("Actor" IN labels(\`person\`) OR "CameraMan" IN labels(\`person\`) OR "User" IN labels(\`person\`)) RETURN head([\`person\` IN [\`person\`] WHERE "Actor" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "Actor",  .userId  }] + [\`person\` IN [\`person\`] WHERE "CameraMan" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "CameraMan",  .name , .userId  }] + [\`person\` IN [\`person\`] WHERE "User" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "User",  .userId  }]) AS \`person\``;
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE ("Actor" IN labels(\`person\`) OR "CameraMan" IN labels(\`person\`) OR "User" IN labels(\`person\`)) RETURN head([\`person\` IN [\`person\`] WHERE "Actor" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "Actor",  .userId  }] + [\`person\` IN [\`person\`] WHERE "CameraMan" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "CameraMan",  .name , .userId  }] + [\`person\` IN [\`person\`] WHERE "User" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "User",  .userId  }]) AS \`person\``,
+    expectedParams = {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
-      offset: 0,
-      cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
-      offset: 0,
-      cypherParams: CYPHER_PARAMS
-    })
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6440,20 +9275,23 @@ test('query fields on interface and implementing object types using only fragmen
       _id
     }
   }`,
-    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE ("Actor" IN labels(\`person\`) OR "User" IN labels(\`person\`)) RETURN head([\`person\` IN [\`person\`] WHERE "Actor" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "Actor", _id: ID(\`person\`) }] + [\`person\` IN [\`person\`] WHERE "User" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "User",  .userId  }]) AS \`person\``;
+    expectedCypherQuery = `MATCH (\`person\`:\`Person\`) WHERE ("Actor" IN labels(\`person\`) OR "User" IN labels(\`person\`)) RETURN head([\`person\` IN [\`person\`] WHERE "Actor" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "Actor", _id: ID(\`person\`) }] + [\`person\` IN [\`person\`] WHERE "User" IN labels(\`person\`) | \`person\` { FRAGMENT_TYPE: "User",  .userId  }]) AS \`person\``,
+    expectedParams = {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
-      offset: 0,
-      cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
-      offset: 0,
-      cypherParams: CYPHER_PARAMS
-    })
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6467,20 +9305,23 @@ test('query fields on object type using inline fragment on implemented interface
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .name , .userId } AS \`user\``;
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .name , .userId } AS \`user\``,
+    expectedParams = {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
-      offset: 0,
-      cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
-      offset: 0,
-      cypherParams: CYPHER_PARAMS
-    })
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6498,20 +9339,23 @@ test('query fields on object type using only fragments on implemented interface'
     __typename
   }
   `,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId } AS \`user\``;
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId } AS \`user\``,
+    expectedParams = {
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
-      offset: 0,
-      cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
-      offset: 0,
-      cypherParams: CYPHER_PARAMS
-    })
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6530,15 +9374,26 @@ test('pagination used on root and nested interface type field', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("Actor" IN labels(\`camera_operators\`) OR "CameraMan" IN labels(\`camera_operators\`) OR "User" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE "Actor" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "Actor",  .name  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE "CameraMan" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE "User" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "User",  .name  }])][1..2] } AS \`camera\` SKIP toInteger($offset) LIMIT toInteger($first)`;
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("Actor" IN labels(\`camera_operators\`) OR "CameraMan" IN labels(\`camera_operators\`) OR "User" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE "Actor" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "Actor",  .name  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE "CameraMan" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE "User" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "User",  .name  }])][1..2] } AS \`camera\` SKIP toInteger($offset) LIMIT toInteger($first)`,
+    expectedParams = {
+      first: 2,
+      offset: 1,
+      '1_first': 1,
+      '1_offset': 1,
+      Camera_derivedTypes: ['NewCamera', 'OldCamera'],
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery
-  );
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });
 
 test('ordering used on root and nested interface type field', t => {
@@ -6556,18 +9411,25 @@ test('ordering used on root and nested interface type field', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WITH \`camera\` ORDER BY camera.type ASC RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,operators: apoc.coll.sortMulti([(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("Actor" IN labels(\`camera_operators\`) OR "CameraMan" IN labels(\`camera_operators\`) OR "User" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE "Actor" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "Actor",  .name  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE "CameraMan" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE "User" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "User",  .name  }])], ['name']) } AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WITH \`camera\` ORDER BY camera.type ASC RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type , .make , .weight ,operators: apoc.coll.sortMulti([(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("Actor" IN labels(\`camera_operators\`) OR "CameraMan" IN labels(\`camera_operators\`) OR "User" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE "Actor" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "Actor",  .name  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE "CameraMan" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE "User" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "User",  .name  }])], ['name']) } AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       '1_orderBy': 'name_desc',
       cypherParams: CYPHER_PARAMS,
       Camera_derivedTypes: ['NewCamera', 'OldCamera']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6591,11 +9453,8 @@ test('filtering used on root and nested interface type field with only fragments
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`)) AND ($filter._operators_not_null = TRUE AND EXISTS((\`camera\`)<-[:cameras]-(:Person))) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera", operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("CameraMan" IN labels(\`camera_operators\`)) AND ($1_filter._name_not_null = TRUE AND EXISTS(\`camera_operators\`.name)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE "CameraMan" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .name  }])]  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`)) AND ($filter._operators_not_null = TRUE AND EXISTS((\`camera\`)<-[:cameras]-(:Person))) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera", operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("CameraMan" IN labels(\`camera_operators\`)) AND ($1_filter._name_not_null = TRUE AND EXISTS(\`camera_operators\`.name)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE "CameraMan" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .name  }])]  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       filter: {
@@ -6605,8 +9464,18 @@ test('filtering used on root and nested interface type field with only fragments
         _name_not_null: true
       },
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6634,44 +9503,41 @@ test('filtering used on root and nested interface using fragments and query vari
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\` {type:$type}) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera", operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE (\`camera_operators\`.userId = $1_filter.userId) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId }] , .id , .type ,computedOperators: [ camera_computedOperators IN apoc.cypher.runFirstColumn("MATCH (this)<-[:cameras]-(p:Person) RETURN p", {this: camera, cypherParams: $cypherParams, name: $3_name}, true) | camera_computedOperators {FRAGMENT_TYPE: head( [ label IN labels(camera_computedOperators) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera", operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE (\`camera_operators\`.userId = $1_filter.userId) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId }] , .id , .type ,computedOperators: [ camera_computedOperators IN apoc.cypher.runFirstColumn("MATCH (this)<-[:cameras]-(p:Person) RETURN p", {this: camera, cypherParams: $cypherParams, name: $3_name}, true) | camera_computedOperators {FRAGMENT_TYPE: head( [ label IN labels(camera_computedOperators) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]  }]) AS \`camera\``;
+    graphqlParams = {
+      type: 'macro',
+      operatorsFilter: {
+        userId: 'man001'
+      },
+      computedOperatorName: 'Johnnie Zoom'
+    },
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\` {type:$type}) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera", operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE (\`camera_operators\`.userId = $1_filter.userId) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId }] , .id , .type ,computedOperators: [ camera_computedOperators IN apoc.cypher.runFirstColumn("MATCH (this)<-[:cameras]-(p:Person) RETURN p", {this: camera, cypherParams: $cypherParams, name: $3_name}, true) | camera_computedOperators {FRAGMENT_TYPE: head( [ label IN labels(camera_computedOperators) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera", operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE (\`camera_operators\`.userId = $1_filter.userId) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId }] , .id , .type ,computedOperators: [ camera_computedOperators IN apoc.cypher.runFirstColumn("MATCH (this)<-[:cameras]-(p:Person) RETURN p", {this: camera, cypherParams: $cypherParams, name: $3_name}, true) | camera_computedOperators {FRAGMENT_TYPE: head( [ label IN labels(camera_computedOperators) WHERE label IN $Person_derivedTypes ] ), .userId , .name }]  }]) AS \`camera\``,
+    expectedParams = {
+      offset: 0,
+      first: -1,
+      type: 'macro',
+      '1_filter': {
+        userId: 'man001'
+      },
+      '3_name': 'Johnnie Zoom',
+      Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
     cypherTestRunner(
       t,
       graphQLQuery,
-      {
-        type: 'macro',
-        operatorsFilter: {
-          userId: 'man001'
-        },
-        computedOperatorName: 'Johnnie Zoom'
-      },
+      graphqlParams,
       expectedCypherQuery,
-      {
-        offset: 0,
-        first: -1,
-        type: 'macro',
-        '1_filter': {
-          userId: 'man001'
-        },
-        '3_name': 'Johnnie Zoom',
-        Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
-        cypherParams: CYPHER_PARAMS
-      }
+      expectedParams
     ),
     augmentedSchemaCypherTestRunner(
       t,
       graphQLQuery,
-      {
-        type: 'macro',
-        operatorsFilter: {
-          userId: 'man001'
-        },
-        computedOperatorName: 'Johnnie Zoom'
-      },
-      expectedCypherQuery
+      graphqlParams,
+      expectedCypherQuery,
+      expectedParams
     )
   ]);
 });
@@ -6685,16 +9551,23 @@ test('query only computed fields on an implementing type using an inline fragmen
       }
     }
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x WITH [\`camera\` IN x WHERE ("OldCamera" IN labels(\`camera\`)) | \`camera\`] AS x UNWIND x AS \`camera\` RETURN head([\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x WITH [\`camera\` IN x WHERE ("OldCamera" IN labels(\`camera\`)) | \`camera\`] AS x UNWIND x AS \`camera\` RETURN head([\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
+      first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6714,16 +9587,23 @@ test('query computed interface fields using fragments on implementing types', t 
     type
     weight
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x WITH [\`camera\` IN x WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) | \`camera\`] AS x UNWIND x AS \`camera\` RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .type , .weight , .id  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .type , .id  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (c:Camera) RETURN c", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x WITH [\`camera\` IN x WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) | \`camera\`] AS x UNWIND x AS \`camera\` RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .type , .weight , .id  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .type , .id  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
+      first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6742,16 +9622,23 @@ test('query interface type relationship field using inline fragment on implement
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("Actor" IN labels(\`camera_operators\`) OR "CameraMan" IN labels(\`camera_operators\`) OR "User" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE "Actor" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "Actor",  .userId  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE "CameraMan" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .name , .userId  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE "User" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "User",  .userId  }])]  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("Actor" IN labels(\`camera_operators\`) OR "CameraMan" IN labels(\`camera_operators\`) OR "User" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE "Actor" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "Actor",  .userId  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE "CameraMan" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .name , .userId  }] + [\`camera_operators\` IN [\`camera_operators\`] WHERE "User" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "User",  .userId  }])]  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
+      first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6770,16 +9657,23 @@ test('query interface type relationship field using only inline fragment', t => 
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("CameraMan" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE "CameraMan" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }])]  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("CameraMan" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE "CameraMan" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }])]  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
+      first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6800,16 +9694,23 @@ test('query interface __typename as only field not within fragments on implement
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("CameraMan" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE "CameraMan" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }])]  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) WHERE ("CameraMan" IN labels(\`camera_operators\`)) | head([\`camera_operators\` IN [\`camera_operators\`] WHERE "CameraMan" IN labels(\`camera_operators\`) | \`camera_operators\` { FRAGMENT_TYPE: "CameraMan",  .userId , .name  }])]  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
+      first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6822,16 +9723,23 @@ test('query same field on implementing type using inline fragment', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
+      first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6845,16 +9753,23 @@ test('query interface and implementing type using inline fragment', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id , .type  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
+      first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6874,17 +9789,24 @@ test('query interface type relationship fields within inline fragment', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id , .type , .make , .weight  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera", operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }] , .id , .type , .make , .weight  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id , .type , .make , .weight  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera", operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }] , .id , .type , .make , .weight  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6900,16 +9822,23 @@ test('query interface and implementing type using fragment spread', t => {
     id
     type
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id , .type  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id , .type  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
+      first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6930,16 +9859,23 @@ test('query interface and implementing types using inline fragment and fragment 
     type
     features
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id , .type , .features , .make  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .smell , .id , .make  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      first: -1,
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id , .type , .features , .make  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .smell , .id , .make  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
+      first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6966,17 +9902,24 @@ test('query interface type relationship field on implementing types using inline
       userId
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId }] , .type , .weight  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }] , .type , .weight  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId }] , .type , .weight  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .id ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .userId , .name }] , .type , .weight  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User'],
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -6989,17 +9932,24 @@ test('query interface type payload of @cypher mutation field', t => {
   }`,
     expectedCypherQuery = `CALL apoc.cypher.doIt("CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro'}) RETURN newCamera", {first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
     WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`camera\`
-    RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type } AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    RETURN \`camera\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera\`) WHERE label IN $Camera_derivedTypes ] ), .id , .type } AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       cypherParams: CYPHER_PARAMS,
       Camera_derivedTypes: ['NewCamera', 'OldCamera']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7022,16 +9972,23 @@ test('query interface type list payload of @cypher mutation field using fragment
   }`,
     expectedCypherQuery = `CALL apoc.cypher.doIt("CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro', features: ['selfie', 'zoom']}) CREATE (oldCamera:Camera:OldCamera {id: apoc.create.uuid(), type: 'floating', smell: 'rusty' }) RETURN [newCamera, oldCamera]", {first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
     UNWIND [\`camera\` IN apoc.map.values(value, [keys(value)[0]])[0]  WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) | \`camera\`] AS \`camera\`
-    RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .features , .id , .type  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .smell , .id , .type  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .features , .id , .type  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .smell , .id , .type  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7050,16 +10007,23 @@ test('query interface type list payload of @cypher mutation field using only fra
   }`,
     expectedCypherQuery = `CALL apoc.cypher.doIt("CREATE (newCamera:Camera:NewCamera {id: apoc.create.uuid(), type: 'macro', features: ['selfie', 'zoom']}) CREATE (oldCamera:Camera:OldCamera {id: apoc.create.uuid(), type: 'floating', smell: 'rusty' }) RETURN [newCamera, oldCamera]", {first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
     UNWIND [\`camera\` IN apoc.map.values(value, [keys(value)[0]])[0]  WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) | \`camera\`] AS \`camera\`
-    RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .features  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .smell  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .features  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .smell  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7082,21 +10046,24 @@ test('query interfaced relationship mutation payload using fragments', t => {
       MATCH (\`person_to\`:\`Person\` {userId: $to.userId})
       CREATE (\`actor_from\`)-[\`knows_relation\`:\`KNOWS\`]->(\`person_to\`)
       RETURN \`knows_relation\` { from: \`actor_from\` { .name } ,to: head([\`person_to\` IN [\`person_to\`] WHERE "Actor" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "Actor",  .name  }] + [\`person_to\` IN [\`person_to\`] WHERE "CameraMan" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "CameraMan",  .name  }] + [\`person_to\` IN [\`person_to\`] WHERE "User" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "User",  .userId , .name  }])  } AS \`_AddActorKnowsPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { userId: '123' },
       to: { userId: '456' },
       first: -1,
       offset: 0
-    },
-    expectedCypherQuery,
-    {}
-  );
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });
 
 test('query interfaced relationship mutation payload using only fragments', t => {
@@ -7117,21 +10084,24 @@ test('query interfaced relationship mutation payload using only fragments', t =>
       MATCH (\`person_to\`:\`Person\` {userId: $to.userId})
       CREATE (\`actor_from\`)-[\`knows_relation\`:\`KNOWS\`]->(\`person_to\`)
       RETURN \`knows_relation\` { from: \`actor_from\` { .name } ,to: head([\`person_to\` IN [\`person_to\`] WHERE "User" IN labels(\`person_to\`) | \`person_to\` { FRAGMENT_TYPE: "User",  .userId  }])  } AS \`_AddActorKnowsPayload\`;
-    `;
-
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {
+    `,
+    expectedParams = {
       from: { userId: '123' },
       to: { userId: '456' },
       first: -1,
       offset: 0
-    },
-    expectedCypherQuery,
-    {}
-  );
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });
 
 test('query interface using multiple fragments on the same implementing type', t => {
@@ -7162,17 +10132,24 @@ test('query interface using multiple fragments on the same implementing type', t
       __typename
     }
   }`,
-    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .name , .userId }] , .type , .weight  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .weight  }]) AS \`camera\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`camera\`:\`Camera\`) WHERE ("NewCamera" IN labels(\`camera\`) OR "OldCamera" IN labels(\`camera\`)) RETURN head([\`camera\` IN [\`camera\`] WHERE "NewCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "NewCamera",  .id ,operators: [(\`camera\`)<-[:\`cameras\`]-(\`camera_operators\`:\`Person\`) | \`camera_operators\` {FRAGMENT_TYPE: head( [ label IN labels(\`camera_operators\`) WHERE label IN $Person_derivedTypes ] ), .name , .userId }] , .type , .weight  }] + [\`camera\` IN [\`camera\`] WHERE "OldCamera" IN labels(\`camera\`) | \`camera\` { FRAGMENT_TYPE: "OldCamera",  .weight  }]) AS \`camera\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       cypherParams: CYPHER_PARAMS,
       Person_derivedTypes: ['Actor', 'CameraMan', 'User']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7188,18 +10165,25 @@ test('Create object type node with additional union label', t => {
     expectedCypherQuery = `
     CREATE (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}:\`MovieSearch\` {movieId: apoc.create.uuid(),title:$params.title})
     RETURN \`movie\` { .movieId , .title } AS \`movie\`
-  `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+  `,
+    expectedParams = {
       offset: 0,
       first: -1,
       params: {
         title: 'Searchable Movie'
       }
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7215,18 +10199,25 @@ test('Create interfaced object type node with additional union label', t => {
     expectedCypherQuery = `
     CREATE (\`actor\`:\`Actor\`:\`Person\`:\`MovieSearch\` {userId: apoc.create.uuid(),name:$params.name})
     RETURN \`actor\` { .userId , .name } AS \`actor\`
-  `;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+  `,
+    expectedParams = {
       offset: 0,
       first: -1,
       params: {
         name: 'John'
       }
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7250,32 +10241,32 @@ test('Create object type node with @id field', t => {
     expectedCypherQuery = `
     CREATE (\`movie\`:\`Movie\`${ADDITIONAL_MOVIE_LABELS}:\`MovieSearch\` {movieId: apoc.create.uuid(),title:$params.title,year:$params.year,plot:$params.plot,poster:$params.poster,imdbRating:$params.imdbRating})
     RETURN \`movie\` {_id: ID(\`movie\`), .movieId , .title ,genres: [(\`movie\`)-[:\`IN_GENRE\`]->(\`movie_genres\`:\`Genre\`) | \`movie_genres\` { .name }] } AS \`movie\`
-  `;
+  `,
+    expectedParams = {
+      params: {
+        title: 'My Super Awesome Movie',
+        year: {
+          high: 0,
+          low: 2018
+        },
+        plot: 'An unending saga',
+        poster: 'www.movieposter.com/img.png',
+        imdbRating: 1
+      },
+      offset: 0,
+      first: -1
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      params: {
-        title: 'My Super Awesome Movie',
-        year: 2018,
-        plot: 'An unending saga',
-        poster: 'www.movieposter.com/img.png',
-        imdbRating: 1
-      },
-      offset: 0,
-      first: -1
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      params: {
-        title: 'My Super Awesome Movie',
-        year: 2018,
-        plot: 'An unending saga',
-        poster: 'www.movieposter.com/img.png',
-        imdbRating: 1
-      },
-      offset: 0,
-      first: -1
-    })
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7294,26 +10285,26 @@ test('Create interfaced object type node with @unique field', t => {
     expectedCypherQuery = `
     CREATE (\`newCamera\`:\`NewCamera\`:\`Camera\` {id: apoc.create.uuid(),type:$params.type,features:$params.features})
     RETURN \`newCamera\` { .id , .type , .features } AS \`newCamera\`
-  `;
+  `,
+    expectedParams = {
+      params: {
+        type: 'floating',
+        features: ['selfie', 'zoom']
+      },
+      offset: 0,
+      first: -1
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      params: {
-        type: 'floating',
-        features: ['selfie', 'zoom']
-      },
-      offset: 0,
-      first: -1
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      params: {
-        type: 'floating',
-        features: ['selfie', 'zoom']
-      },
-      offset: 0,
-      first: -1
-    })
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7327,26 +10318,26 @@ test('Create object type node with @index field', t => {
     expectedCypherQuery = `
     CREATE (\`state\`:\`State\` {name:$params.name,id:$params.id})
     RETURN \`state\` { .name } AS \`state\`
-  `;
+  `,
+    expectedParams = {
+      params: {
+        name: 'California',
+        id: '123'
+      },
+      offset: 0,
+      first: -1
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      params: {
-        name: 'California',
-        id: '123'
-      },
-      offset: 0,
-      first: -1
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      params: {
-        name: 'California',
-        id: '123'
-      },
-      offset: 0,
-      first: -1
-    })
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7361,26 +10352,26 @@ test('Create object type node with multiple @unique ID type fields', t => {
     expectedCypherQuery = `
     CREATE (\`uniqueNode\`:\`UniqueNode\` {id: apoc.create.uuid(),string:$params.string,anotherId:$params.anotherId})
     RETURN \`uniqueNode\` { .string , .id , .anotherId } AS \`uniqueNode\`
-  `;
+  `,
+    expectedParams = {
+      params: {
+        string: 'hello world',
+        anotherId: '123'
+      },
+      offset: 0,
+      first: -1
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      params: {
-        string: 'hello world',
-        anotherId: '123'
-      },
-      offset: 0,
-      first: -1
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      params: {
-        string: 'hello world',
-        anotherId: '123'
-      },
-      offset: 0,
-      first: -1
-    })
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7393,26 +10384,26 @@ test('Merge object type node with @unique field', t => {
   }
 `,
     expectedCypherQuery = `MERGE (\`uniqueStringNode\`:\`UniqueStringNode\`{uniqueString: $params.uniqueString})
-  SET \`uniqueStringNode\` += {id:$params.id} RETURN \`uniqueStringNode\` { .id , .uniqueString } AS \`uniqueStringNode\``;
+  SET \`uniqueStringNode\` += {id:$params.id} RETURN \`uniqueStringNode\` { .id , .uniqueString } AS \`uniqueStringNode\``,
+    expectedParams = {
+      params: {
+        id: '123',
+        uniqueString: 'abc'
+      },
+      offset: 0,
+      first: -1
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      params: {
-        id: '123',
-        uniqueString: 'abc'
-      },
-      offset: 0,
-      first: -1
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      params: {
-        id: '123',
-        uniqueString: 'abc'
-      },
-      offset: 0,
-      first: -1
-    })
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7426,20 +10417,23 @@ test('Delete object type node with @unique field', t => {
     expectedCypherQuery = `MATCH (\`uniqueStringNode\`:\`UniqueStringNode\` {uniqueString: $uniqueString})
 WITH \`uniqueStringNode\` AS \`uniqueStringNode_toDelete\`, \`uniqueStringNode\` { .id , .uniqueString } AS \`uniqueStringNode\`
 DETACH DELETE \`uniqueStringNode_toDelete\`
-RETURN \`uniqueStringNode\``;
+RETURN \`uniqueStringNode\``,
+    expectedParams = {
+      uniqueString: 'abc',
+      offset: 0,
+      first: -1
+    };
 
-  t.plan(3);
+  t.plan(4);
   return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      uniqueString: 'abc',
-      offset: 0,
-      first: -1
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      uniqueString: 'abc',
-      offset: 0,
-      first: -1
-    })
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7464,11 +10458,8 @@ test('Add relationship using @id and @unique node type for node selection', t =>
       MATCH (\`uniqueStringNode_to\`:\`UniqueStringNode\` {uniqueString: $to.uniqueString})
       CREATE (\`uniqueNode_from\`)-[\`test_relation_relation\`:\`TEST_RELATION\`]->(\`uniqueStringNode_to\`)
       RETURN \`test_relation_relation\` { from: \`uniqueNode_from\` { .string , .id , .anotherId } ,to: \`uniqueStringNode_to\` { .uniqueString }  } AS \`_AddUniqueNodeTestRelationPayload\`;
-    `;
-
-  t.plan(1);
-  return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    `,
+    expectedParams = {
       from: {
         id: '123'
       },
@@ -7477,7 +10468,17 @@ test('Add relationship using @id and @unique node type for node selection', t =>
       },
       offset: 0,
       first: -1
-    })
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7502,11 +10503,8 @@ test('Merge relationship using @id and @unique node type fields for node selecti
       MATCH (\`uniqueStringNode_to\`:\`UniqueStringNode\` {uniqueString: $to.uniqueString})
       MERGE (\`uniqueNode_from\`)-[\`test_relation_relation\`:\`TEST_RELATION\`]->(\`uniqueStringNode_to\`)
       RETURN \`test_relation_relation\` { from: \`uniqueNode_from\` { .string , .id , .anotherId } ,to: \`uniqueStringNode_to\` { .uniqueString }  } AS \`_MergeUniqueNodeTestRelationPayload\`;
-    `;
-
-  t.plan(1);
-  return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    `,
+    expectedParams = {
       from: {
         id: '123'
       },
@@ -7515,7 +10513,17 @@ test('Merge relationship using @id and @unique node type fields for node selecti
       },
       first: -1,
       offset: 0
-    })
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7543,11 +10551,8 @@ test('Remove relationship using @id and @unique node type fields for node select
       DELETE \`uniqueNode_fromuniqueStringNode_to\`
       WITH COUNT(*) AS scope, \`uniqueNode_from\` AS \`_uniqueNode_from\`, \`uniqueStringNode_to\` AS \`_uniqueStringNode_to\`
       RETURN {from: \`_uniqueNode_from\` { .string , .id , .anotherId } ,to: \`_uniqueStringNode_to\` { .uniqueString } } AS \`_RemoveUniqueNodeTestRelationPayload\`;
-    `;
-
-  t.plan(1);
-  return Promise.all([
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    `,
+    expectedParams = {
       from: {
         id: '123'
       },
@@ -7556,7 +10561,17 @@ test('Remove relationship using @id and @unique node type fields for node select
       },
       first: -1,
       offset: 0
-    })
+    };
+
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7566,17 +10581,24 @@ test('query only __typename field on union type', t => {
       __typename
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movieSearch\`:\`MovieSearch\`) RETURN \`movieSearch\` {FRAGMENT_TYPE: head( [ label IN labels(\`movieSearch\`) WHERE label IN $MovieSearch_derivedTypes ] )} AS \`movieSearch\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movieSearch\`:\`MovieSearch\`) RETURN \`movieSearch\` {FRAGMENT_TYPE: head( [ label IN labels(\`movieSearch\`) WHERE label IN $MovieSearch_derivedTypes ] )} AS \`movieSearch\``,
+    expectedParams = {
       first: -1,
       offset: 0,
       cypherParams: CYPHER_PARAMS,
       MovieSearch_derivedTypes: ['Movie', 'Genre', 'Book', 'Actor', 'OldCamera']
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7594,16 +10616,23 @@ test('query union type using fragments', t => {
   fragment MovieSearchGenre on Genre {
     name
   }`,
-    expectedCypherQuery = `MATCH (\`movieSearch\`:\`MovieSearch\`) WHERE ("Genre" IN labels(\`movieSearch\`) OR "Movie" IN labels(\`movieSearch\`)) RETURN head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Genre" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Movie" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title  }]) AS \`movieSearch\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      offset: 0,
+    expectedCypherQuery = `MATCH (\`movieSearch\`:\`MovieSearch\`) WHERE ("Genre" IN labels(\`movieSearch\`) OR "Movie" IN labels(\`movieSearch\`)) RETURN head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Genre" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Movie" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title  }]) AS \`movieSearch\``,
+    expectedParams = {
       first: -1,
+      offset: 0,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7621,16 +10650,23 @@ test('query computed union type using fragments', t => {
   fragment MovieSearchGenre on Genre {
     name
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (ms:MovieSearch) RETURN ms", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x WITH [\`movieSearch\` IN x WHERE ("Genre" IN labels(\`movieSearch\`) OR "Movie" IN labels(\`movieSearch\`)) | \`movieSearch\`] AS x UNWIND x AS \`movieSearch\` RETURN head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Genre" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Movie" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title  }]) AS \`movieSearch\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      offset: 0,
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (ms:MovieSearch) RETURN ms", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x WITH [\`movieSearch\` IN x WHERE ("Genre" IN labels(\`movieSearch\`) OR "Movie" IN labels(\`movieSearch\`)) | \`movieSearch\`] AS x UNWIND x AS \`movieSearch\` RETURN head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Genre" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Movie" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title  }]) AS \`movieSearch\``,
+    expectedParams = {
       first: -1,
+      offset: 0,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7650,16 +10686,23 @@ test('query union type relationship using fragments', t => {
   fragment MovieSearchGenre on Genre {
     name
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {movieSearch: [(\`user\`)--(\`user_movieSearch\`:\`MovieSearch\`) WHERE ("Genre" IN labels(\`user_movieSearch\`) OR "Movie" IN labels(\`user_movieSearch\`)) | head([\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Genre" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Movie" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Movie",  .title ,_id: ID(\`user_movieSearch\`) }])] } AS \`user\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
-      offset: 0,
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {movieSearch: [(\`user\`)--(\`user_movieSearch\`:\`MovieSearch\`) WHERE ("Genre" IN labels(\`user_movieSearch\`) OR "Movie" IN labels(\`user_movieSearch\`)) | head([\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Genre" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Movie" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Movie",  .title ,_id: ID(\`user_movieSearch\`) }])] } AS \`user\``,
+    expectedParams = {
       first: -1,
+      offset: 0,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7676,11 +10719,8 @@ test('query only __typename field on union type relationship', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId , .name ,movieSearch: [(\`user\`)--(\`user_movieSearch\`:\`MovieSearch\`) | \`user_movieSearch\` {FRAGMENT_TYPE: head( [ label IN labels(\`user_movieSearch\`) WHERE label IN $MovieSearch_derivedTypes ] )}] ,favorites: [(\`user\`)-[:\`FAVORITED\`]->(\`user_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`user_favorites\` { .movieId }] } AS \`user\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId , .name ,movieSearch: [(\`user\`)--(\`user_movieSearch\`:\`MovieSearch\`) | \`user_movieSearch\` {FRAGMENT_TYPE: head( [ label IN labels(\`user_movieSearch\`) WHERE label IN $MovieSearch_derivedTypes ] )}] ,favorites: [(\`user\`)-[:\`FAVORITED\`]->(\`user_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`user_favorites\` { .movieId }] } AS \`user\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       MovieSearch_derivedTypes: [
@@ -7691,8 +10731,18 @@ test('query only __typename field on union type relationship', t => {
         'OldCamera'
       ],
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7704,11 +10754,8 @@ test('query only __typename field on computed union type relationship', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {computedMovieSearch: [ user_computedMovieSearch IN apoc.cypher.runFirstColumn("MATCH (ms:MovieSearch) RETURN ms", {this: user, cypherParams: $cypherParams}, true) | user_computedMovieSearch {FRAGMENT_TYPE: head( [ label IN labels(user_computedMovieSearch) WHERE label IN $MovieSearch_derivedTypes ] )}] } AS \`user\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {computedMovieSearch: [ user_computedMovieSearch IN apoc.cypher.runFirstColumn("MATCH (ms:MovieSearch) RETURN ms", {this: user, cypherParams: $cypherParams}, true) | user_computedMovieSearch {FRAGMENT_TYPE: head( [ label IN labels(user_computedMovieSearch) WHERE label IN $MovieSearch_derivedTypes ] )}] } AS \`user\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       MovieSearch_derivedTypes: [
@@ -7719,8 +10766,18 @@ test('query only __typename field on computed union type relationship', t => {
         'OldCamera'
       ],
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7740,16 +10797,23 @@ test('query computed union type relationship using fragments', t => {
   fragment MovieSearchGenre on Genre {
     name
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {computedMovieSearch: [user_computedMovieSearch IN [ user_computedMovieSearch IN apoc.cypher.runFirstColumn("MATCH (ms:MovieSearch) RETURN ms", {this: user, cypherParams: $cypherParams}, true) WHERE ("Genre" IN labels(user_computedMovieSearch) OR "Movie" IN labels(user_computedMovieSearch)) | user_computedMovieSearch] | head([\`user_computedMovieSearch\` IN [\`user_computedMovieSearch\`] WHERE "Genre" IN labels(\`user_computedMovieSearch\`) | \`user_computedMovieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`user_computedMovieSearch\` IN [\`user_computedMovieSearch\`] WHERE "Movie" IN labels(\`user_computedMovieSearch\`) | \`user_computedMovieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title  }])] } AS \`user\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {computedMovieSearch: [user_computedMovieSearch IN [ user_computedMovieSearch IN apoc.cypher.runFirstColumn("MATCH (ms:MovieSearch) RETURN ms", {this: user, cypherParams: $cypherParams}, true) WHERE ("Genre" IN labels(user_computedMovieSearch) OR "Movie" IN labels(user_computedMovieSearch)) | user_computedMovieSearch] | head([\`user_computedMovieSearch\` IN [\`user_computedMovieSearch\`] WHERE "Genre" IN labels(\`user_computedMovieSearch\`) | \`user_computedMovieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`user_computedMovieSearch\` IN [\`user_computedMovieSearch\`] WHERE "Movie" IN labels(\`user_computedMovieSearch\`) | \`user_computedMovieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title  }])] } AS \`user\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7763,16 +10827,23 @@ test('query union type payload of computed mutation field', t => {
   }`,
     expectedCypherQuery = `CALL apoc.cypher.doIt("MATCH (ms:MovieSearch) RETURN ms", {first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
     UNWIND [\`movieSearch\` IN apoc.map.values(value, [keys(value)[0]])[0]  WHERE ("Movie" IN labels(\`movieSearch\`)) | \`movieSearch\`] AS \`movieSearch\`
-    RETURN head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Movie" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Movie",  .title  }]) AS \`movieSearch\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    RETURN head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Movie" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Movie",  .title  }]) AS \`movieSearch\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7815,16 +10886,23 @@ test('query union type using multiple fragments on the same interfaced object ty
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movieSearch\`:\`MovieSearch\`) WHERE ("Genre" IN labels(\`movieSearch\`) OR "Movie" IN labels(\`movieSearch\`) OR "Person" IN labels(\`movieSearch\`)) RETURN head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Genre" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Movie" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Person" IN labels(\`movieSearch\`) | head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Actor" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Actor",  .userId ,movies: [(\`movieSearch\`)-[:\`ACTED_IN\`]->(\`movieSearch_movies\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`movieSearch_movies\` { .movieId ,genres: [(\`movieSearch_movies\`)-[:\`IN_GENRE\`]->(\`movieSearch_movies_genres\`:\`Genre\`) | \`movieSearch_movies_genres\` {_id: ID(\`movieSearch_movies_genres\`), .name }] , .title }] , .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "CameraMan" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "CameraMan",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "User" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "User",  .name  }])]) AS \`movieSearch\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movieSearch\`:\`MovieSearch\`) WHERE ("Genre" IN labels(\`movieSearch\`) OR "Movie" IN labels(\`movieSearch\`) OR "Person" IN labels(\`movieSearch\`)) RETURN head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Genre" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Movie" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Person" IN labels(\`movieSearch\`) | head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Actor" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Actor",  .userId ,movies: [(\`movieSearch\`)-[:\`ACTED_IN\`]->(\`movieSearch_movies\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`movieSearch_movies\` { .movieId ,genres: [(\`movieSearch_movies\`)-[:\`IN_GENRE\`]->(\`movieSearch_movies_genres\`:\`Genre\`) | \`movieSearch_movies_genres\` {_id: ID(\`movieSearch_movies_genres\`), .name }] , .title }] , .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "CameraMan" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "CameraMan",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "User" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "User",  .name  }])]) AS \`movieSearch\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7882,17 +10960,24 @@ test('query union type relationship using multiple fragments and interfaced obje
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId , .name ,movieSearch: [(\`user\`)--(\`user_movieSearch\`:\`MovieSearch\`) WHERE ("Actor" IN labels(\`user_movieSearch\`) OR "Camera" IN labels(\`user_movieSearch\`) OR "Genre" IN labels(\`user_movieSearch\`) OR "Movie" IN labels(\`user_movieSearch\`)) | head([\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Camera" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: head( [ label IN labels(\`user_movieSearch\`) WHERE label IN $Camera_derivedTypes ] ),  .id , .type  }] + [\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Genre" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Movie" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title ,released: { year: \`user_movieSearch\`.released.year } }] + [\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Person" IN labels(\`user_movieSearch\`) | head([\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Actor" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Actor",  .userId , .name ,movies: [(\`user_movieSearch\`)-[:\`ACTED_IN\`]->(\`user_movieSearch_movies\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`user_movieSearch_movies\` { .movieId ,genres: [(\`user_movieSearch_movies\`)-[:\`IN_GENRE\`]->(\`user_movieSearch_movies_genres\`:\`Genre\`) | \`user_movieSearch_movies_genres\` {_id: ID(\`user_movieSearch_movies_genres\`), .name }] , .title }]  }])])] ,favorites: [(\`user\`)-[:\`FAVORITED\`]->(\`user_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`user_favorites\` { .movieId }] } AS \`user\``;
-
-  t.plan(3);
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` { .userId , .name ,movieSearch: [(\`user\`)--(\`user_movieSearch\`:\`MovieSearch\`) WHERE ("Actor" IN labels(\`user_movieSearch\`) OR "Camera" IN labels(\`user_movieSearch\`) OR "Genre" IN labels(\`user_movieSearch\`) OR "Movie" IN labels(\`user_movieSearch\`)) | head([\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Camera" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: head( [ label IN labels(\`user_movieSearch\`) WHERE label IN $Camera_derivedTypes ] ),  .id , .type  }] + [\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Genre" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Movie" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title ,released: { year: \`user_movieSearch\`.released.year } }] + [\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Person" IN labels(\`user_movieSearch\`) | head([\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Actor" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Actor",  .userId , .name ,movies: [(\`user_movieSearch\`)-[:\`ACTED_IN\`]->(\`user_movieSearch_movies\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`user_movieSearch_movies\` { .movieId ,genres: [(\`user_movieSearch_movies\`)-[:\`IN_GENRE\`]->(\`user_movieSearch_movies_genres\`:\`Genre\`) | \`user_movieSearch_movies_genres\` {_id: ID(\`user_movieSearch_movies_genres\`), .name }] , .title }]  }])])] ,favorites: [(\`user\`)-[:\`FAVORITED\`]->(\`user_favorites\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`user_favorites\` { .movieId }] } AS \`user\``,
+    expectedParams = {
       offset: 0,
       first: -1,
       Camera_derivedTypes: ['NewCamera', 'OldCamera'],
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7935,14 +11020,23 @@ test('query union type using pagination', t => {
       }
     }
   }`,
-    expectedCypherQuery = `MATCH (\`movieSearch\`:\`MovieSearch\`) WHERE ("Genre" IN labels(\`movieSearch\`) OR "Movie" IN labels(\`movieSearch\`) OR "Person" IN labels(\`movieSearch\`)) RETURN head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Genre" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Movie" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Person" IN labels(\`movieSearch\`) | head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Actor" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Actor",  .userId ,movies: [(\`movieSearch\`)-[:\`ACTED_IN\`]->(\`movieSearch_movies\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`movieSearch_movies\` { .movieId ,genres: [(\`movieSearch_movies\`)-[:\`IN_GENRE\`]->(\`movieSearch_movies_genres\`:\`Genre\`) | \`movieSearch_movies_genres\` {_id: ID(\`movieSearch_movies_genres\`), .name }] , .title }] , .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "CameraMan" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "CameraMan",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "User" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "User",  .name  }])]) AS \`movieSearch\` LIMIT toInteger($first)`;
-  return Promise.all([
-    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, {
+    expectedCypherQuery = `MATCH (\`movieSearch\`:\`MovieSearch\`) WHERE ("Genre" IN labels(\`movieSearch\`) OR "Movie" IN labels(\`movieSearch\`) OR "Person" IN labels(\`movieSearch\`)) RETURN head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Genre" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Movie" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Person" IN labels(\`movieSearch\`) | head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Actor" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Actor",  .userId ,movies: [(\`movieSearch\`)-[:\`ACTED_IN\`]->(\`movieSearch_movies\`:\`Movie\`:\`u_user-id\`:\`newMovieLabel\`) | \`movieSearch_movies\` { .movieId ,genres: [(\`movieSearch_movies\`)-[:\`IN_GENRE\`]->(\`movieSearch_movies_genres\`:\`Genre\`) | \`movieSearch_movies_genres\` {_id: ID(\`movieSearch_movies_genres\`), .name }] , .title }] , .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "CameraMan" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "CameraMan",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "User" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "User",  .name  }])]) AS \`movieSearch\` LIMIT toInteger($first)`,
+    expectedParams = {
       offset: 0,
       first: 10,
       cypherParams: CYPHER_PARAMS
-    }),
-    augmentedSchemaCypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery)
+    };
+
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
   ]);
 });
 
@@ -7962,15 +11056,25 @@ test('query union type relationship using pagination', t => {
   fragment MovieSearchGenre on Genre {
     name
   }`,
-    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {movieSearch: [(\`user\`)--(\`user_movieSearch\`:\`MovieSearch\`) WHERE ("Genre" IN labels(\`user_movieSearch\`) OR "Movie" IN labels(\`user_movieSearch\`)) | head([\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Genre" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Movie" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Movie",  .title ,_id: ID(\`user_movieSearch\`) }])][1..3] } AS \`user\``;
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) RETURN \`user\` {movieSearch: [(\`user\`)--(\`user_movieSearch\`:\`MovieSearch\`) WHERE ("Genre" IN labels(\`user_movieSearch\`) OR "Movie" IN labels(\`user_movieSearch\`)) | head([\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Genre" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`user_movieSearch\` IN [\`user_movieSearch\`] WHERE "Movie" IN labels(\`user_movieSearch\`) | \`user_movieSearch\` { FRAGMENT_TYPE: "Movie",  .title ,_id: ID(\`user_movieSearch\`) }])][1..3] } AS \`user\``,
+    expectedParams = {
+      '1_first': 2,
+      '1_offset': 1,
+      offset: 0,
+      first: -1,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery
-  );
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });
 
 test('query computed union type relationship using pagination', t => {
@@ -7987,13 +11091,21 @@ test('query computed union type relationship using pagination', t => {
   fragment MovieSearchGenre on Genre {
     name
   }`,
-    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (ms:MovieSearch) RETURN ms", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x WITH [\`movieSearch\` IN x WHERE ("Genre" IN labels(\`movieSearch\`) OR "Movie" IN labels(\`movieSearch\`)) | \`movieSearch\`] AS x UNWIND x AS \`movieSearch\` RETURN head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Genre" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Movie" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title  }]) AS \`movieSearch\` SKIP toInteger($offset) LIMIT toInteger($first)`;
+    expectedCypherQuery = `WITH apoc.cypher.runFirstColumn("MATCH (ms:MovieSearch) RETURN ms", {offset:$offset, first:$first, cypherParams: $cypherParams}, True) AS x WITH [\`movieSearch\` IN x WHERE ("Genre" IN labels(\`movieSearch\`) OR "Movie" IN labels(\`movieSearch\`)) | \`movieSearch\`] AS x UNWIND x AS \`movieSearch\` RETURN head([\`movieSearch\` IN [\`movieSearch\`] WHERE "Genre" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Genre",  .name  }] + [\`movieSearch\` IN [\`movieSearch\`] WHERE "Movie" IN labels(\`movieSearch\`) | \`movieSearch\` { FRAGMENT_TYPE: "Movie",  .movieId , .title  }]) AS \`movieSearch\` SKIP toInteger($offset) LIMIT toInteger($first)`,
+    expectedParams = {
+      offset: 2,
+      first: 5,
+      cypherParams: CYPHER_PARAMS
+    };
 
-  t.plan(1);
-  return augmentedSchemaCypherTestRunner(
-    t,
-    graphQLQuery,
-    {},
-    expectedCypherQuery
-  );
+  t.plan(2);
+  return Promise.all([
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
 });


### PR DESCRIPTION
#### Query API

##### Feature
* List Fields

  * #221 - How to generate a query for a [String] type  
  List arguments are now generated and translated for Scalar, Enum, Temporal, and Point type list fields. <br>

  * #350 - Feature request: Filters for list properties
    List filters are now generated and translated for Scalar, Enum, Temporal, and Point type list fields. 

##### Bug
* Computed Fields
  * #463 - Cypher statements in cypher directives should escape special characters
  The augmentation process now escapes double-quotes used within a multi-line `@cypher` statement.

#### Mutation API

##### Bug
* Integers
  * #464 Integers being converted to floats in Neo4j database
  `Int` type field argument values used in the mutation API are now appropriately converted to Neo4j integers using `neo4j-driver`.