### PR TITLE
feat: allow functional directives via schemaTransforms

### DIFF
--- a/src/augment/augment.js
+++ b/src/augment/augment.js
@@ -30,6 +30,7 @@ export const makeAugmentedExecutableSchema = ({
   resolverValidationOptions,
   directiveResolvers,
   schemaDirectives = {},
+  schemaTransforms = [],
   parseOptions,
   inheritResolversFromInterfaces,
   config
@@ -112,6 +113,7 @@ export const makeAugmentedExecutableSchema = ({
     resolverValidationOptions,
     directiveResolvers,
     schemaDirectives,
+    schemaTransforms,
     parseOptions,
     inheritResolversFromInterfaces
   });

--- a/src/index.js
+++ b/src/index.js
@@ -261,6 +261,7 @@ export const makeAugmentedSchema = ({
   resolverValidationOptions = {},
   directiveResolvers = null,
   schemaDirectives = {},
+  schemaTransforms = [],
   parseOptions = {},
   inheritResolversFromInterfaces = false,
   config
@@ -277,6 +278,7 @@ export const makeAugmentedSchema = ({
     resolverValidationOptions,
     directiveResolvers,
     schemaDirectives,
+    schemaTransforms,
     parseOptions,
     inheritResolversFromInterfaces,
     config


### PR DESCRIPTION
The graphql-tools documentation [suggests to write functional directives instead of class-based ones](https://www.graphql-tools.com/docs/schema-directives/).

This can be done with neo4j-graphql-js by allowing the `schemaTransforms` key to makeAugmentedSchema:

```ts
const schema = makeAugmentedSchema({
  typeDefs,
  schemaTransforms: [canUpdateRoleTransformer],
});
```

<details><summary>Example of functional directive I could get working with my fork of neo4j-graphql-js</summary>

```ts
const canUpdateRoleTransformer = (schema: GraphQLSchema): GraphQLSchema =>
  mapSchema(schema, {
    [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
      let directives: DirectiveUseMap;
      try {
        directives = getDirectives(schema, fieldConfig);
      } catch {
        // GraphQLError [Object]: Argument "direction" has invalid value "BOTH".
        // Not sure why but I'm getting this error when getdirectives reads @relation
        return fieldConfig;
      }

      if (directives.canUpdateRole) {
        const { resolve = defaultFieldResolver } = fieldConfig;
        return {
          ...fieldConfig,
          resolve: async (source, args, context, info) => {
            const decoded = verifyAndDecodeToken({ context });

            const isAuthorized = await context.models.User.canUpdateRoleFor(
              args
            );
            if (isAuthorized) {
              return resolve(source, args, { ...context, user: decoded }, info);
            }

            throw new AuthorizationError({
              message: "unauthorized_resource",
            });
          },
        };
      }
      return fieldConfig;
    },
  });

export default canUpdateRoleTransformer;
```
</details>