### PR TITLE
Experimental mutation API: Fixes for data input objects

### DIFF
--- a/src/augment/types/node/mutation.js
+++ b/src/augment/types/node/mutation.js
@@ -30,7 +30,7 @@ import {
 /**
  * An enum describing the names of node type mutations
  */
-const NodeMutation = {
+export const NodeMutation = {
   CREATE: 'Create',
   UPDATE: 'Update',
   DELETE: 'Delete',
@@ -213,20 +213,29 @@ const buildNodeMutationObjectArguments = ({ typeName, operationName = '' }) => {
       }
     }
   };
-  const propertyInputConfig = {
+  const propertyCreateInputConfig = {
     name: 'data',
     type: {
-      name: `_${typeName}Data`,
+      name: `_${typeName}Create`,
+      wrappers: {
+        [TypeWrappers.NON_NULL_NAMED_TYPE]: true
+      }
+    }
+  };
+  const propertyUpdateInputConfig = {
+    name: 'data',
+    type: {
+      name: `_${typeName}Update`,
       wrappers: {
         [TypeWrappers.NON_NULL_NAMED_TYPE]: true
       }
     }
   };
   if (operationName === NodeMutation.CREATE) {
-    args.push(propertyInputConfig);
+    args.push(propertyCreateInputConfig);
   } else if (operationName === NodeMutation.UPDATE) {
     args.push(nodeSelectionConfig);
-    args.push(propertyInputConfig);
+    args.push(propertyUpdateInputConfig);
   } else if (operationName === NodeMutation.MERGE) {
     const keySelectionInputConfig = {
       name: 'where',
@@ -238,7 +247,7 @@ const buildNodeMutationObjectArguments = ({ typeName, operationName = '' }) => {
       }
     };
     args.push(keySelectionInputConfig);
-    args.push(propertyInputConfig);
+    args.push(propertyCreateInputConfig);
   } else if (operationName === NodeMutation.DELETE) {
     args.push(nodeSelectionConfig);
   }

--- a/test/helpers/experimental/augmentSchemaTest.js
+++ b/test/helpers/experimental/augmentSchemaTest.js
@@ -33,14 +33,36 @@ export function cypherTestRunner(
     testSchema +
     `
     type Mutation {
-      CreateUser(data: _UserData!): User @hasScope(scopes: ["User: Create", "create:user"])
-      UpdateUser(where: _UserWhere!, data: _UserData!): User @hasScope(scopes: ["User: Update", "update:user"])
+      CreateUser(data: _UserCreate!): User @hasScope(scopes: ["User: Create", "create:user"])
+      UpdateUser(where: _UserWhere!, data: _UserUpdate!): User @hasScope(scopes: ["User: Update", "update:user"])
       DeleteUser(where: _UserWhere!): User @hasScope(scopes: ["User: Delete", "delete:user"])
-      MergeUser(where: _UserWhere!, data: _UserData!): User @hasScope(scopes: ["User: Merge", "merge:user"])
+      MergeUser(where: _UserKeys!, data: _UserCreate!): User @hasScope(scopes: ["User: Merge", "merge:user"])
     }
 
     type Query {
       User: [User] @hasScope(scopes: ["User: Read", "read:user"])
+    }
+
+    input _UserCreate {
+      idField: ID
+      name: String
+      names: [String]
+      birthday: _Neo4jDateTimeInput
+      birthdays: [_Neo4jDateTimeInput]
+      uniqueString: String!
+      indexedInt: Int
+      extensionString: String!
+    }
+
+    input _UserUpdate {
+      idField: ID
+      name: String
+      names: [String]
+      birthday: _Neo4jDateTimeInput
+      birthdays: [_Neo4jDateTimeInput]
+      uniqueString: String
+      indexedInt: Int
+      extensionString: String
     }
 
     input _UserWhere {
@@ -80,15 +102,6 @@ export function cypherTestRunner(
       idField: ID
       uniqueString: String
       indexedInt: Int
-    }
-
-    input _UserData {
-      idField: ID
-      name: String
-      birthday: _Neo4jDateTimeInput
-      uniqueString: String
-      indexedInt: Int
-      extensionString: String
     }
     
   `;

--- a/test/helpers/experimental/testSchema.js
+++ b/test/helpers/experimental/testSchema.js
@@ -4,7 +4,9 @@ export const testSchema = `
   type User {
     idField: ID! @id
     name: String
+    names: [String]
     birthday: DateTime
+    birthdays: [DateTime]
     uniqueString: String! @unique
     indexedInt: Int @index
     liked: [Movie!]! @relation(

--- a/test/unit/experimental/augmentSchemaTest.test.js
+++ b/test/unit/experimental/augmentSchemaTest.test.js
@@ -115,10 +115,23 @@ test.cb('Test augmented schema', t => {
       _id: String
     }
 
-    input _UserData {
+    input _UserCreate {
       idField: ID
       name: String
+      names: [String]
       birthday: _Neo4jDateTimeInput
+      birthdays: [_Neo4jDateTimeInput]
+      uniqueString: String!
+      indexedInt: Int
+      extensionString: String!
+    }
+
+    input _UserUpdate {
+      idField: ID
+      name: String
+      names: [String]
+      birthday: _Neo4jDateTimeInput
+      birthdays: [_Neo4jDateTimeInput]
       uniqueString: String
       indexedInt: Int
       extensionString: String
@@ -203,6 +216,14 @@ test.cb('Test augmented schema', t => {
       name_not_starts_with: String
       name_ends_with: String
       name_not_ends_with: String
+      names: [String!]
+      names_not: [String!]
+      names_contains: [String!]
+      names_not_contains: [String!]
+      names_starts_with: [String!]
+      names_not_starts_with: [String!]
+      names_ends_with: [String!]
+      names_not_ends_with: [String!]
       birthday: _Neo4jDateTimeInput
       birthday_not: _Neo4jDateTimeInput
       birthday_in: [_Neo4jDateTimeInput!]
@@ -211,6 +232,12 @@ test.cb('Test augmented schema', t => {
       birthday_lte: _Neo4jDateTimeInput
       birthday_gt: _Neo4jDateTimeInput
       birthday_gte: _Neo4jDateTimeInput
+      birthdays: [_Neo4jDateTimeInput!]
+      birthdays_not: [_Neo4jDateTimeInput!]
+      birthdays_lt: [_Neo4jDateTimeInput!]
+      birthdays_lte: [_Neo4jDateTimeInput!]
+      birthdays_gt: [_Neo4jDateTimeInput!]
+      birthdays_gte: [_Neo4jDateTimeInput!]
       uniqueString: String
       uniqueString_not: String
       uniqueString_in: [String!]
@@ -260,7 +287,9 @@ test.cb('Test augmented schema', t => {
     type User {
       idField: ID! @id
       name: String
+      names: [String]
       birthday: _Neo4jDateTime
+      birthdays: [_Neo4jDateTime]
       uniqueString: String! @unique
       indexedInt: Int @index
       liked(
@@ -372,7 +401,13 @@ test.cb('Test augmented schema', t => {
       _id: String
     }
 
-    input _MovieData {
+    input _MovieCreate {
+      id: ID
+      title: String!
+      genre: MovieGenre
+    }
+
+    input _MovieUpdate {
       id: ID
       title: String
       genre: MovieGenre
@@ -705,7 +740,9 @@ test.cb('Test augmented schema', t => {
       User(
         idField: ID
         name: String
+        names: [String]
         birthday: _Neo4jDateTimeInput
+        birthdays: [_Neo4jDateTimeInput]
         uniqueString: String
         indexedInt: Int
         extensionString: String
@@ -818,16 +855,16 @@ test.cb('Test augmented schema', t => {
           scopes: ["User: Merge", "merge:user", "Movie: Merge", "merge:movie"]
         )
       "[Generated mutation](https://grandstack.io/docs/graphql-schema-generation-augmentation/#create) for [creating](https://neo4j.com/docs/cypher-manual/4.1/clauses/create/#create-nodes) a User node."
-      CreateUser(data: _UserData!): User
+      CreateUser(data: _UserCreate!): User
         @hasScope(scopes: ["User: Create", "create:user"])
       "[Generated mutation](https://grandstack.io/docs/graphql-schema-generation-augmentation/#update) for [updating](https://neo4j.com/docs/cypher-manual/4.1/clauses/set/#set-update-a-property) a User node."
-      UpdateUser(where: _UserWhere!, data: _UserData!): User
+      UpdateUser(where: _UserWhere!, data: _UserUpdate!): User
         @hasScope(scopes: ["User: Update", "update:user"])
       "[Generated mutation](https://grandstack.io/docs/graphql-schema-generation-augmentation/#delete) for [deleting](https://neo4j.com/docs/cypher-manual/4.1/clauses/delete/#delete-delete-single-node) a User node."
       DeleteUser(where: _UserWhere!): User
         @hasScope(scopes: ["User: Delete", "delete:user"])
       "[Generated mutation](https://grandstack.io/docs/graphql-schema-generation-augmentation/#merge) for [merging](https://neo4j.com/docs/cypher-manual/4.1/clauses/merge/#query-merge-node-derived) a User node."
-      MergeUser(where: _UserKeys!, data: _UserData!): User
+      MergeUser(where: _UserKeys!, data: _UserCreate!): User
         @hasScope(scopes: ["User: Merge", "merge:user"])
       "[Generated mutation](https://grandstack.io/docs/graphql-schema-generation-augmentation/##add--remove-relationship) for [creating](https://neo4j.com/docs/cypher-manual/4.1/clauses/create/#create-relationships) the RATING relationship."
       AddMovieLikedBy(
@@ -921,16 +958,16 @@ test.cb('Test augmented schema', t => {
           scopes: ["User: Merge", "merge:user", "Movie: Merge", "merge:movie"]
         )
       "[Generated mutation](https://grandstack.io/docs/graphql-schema-generation-augmentation/#create) for [creating](https://neo4j.com/docs/cypher-manual/4.1/clauses/create/#create-nodes) a Movie node."
-      CreateMovie(data: _MovieData!): Movie
+      CreateMovie(data: _MovieCreate!): Movie
         @hasScope(scopes: ["Movie: Create", "create:movie"])
       "[Generated mutation](https://grandstack.io/docs/graphql-schema-generation-augmentation/#update) for [updating](https://neo4j.com/docs/cypher-manual/4.1/clauses/set/#set-update-a-property) a Movie node."
-      UpdateMovie(where: _MovieWhere!, data: _MovieData!): Movie
+      UpdateMovie(where: _MovieWhere!, data: _MovieUpdate!): Movie
         @hasScope(scopes: ["Movie: Update", "update:movie"])
       "[Generated mutation](https://grandstack.io/docs/graphql-schema-generation-augmentation/#delete) for [deleting](https://neo4j.com/docs/cypher-manual/4.1/clauses/delete/#delete-delete-single-node) a Movie node."
       DeleteMovie(where: _MovieWhere!): Movie
         @hasScope(scopes: ["Movie: Delete", "delete:movie"])
       "[Generated mutation](https://grandstack.io/docs/graphql-schema-generation-augmentation/#merge) for [merging](https://neo4j.com/docs/cypher-manual/4.1/clauses/merge/#query-merge-node-derived) a Movie node."
-      MergeMovie(where: _MovieKeys!, data: _MovieData!): Movie
+      MergeMovie(where: _MovieKeys!, data: _MovieCreate!): Movie
         @hasScope(scopes: ["Movie: Merge", "merge:movie"])
     }
 


### PR DESCRIPTION
This PR fixes some issues in the initial implementation of the experimental node mutation API introduced in #531. Given a `User` node type, the `_UserData` input object generated for the `data` argument of `Create`, `Merge`, and `Update` mutations was failing to preserve list type wrappers and nullability. So, `Create` and `Merge` now use a new `_UserCreate` input object, which preserves nullability and `Update` uses a `_UserUpdate` input object that keeps arguments optional. In both cases, list type wrappers are preserved, appropriately allowing for list arguments. 

Docs update: https://deploy-preview-60--distracted-golick-08ed24.netlify.app/docs/graphql-schema-generation-augmentation#experimental-api