### PR TITLE
feat: User-defined Role enum name

### DIFF
--- a/src/augment/directives.js
+++ b/src/augment/directives.js
@@ -31,7 +31,7 @@ export const DirectiveDefinition = {
 };
 
 // The name of Role type used in authorization logic
-const ROLE_TYPE = 'Role';
+const ROLE_TYPE = process.env.AUTH_ROLE_ENUM_NAME || 'Role';
 
 /**
  * Enum for the names of directed fields on relationship types


### PR DESCRIPTION
Let the user define an environment variable `AUTH_ROLE_ENUM_NAME` if he needs to use the name `Role` for something else.


While `hasScope` and `hasRole` are useful for basic authorization cases, other cases are better handled with a Role type and relationships instead of an enum.
I would like to be able to use `Role` for a graphql type, and `RoleTitle` for the graphql-auth-directives required enum name.

Example:
```graphql
enum RoleTitle {
  ADMIN
  STAFF
  TRAINER
  STUDENT
}

type Role {
  title: RoleTitle!
  scopes: [Scope!]
  users: [User!] @relation(name: "HAS", direction: "IN")
}

type User {
  role: Role @relation(name: "HAS", direction: "OUT")
}

type Mutation {
  updateUserRole(id: ID!, role: RoleTitle): User
    @hasScope(scopes: ["User: UpdateRole"])
    @cypher(
      statement: """
      MATCH (u1:User {id: $cypherParams.myId}),
            (u2:User {id: $id}),
            (r:Role {title: $role})
      WHERE (u1)-[:HAS]->(:Role)-[:CAN_UPDATE]->(:Role)<-[rel:HAS]-(u2)
      CALL apoc.refactor.to(rel, r)
      YIELD input, output
      RETURN input, output
      """
    )
}
```

.env
```
AUTH_ROLE_ENUM_NAME=RoleTitle
```