### PR TITLE
Custom nested mutations using @cypher on input fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build-with-sourcemaps": "babel src --presets @babel/preset-env --out-dir dist --source-maps",
     "precommit": "lint-staged",
     "prepare": "npm run build",
-    "test": "nyc --reporter=lcov ava test/unit/augmentSchemaTest.test.js test/unit/configTest.test.js test/unit/assertSchema.test.js test/unit/cypherTest.test.js test/unit/filterTest.test.js test/unit/filterTests.test.js test/unit/experimental/augmentSchemaTest.test.js test/unit/experimental/cypherTest.test.js",
+    "test": "nyc --reporter=lcov ava test/unit/augmentSchemaTest.test.js test/unit/configTest.test.js test/unit/assertSchema.test.js test/unit/cypherTest.test.js test/unit/filterTest.test.js test/unit/filterTests.test.js test/unit/custom/cypherTest.test.js test/unit/experimental/augmentSchemaTest.test.js test/unit/experimental/cypherTest.test.js test/unit/experimental/custom/cypherTest.test.js",
     "parse-tck": "babel-node test/helpers/tck/parseTck.js",
     "test-tck": "nyc ava --fail-fast test/unit/filterTests.test.js",
     "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",

--- a/src/augment/augment.js
+++ b/src/augment/augment.js
@@ -18,6 +18,7 @@ import {
 import { augmentDirectiveDefinitions } from './directives';
 import { extractResolversFromSchema, augmentResolvers } from './resolvers';
 import { addAuthDirectiveImplementations } from '../auth';
+import _ from 'lodash';
 
 /**
  * The main export for augmenting an SDL document
@@ -40,7 +41,7 @@ export const makeAugmentedExecutableSchema = ({
   let definitions = [];
   if (isParsedTypeDefs) {
     // Print if we recieved parsed type definitions in a GraphQL Document
-    definitions = typeDefs.definitions;
+    definitions = _.cloneDeep(typeDefs.definitions);
   } else {
     // Otherwise parse the SDL and get its definitions
     definitions = parse(typeDefs).definitions;

--- a/src/augment/directives.js
+++ b/src/augment/directives.js
@@ -315,7 +315,10 @@ const directiveDefinitionBuilderMap = {
           }
         }
       ],
-      locations: [DirectiveLocation.FIELD_DEFINITION]
+      locations: [
+        DirectiveLocation.FIELD_DEFINITION,
+        DirectiveLocation.INPUT_FIELD_DEFINITION
+      ]
     };
   },
   [DirectiveDefinition.RELATION]: ({ config }) => {

--- a/test/helpers/custom/customSchemaTest.js
+++ b/test/helpers/custom/customSchemaTest.js
@@ -1,0 +1,125 @@
+import { graphql } from 'graphql';
+import { makeExecutableSchema } from 'graphql-tools';
+import _ from 'lodash';
+import {
+  cypherQuery,
+  cypherMutation,
+  makeAugmentedSchema,
+  augmentTypeDefs
+} from '../../../src/index';
+import { printSchemaDocument } from '../../../src/augment/augment';
+import { testSchema } from './testSchema';
+
+export function cypherTestRunner(
+  t,
+  graphqlQuery,
+  graphqlParams,
+  expectedCypherQuery,
+  expectedCypherParams
+) {
+  const checkCypherQuery = (object, params, ctx, resolveInfo) => {
+    const [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
+    t.is(query, expectedCypherQuery);
+    const deserializedParams = JSON.parse(JSON.stringify(queryParams));
+    t.deepEqual(deserializedParams, expectedCypherParams);
+  };
+
+  const checkCypherMutation = (object, params, ctx, resolveInfo) => {
+    const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
+    t.is(query, expectedCypherQuery);
+    const deserializedParams = JSON.parse(JSON.stringify(queryParams));
+    t.deepEqual(deserializedParams, expectedCypherParams);
+  };
+
+  const resolvers = {
+    Mutation: {
+      CreateUser: checkCypherMutation,
+      DeleteUser: checkCypherMutation,
+      MergeUser: checkCypherMutation,
+      Custom: checkCypherMutation
+    }
+  };
+  let augmentedTypeDefs = augmentTypeDefs(testSchema, {
+    auth: true
+  });
+  const schema = makeExecutableSchema({
+    typeDefs: augmentedTypeDefs,
+    resolvers,
+    resolverValidationOptions: {
+      requireResolversForResolveType: false
+    }
+  });
+
+  // query the test schema with the test query, assertion is in the resolver
+  return graphql(
+    schema,
+    graphqlQuery,
+    null,
+    {
+      cypherParams: {
+        userId: 'user-id'
+      }
+    },
+    graphqlParams
+  );
+}
+
+export function augmentedSchemaCypherTestRunner(
+  t,
+  graphqlQuery,
+  graphqlParams,
+  expectedCypherQuery,
+  expectedCypherParams
+) {
+  const checkCypherQuery = (object, params, ctx, resolveInfo) => {
+    const [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
+    t.is(query, expectedCypherQuery);
+    const deserializedParams = JSON.parse(JSON.stringify(queryParams));
+    t.deepEqual(deserializedParams, expectedCypherParams);
+  };
+  const checkCypherMutation = (object, params, ctx, resolveInfo) => {
+    const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
+    t.is(query, expectedCypherQuery);
+    const deserializedParams = JSON.parse(JSON.stringify(queryParams));
+    t.deepEqual(deserializedParams, expectedCypherParams);
+  };
+
+  const resolvers = {
+    Mutation: {
+      CreateUser: checkCypherMutation,
+      DeleteUser: checkCypherMutation,
+      MergeUser: checkCypherMutation,
+      Custom: checkCypherMutation
+    }
+  };
+
+  const cypherTestTypeDefs = printSchemaDocument({
+    schema: makeAugmentedSchema({
+      typeDefs: testSchema,
+      resolvers: {},
+      config: {
+        auth: true
+      }
+    })
+  });
+
+  const augmentedSchema = makeExecutableSchema({
+    typeDefs: cypherTestTypeDefs,
+    resolvers,
+    resolverValidationOptions: {
+      requireResolversForResolveType: false
+    }
+  });
+
+  return graphql(
+    augmentedSchema,
+    graphqlQuery,
+    null,
+    {
+      cypherParams: {
+        userId: 'user-id'
+      }
+    },
+    graphqlParams
+  );
+}

--- a/test/helpers/custom/testSchema.js
+++ b/test/helpers/custom/testSchema.js
@@ -1,0 +1,183 @@
+import { gql } from 'apollo-server';
+import { cypher } from '../../../src/index';
+
+export const testSchema = gql`
+  type User {
+    idField: ID! @id
+    name: String
+    names: [String]
+    birthday: DateTime
+    liked: [Movie!] @relation(name: "RATING", direction: OUT)
+    uniqueString: String @unique
+    createdAt: DateTime
+    modifiedAt: DateTime
+  }
+
+  type Movie {
+    id: ID! @id
+    title: String! @unique
+    likedBy: [User!] @relation(name: "RATING", direction: IN)
+    custom: String
+  }
+
+  type Query {
+    User: [User!]
+    Movie: [Movie!]
+  }
+
+  type Mutation {
+    CreateUser(idField: ID, name: String, names: [String], birthday: DateTime, uniqueString: String, liked: UserLiked, sideEffects: OnUserCreate): User
+    MergeUser(idField: ID!, name: String, names: [String], birthday: DateTime, uniqueString: String, liked: UserLiked, sideEffects: OnUserMerge): User
+    DeleteUser(idField: ID!, liked: UserLiked): User
+    Custom(id: ID!, sideEffects: CustomSideEffects, computed: CustomComputed): Custom @cypher(${cypher`
+      MERGE (custom: Custom {
+        id: $id
+      })
+      RETURN custom
+    `})
+  }
+
+  type Custom {
+    id: ID! @id
+    computed: Int
+    nested: [Custom] @relation(name: "RELATED", direction: OUT)
+  }
+
+  input CustomData {
+    id: ID!
+    nested: CustomSideEffects
+  }
+
+  input CustomComputed {
+    computed: ComputeComputed
+  }
+
+  input CustomComputedInput {
+    value: Int!
+  }
+
+  input ComputeComputed {
+    multiply: CustomComputedInput @cypher(${cypher`
+      SET custom.computed = CustomComputedInput.value * 10
+    `})
+  }
+
+  input CustomSideEffects {
+    create: [CustomData] @cypher(${cypher`
+      MERGE (custom)-[:RELATED]->(subCustom: Custom {
+        id: CustomData.id
+      })
+      WITH subCustom AS custom
+    `})
+  }
+
+  input UserWhere {
+    idField: ID
+  }
+
+  input UserCreate {
+    idField: ID
+    name: String
+    names: [String]
+    birthday: DateTime
+    uniqueString: String
+    liked: UserLiked
+  }
+
+  input OnUserCreate {
+    createdAt: CreatedAt @cypher(${cypher`
+      SET user.createdAt = datetime(CreatedAt.datetime)
+    `})
+  }
+
+  input OnUserMerge {
+    mergedAt: CreatedAt @cypher(${cypher`
+      SET user.modifiedAt = datetime(CreatedAt.datetime)
+    `})
+  }
+
+  input CreatedAt {
+    datetime: DateTime!
+  }
+
+  input UserMerge {
+    where: UserWhere
+    data: UserCreate
+  }
+
+  input UserLiked {
+    create: [MovieCreate!] @cypher(${cypher`
+      CREATE (user)-[:RATING]->(movie: Movie {
+        id: MovieCreate.id,
+        title: MovieCreate.title
+      })
+      WITH movie
+    `})
+    nestedCreate: [MovieCreate!] @cypher(${cypher`
+      CREATE (user)-[:RATING]->(movie: Movie {
+        id: MovieCreate.customLayer.movie.id,
+        title: MovieCreate.customLayer.movie.title,
+        custom: MovieCreate.customLayer.custom
+      })
+      WITH movie
+    `})
+    merge: [MovieMerge!] @cypher(${cypher`
+      MERGE (movie: Movie {
+        id: MovieMerge.where.id
+      })
+      ON CREATE
+        SET movie.title = MovieMerge.data.title
+      MERGE (user)-[:RATING]->(movie)
+      WITH movie
+    `})
+    delete: [MovieWhere!] @cypher(${cypher`
+      MATCH (user)-[:RATING]->(movie: Movie { id: MovieWhere.id })
+      DETACH DELETE movie
+    `})    
+  }
+
+  input MovieMerge {
+    where: MovieWhere
+    data: MovieCreate
+  }
+
+  input MovieWhere {
+    id: ID!
+  }
+
+  input MovieCreate {
+    id: ID
+    title: String
+    likedBy: MovieLikedBy
+    customLayer: MovieCreateParamLayer
+  }
+
+  input MovieCreateParamLayer {
+    custom: String
+    movie: MovieCreate
+  }
+
+  input MovieLikedBy {
+    create: [UserCreate!] @cypher(${cypher`
+      CREATE (movie)<-[:RATING]-(user:User {
+        name: UserCreate.name,
+        uniqueString: UserCreate.uniqueString
+      })
+    `})
+    merge: [UserMerge!] @cypher(${cypher`
+      MERGE (user: User {
+        idField: UserMerge.where.idField
+      })
+      ON CREATE 
+        SET user.name = UserMerge.data.name, 
+            user.uniqueString = UserMerge.data.uniqueString
+      MERGE (movie)<-[:RATING]-(user)
+    `})
+  }
+
+  enum Role {
+    reader
+    user
+    admin
+  }
+`;

--- a/test/helpers/experimental/augmentSchemaTest.js
+++ b/test/helpers/experimental/augmentSchemaTest.js
@@ -8,7 +8,7 @@ import {
   augmentTypeDefs
 } from '../../../src/index';
 import { printSchemaDocument } from '../../../src/augment/augment';
-import { testSchema } from '../../helpers/experimental/testSchema';
+import { testSchema } from './testSchema';
 
 // Optimization to prevent schema augmentation from running for every test
 const cypherTestTypeDefs = printSchemaDocument({
@@ -192,10 +192,6 @@ export function augmentedSchemaCypherTestRunner(
     resolvers,
     resolverValidationOptions: {
       requireResolversForResolveType: false
-    },
-    config: {
-      auth: true,
-      experimental: true
     }
   });
 

--- a/test/helpers/experimental/custom/customSchemaTest.js
+++ b/test/helpers/experimental/custom/customSchemaTest.js
@@ -1,0 +1,127 @@
+import { graphql } from 'graphql';
+import { makeExecutableSchema } from 'graphql-tools';
+import _ from 'lodash';
+import {
+  cypherQuery,
+  cypherMutation,
+  makeAugmentedSchema,
+  augmentTypeDefs
+} from '../../../../src/index';
+import { printSchemaDocument } from '../../../../src/augment/augment';
+import { testSchema } from './testSchema';
+
+export function cypherTestRunner(
+  t,
+  graphqlQuery,
+  graphqlParams,
+  expectedCypherQuery,
+  expectedCypherParams
+) {
+  const checkCypherQuery = (object, params, ctx, resolveInfo) => {
+    const [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
+    t.is(query, expectedCypherQuery);
+    const deserializedParams = JSON.parse(JSON.stringify(queryParams));
+    t.deepEqual(deserializedParams, expectedCypherParams);
+  };
+
+  const checkCypherMutation = (object, params, ctx, resolveInfo) => {
+    const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
+    t.is(query, expectedCypherQuery);
+    const deserializedParams = JSON.parse(JSON.stringify(queryParams));
+    t.deepEqual(deserializedParams, expectedCypherParams);
+  };
+
+  const resolvers = {
+    Mutation: {
+      CreateUser: checkCypherMutation,
+      DeleteUser: checkCypherMutation,
+      MergeUser: checkCypherMutation,
+      Custom: checkCypherMutation
+    }
+  };
+  let augmentedTypeDefs = augmentTypeDefs(testSchema, {
+    auth: true,
+    experimental: true
+  });
+  const schema = makeExecutableSchema({
+    typeDefs: augmentedTypeDefs,
+    resolvers,
+    resolverValidationOptions: {
+      requireResolversForResolveType: false
+    }
+  });
+
+  // query the test schema with the test query, assertion is in the resolver
+  return graphql(
+    schema,
+    graphqlQuery,
+    null,
+    {
+      cypherParams: {
+        userId: 'user-id'
+      }
+    },
+    graphqlParams
+  );
+}
+
+export function augmentedSchemaCypherTestRunner(
+  t,
+  graphqlQuery,
+  graphqlParams,
+  expectedCypherQuery,
+  expectedCypherParams
+) {
+  const checkCypherQuery = (object, params, ctx, resolveInfo) => {
+    const [query, queryParams] = cypherQuery(params, ctx, resolveInfo);
+    t.is(query, expectedCypherQuery);
+    const deserializedParams = JSON.parse(JSON.stringify(queryParams));
+    t.deepEqual(deserializedParams, expectedCypherParams);
+  };
+  const checkCypherMutation = (object, params, ctx, resolveInfo) => {
+    const [query, queryParams] = cypherMutation(params, ctx, resolveInfo);
+    t.is(query, expectedCypherQuery);
+    const deserializedParams = JSON.parse(JSON.stringify(queryParams));
+    t.deepEqual(deserializedParams, expectedCypherParams);
+  };
+
+  const resolvers = {
+    Mutation: {
+      CreateUser: checkCypherMutation,
+      DeleteUser: checkCypherMutation,
+      MergeUser: checkCypherMutation,
+      Custom: checkCypherMutation
+    }
+  };
+
+  const cypherTestTypeDefs = printSchemaDocument({
+    schema: makeAugmentedSchema({
+      typeDefs: testSchema,
+      resolvers: {},
+      config: {
+        auth: true,
+        experimental: true
+      }
+    })
+  });
+
+  const augmentedSchema = makeExecutableSchema({
+    typeDefs: cypherTestTypeDefs,
+    resolvers,
+    resolverValidationOptions: {
+      requireResolversForResolveType: false
+    }
+  });
+
+  return graphql(
+    augmentedSchema,
+    graphqlQuery,
+    null,
+    {
+      cypherParams: {
+        userId: 'user-id'
+      }
+    },
+    graphqlParams
+  );
+}

--- a/test/helpers/experimental/custom/testSchema.js
+++ b/test/helpers/experimental/custom/testSchema.js
@@ -1,0 +1,189 @@
+import { gql } from 'apollo-server';
+import { cypher } from '../../../../src/index';
+
+export const testSchema = gql`
+  type User {
+    idField: ID! @id
+    name: String
+    names: [String]
+    birthday: DateTime
+    liked: [Movie!] @relation(name: "RATING", direction: OUT)
+    uniqueString: String @unique
+    createdAt: DateTime
+    modifiedAt: DateTime
+    int: Int
+  }
+
+  type Movie {
+    id: ID! @id
+    title: String! @unique
+    likedBy: [User!] @relation(name: "RATING", direction: IN)
+    custom: String
+  }
+
+  type Query {
+    User: [User!]
+    Movie: [Movie!]
+  }
+
+  type Mutation {
+    CreateUser(data: UserCreate!): User
+    MergeUser(where: UserWhere!, data: UserCreate!): User
+    DeleteUser(where: UserWhere!, liked: UserLiked): User
+    Custom(id: ID!, sideEffects: CustomSideEffects, computed: CustomComputed): Custom @cypher(${cypher`
+      MERGE (custom: Custom {
+        id: $id
+      })
+      RETURN custom
+    `})
+  }
+
+  type Custom {
+    id: ID! @id
+    computed: Int
+    nested: [Custom] @relation(name: "RELATED", direction: OUT)
+  }
+
+  input CustomData {
+    id: ID!
+    nested: CustomSideEffects
+  }
+
+  input CustomComputed {
+    computed: ComputeComputed
+  }
+
+  input CustomComputedInput {
+    value: Int!
+  }
+
+  input ComputeComputed {
+    multiply: CustomComputedInput @cypher(${cypher`
+      SET custom.computed = CustomComputedInput.value * 10
+    `})
+  }
+
+  input CustomSideEffects {
+    create: [CustomData] @cypher(${cypher`
+      MERGE (custom)-[:RELATED]->(subCustom: Custom {
+        id: CustomData.id
+      })
+      WITH subCustom AS custom
+    `})
+  }
+
+  input UserWhere {
+    idField: ID
+  }
+
+  input UserCreate {
+    idField: ID
+    name: String
+    names: [String]
+    birthday: DateTime
+    uniqueString: String
+    liked: UserLiked
+    onUserCreate: OnUserCreate
+    onUserMerge: OnUserMerge
+  }
+
+  input OnUserCreate {
+    nested: OnUserCreate
+    int: Int
+    createdAt: CreatedAt @cypher(${cypher`
+      SET user.int = $data.onUserCreate.int
+      SET user.createdAt = datetime(CreatedAt.datetime)
+    `})
+  }
+
+  input OnUserMerge {
+    mergedAt: CreatedAt @cypher(${cypher`
+      SET user.modifiedAt = datetime(CreatedAt.datetime)
+    `})
+  }
+
+  input CreatedAt {
+    datetime: DateTime!
+  }
+
+  input UserMerge {
+    where: UserWhere
+    data: UserCreate
+  }
+
+  input UserLiked { 
+    create: [MovieCreate!] @cypher(${cypher`
+      CREATE (user)-[:RATING]->(movie: Movie {
+        id: MovieCreate.id,
+        title: MovieCreate.title
+      })
+      WITH movie
+    `})
+    nestedCreate: [MovieCreate!] @cypher(${cypher`
+      CREATE (user)-[:RATING]->(movie: Movie {
+        id: MovieCreate.customLayer.data.id,
+        title: MovieCreate.customLayer.data.title,
+        custom: MovieCreate.customLayer.custom
+      })
+      WITH movie
+    `})
+    merge: [MovieMerge!] @cypher(${cypher`
+      MERGE (movie: Movie {
+        id: MovieMerge.where.id
+      })
+      ON CREATE
+        SET movie.title = MovieMerge.data.title
+      MERGE (user)-[:RATING]->(movie)
+      WITH movie
+    `})
+    delete: [MovieWhere!] @cypher(${cypher`
+      MATCH (user)-[:RATING]->(movie: Movie { id: MovieWhere.id })
+      DETACH DELETE movie
+    `})
+  }
+
+  input MovieMerge {
+    where: MovieWhere
+    data: MovieCreate
+  }
+
+  input MovieWhere {
+    id: ID!
+  }
+
+  input MovieCreate {
+    id: ID
+    title: String
+    likedBy: MovieLikedBy
+    customLayer: MovieCreateParamLayer
+  }
+
+  input MovieCreateParamLayer {
+    custom: String
+    data: MovieCreate
+  }
+
+  input MovieLikedBy {
+    create: [UserCreate!] @cypher(${cypher`
+      CREATE (movie)<-[:RATING]-(user:User {
+        name: UserCreate.name,
+        uniqueString: UserCreate.uniqueString
+      })
+    `})
+    merge: [UserMerge!] @cypher(${cypher`
+      MERGE (user: User {
+        idField: UserMerge.where.idField
+      })
+      ON CREATE 
+        SET user.name = UserMerge.data.name, 
+            user.uniqueString = UserMerge.data.uniqueString
+      MERGE (movie)<-[:RATING]-(user)
+    `})
+  }
+
+  enum Role {
+    reader
+    user
+    admin
+  }
+`;

--- a/test/helpers/testSchema.js
+++ b/test/helpers/testSchema.js
@@ -6,7 +6,7 @@ export const testSchema = `
   block
   description
   """
-  directive @cypher(statement: String) on FIELD_DEFINITION
+  directive @cypher(statement: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
   "Object type line description"
   type Movie

--- a/test/unit/augmentSchemaTest.test.js
+++ b/test/unit/augmentSchemaTest.test.js
@@ -6001,7 +6001,9 @@ test.cb('Test augmented schema', t => {
     block
     description
     """
-    directive @cypher(statement: String) on FIELD_DEFINITION
+    directive @cypher(
+      statement: String
+    ) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
     directive @relation(
       name: String

--- a/test/unit/custom/cypherTest.test.js
+++ b/test/unit/custom/cypherTest.test.js
@@ -1,0 +1,742 @@
+import test from 'ava';
+import {
+  cypherTestRunner,
+  augmentedSchemaCypherTestRunner
+} from '../../helpers/custom/customSchemaTest';
+
+const CYPHER_PARAMS = {
+  userId: 'user-id'
+};
+
+test('Create node mutation with nested @cypher', t => {
+  const graphQLQuery = `mutation {
+    CreateUser(
+      idField: "user-1"
+      liked: {
+        create: [
+          {
+            id: "movie-1"
+            title: "title-1"
+          }
+          {
+            id: "movie-2"
+            title: "title-2"
+          }
+          {
+            id: "movie-3"
+            title: "title-4"
+          }
+          {
+            id: "movie-4"
+            title: "title-4"
+          }
+        ]
+      }
+    ) {
+      idField
+      liked {
+        id
+        title
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `
+    CREATE (\`user\`:\`User\` {idField:$params.idField})
+  WITH *
+  
+CALL {
+  WITH *
+  UNWIND $params.liked.create AS MovieCreate
+  CREATE (user)-[:RATING]->(movie: Movie {
+  id: MovieCreate.id,
+  title: MovieCreate.title
+})
+WITH movie
+  RETURN COUNT(*) AS _liked_create_
+}
+    RETURN \`user\` { .idField ,liked: [(\`user\`)-[:\`RATING\`]->(\`user_liked\`:\`Movie\`) | \`user_liked\` { .id , .title }] } AS \`user\`
+  `,
+    expectedParams = {
+      params: {
+        idField: 'user-1',
+        liked: {
+          create: [
+            {
+              id: 'movie-1',
+              title: 'title-1'
+            },
+            {
+              id: 'movie-2',
+              title: 'title-2'
+            },
+            {
+              id: 'movie-3',
+              title: 'title-4'
+            },
+            {
+              id: 'movie-4',
+              title: 'title-4'
+            }
+          ]
+        }
+      },
+      first: -1,
+      offset: 0
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Create node mutation with nested @cypher, skipping 1 non-@mutation input object', t => {
+  const graphQLQuery = `mutation {
+    CreateUser(
+      idField: "user-1"
+      liked: {
+        nestedCreate: [
+          {
+            customLayer: {
+              custom: "custom-1"
+              movie: {
+                id: "movie-1"
+                title: "title-1"
+              }
+            }
+          }
+          {
+            customLayer: {
+              custom: "custom-2"
+              movie: {
+                id: "movie-2"
+                title: "title-2"
+              }
+            }
+          }
+          {
+            customLayer: {
+              custom: "custom-3"
+              movie: {
+                id: "movie-3"
+                title: "title-3"
+              }
+            }
+          }
+          {
+            customLayer: {
+              custom: "custom-4"
+              movie: {
+                id: "movie-4"
+                title: "title-4"
+              }
+            }
+          }
+        ]
+      }
+    ) {
+      idField
+      liked {
+        id
+        title
+        custom
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `
+    CREATE (\`user\`:\`User\` {idField:$params.idField})
+  WITH *
+  
+CALL {
+  WITH *
+  UNWIND $params.liked.nestedCreate AS MovieCreate
+  CREATE (user)-[:RATING]->(movie: Movie {
+  id: MovieCreate.customLayer.movie.id,
+  title: MovieCreate.customLayer.movie.title,
+  custom: MovieCreate.customLayer.custom
+})
+WITH movie
+  RETURN COUNT(*) AS _liked_nestedCreate_
+}
+    RETURN \`user\` { .idField ,liked: [(\`user\`)-[:\`RATING\`]->(\`user_liked\`:\`Movie\`) | \`user_liked\` { .id , .title , .custom }] } AS \`user\`
+  `,
+    expectedParams = {
+      params: {
+        idField: 'user-1',
+        liked: {
+          nestedCreate: [
+            {
+              customLayer: {
+                custom: 'custom-1',
+                movie: {
+                  id: 'movie-1',
+                  title: 'title-1'
+                }
+              }
+            },
+            {
+              customLayer: {
+                custom: 'custom-2',
+                movie: {
+                  id: 'movie-2',
+                  title: 'title-2'
+                }
+              }
+            },
+            {
+              customLayer: {
+                custom: 'custom-3',
+                movie: {
+                  id: 'movie-3',
+                  title: 'title-3'
+                }
+              }
+            },
+            {
+              customLayer: {
+                custom: 'custom-4',
+                movie: {
+                  id: 'movie-4',
+                  title: 'title-4'
+                }
+              }
+            }
+          ]
+        }
+      },
+      first: -1,
+      offset: 0
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Delete node mutation with @cypher deleting related node', t => {
+  const graphQLQuery = `mutation {
+    DeleteUser(
+      idField: "a"
+      liked: {
+        delete: {
+          id: "movie-1"
+        }
+      }
+    ) {
+      idField
+      liked {
+        id
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`user\`:\`User\` {idField: $idField})
+
+CALL {
+  WITH *
+  UNWIND $liked.delete AS MovieWhere
+  MATCH (user)-[:RATING]->(movie: Movie { id: MovieWhere.id })
+DETACH DELETE movie
+  RETURN COUNT(*) AS _liked_delete_
+}
+WITH \`user\` AS \`user_toDelete\`, \`user\` { .idField ,liked: [(\`user\`)-[:\`RATING\`]->(\`user_liked\`:\`Movie\`) | \`user_liked\` { .id }] } AS \`user\`
+DETACH DELETE \`user_toDelete\`
+RETURN \`user\``,
+    expectedParams = {
+      idField: 'a',
+      liked: {
+        delete: [
+          {
+            id: 'movie-1'
+          }
+        ]
+      },
+      first: -1,
+      offset: 0
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Create node mutation with multiple nested @cypher', t => {
+  const graphQLQuery = `mutation {
+    CreateUser(
+      idField: "a"
+      name: "Ada"
+      uniqueString: "b"
+      birthday: { year: 2020, month: 11, day: 10 }
+      names: ["A", "B"]
+      liked: {
+        create: [
+          {
+            id: "movie-1"
+            title: "title-1"
+            likedBy: {
+              create: [
+                { name: "Alan", uniqueString: "x" }
+                { name: "Ada", uniqueString: "y" }
+              ]
+            }
+          }
+          {
+            id: "movie-2"
+            title: "title-2"
+            likedBy: {
+              create: [
+                { name: "Alan", uniqueString: "a" }
+                { name: "Ada", uniqueString: "b" }
+              ]
+            }
+          }
+        ]
+      }
+      sideEffects: {
+        createdAt: { datetime: { year: 2020, month: 11, day: 13 } }
+      }
+    ) {
+      idField
+      uniqueString
+      liked {
+        id
+        title
+        likedBy {
+          name
+          uniqueString
+        }
+      }
+      createdAt {
+        formatted
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `
+    CREATE (\`user\`:\`User\` {idField:$params.idField,name:$params.name,names:$params.names,birthday: datetime($params.birthday),uniqueString:$params.uniqueString})
+  WITH *
+  
+CALL {
+  WITH *
+  UNWIND $params.liked.create AS MovieCreate
+  CREATE (user)-[:RATING]->(movie: Movie {   id: MovieCreate.id,   title: MovieCreate.title }) 
+WITH MovieCreate AS _MovieCreate,  movie
+CALL {
+  WITH *
+  UNWIND _MovieCreate.likedBy.create AS UserCreate
+  CREATE (movie)<-[:RATING]-(user:User {
+  name: UserCreate.name,
+  uniqueString: UserCreate.uniqueString
+})
+  RETURN COUNT(*) AS _likedBy_create_
+}
+  RETURN COUNT(*) AS _liked_create_
+}
+
+CALL {
+  WITH *
+  UNWIND $params.sideEffects.createdAt AS CreatedAt
+  SET user.createdAt = datetime(CreatedAt.datetime)
+  RETURN COUNT(*) AS _sideEffects_createdAt_
+}
+    RETURN \`user\` { .idField , .uniqueString ,liked: [(\`user\`)-[:\`RATING\`]->(\`user_liked\`:\`Movie\`) | \`user_liked\` { .id , .title ,likedBy: [(\`user_liked\`)<-[:\`RATING\`]-(\`user_liked_likedBy\`:\`User\`) | \`user_liked_likedBy\` { .name , .uniqueString }] }] ,createdAt: { formatted: toString(\`user\`.createdAt) }} AS \`user\`
+  `,
+    expectedParams = {
+      params: {
+        idField: 'a',
+        name: 'Ada',
+        names: ['A', 'B'],
+        birthday: {
+          year: {
+            low: 2020,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 10,
+            high: 0
+          }
+        },
+        uniqueString: 'b',
+        liked: {
+          create: [
+            {
+              id: 'movie-1',
+              title: 'title-1',
+              likedBy: {
+                create: [
+                  {
+                    name: 'Alan',
+                    uniqueString: 'x'
+                  },
+                  {
+                    name: 'Ada',
+                    uniqueString: 'y'
+                  }
+                ]
+              }
+            },
+            {
+              id: 'movie-2',
+              title: 'title-2',
+              likedBy: {
+                create: [
+                  {
+                    name: 'Alan',
+                    uniqueString: 'a'
+                  },
+                  {
+                    name: 'Ada',
+                    uniqueString: 'b'
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        sideEffects: {
+          createdAt: {
+            datetime: {
+              year: {
+                low: 2020,
+                high: 0
+              },
+              month: {
+                low: 11,
+                high: 0
+              },
+              day: {
+                low: 13,
+                high: 0
+              }
+            }
+          }
+        }
+      },
+      first: -1,
+      offset: 0
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Merge node mutation with multiple nested @cypher', t => {
+  const graphQLQuery = `mutation {
+    MergeUser(
+      idField: "a"
+      name: "Ada"
+      uniqueString: "b"
+      birthday: { year: 2020, month: 11, day: 10 }
+      names: ["A", "B"]
+      liked: {
+        create: [
+          {
+            id: "movie-1"
+            title: "title-1"
+            likedBy: {
+              create: [
+                { name: "Alan", uniqueString: "x" }
+                { name: "Ada", uniqueString: "y" }
+              ]
+            }
+          }
+          {
+            id: "movie-2"
+            title: "title-2"
+            likedBy: {
+              create: [
+                { name: "Alan", uniqueString: "a" }
+                { name: "Ada", uniqueString: "b" }
+              ]
+            }
+          }
+        ]
+      }
+      sideEffects: {
+        mergedAt: { datetime: { year: 2020, month: 11, day: 13 } }
+      }
+    ) {
+      idField
+      uniqueString
+      liked {
+        id
+        title
+        likedBy {
+          name
+          uniqueString
+        }
+      }
+      createdAt {
+        formatted
+      }
+    }
+  }  
+  `,
+    expectedCypherQuery = `MERGE (\`user\`:\`User\`{idField: $params.idField})
+  SET \`user\` += {name:$params.name,names:$params.names,birthday: datetime($params.birthday),uniqueString:$params.uniqueString} 
+  WITH *
+  
+CALL {
+  WITH *
+  UNWIND $params.liked.create AS MovieCreate
+  CREATE (user)-[:RATING]->(movie: Movie {   id: MovieCreate.id,   title: MovieCreate.title }) 
+WITH MovieCreate AS _MovieCreate,  movie
+CALL {
+  WITH *
+  UNWIND _MovieCreate.likedBy.create AS UserCreate
+  CREATE (movie)<-[:RATING]-(user:User {
+  name: UserCreate.name,
+  uniqueString: UserCreate.uniqueString
+})
+  RETURN COUNT(*) AS _likedBy_create_
+}
+  RETURN COUNT(*) AS _liked_create_
+}
+
+CALL {
+  WITH *
+  UNWIND $params.sideEffects.mergedAt AS CreatedAt
+  SET user.modifiedAt = datetime(CreatedAt.datetime)
+  RETURN COUNT(*) AS _sideEffects_mergedAt_
+}RETURN \`user\` { .idField , .uniqueString ,liked: [(\`user\`)-[:\`RATING\`]->(\`user_liked\`:\`Movie\`) | \`user_liked\` { .id , .title ,likedBy: [(\`user_liked\`)<-[:\`RATING\`]-(\`user_liked_likedBy\`:\`User\`) | \`user_liked_likedBy\` { .name , .uniqueString }] }] ,createdAt: { formatted: toString(\`user\`.createdAt) }} AS \`user\``,
+    expectedParams = {
+      params: {
+        idField: 'a',
+        name: 'Ada',
+        names: ['A', 'B'],
+        birthday: {
+          year: {
+            low: 2020,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 10,
+            high: 0
+          }
+        },
+        uniqueString: 'b',
+        liked: {
+          create: [
+            {
+              id: 'movie-1',
+              title: 'title-1',
+              likedBy: {
+                create: [
+                  {
+                    name: 'Alan',
+                    uniqueString: 'x'
+                  },
+                  {
+                    name: 'Ada',
+                    uniqueString: 'y'
+                  }
+                ]
+              }
+            },
+            {
+              id: 'movie-2',
+              title: 'title-2',
+              likedBy: {
+                create: [
+                  {
+                    name: 'Alan',
+                    uniqueString: 'a'
+                  },
+                  {
+                    name: 'Ada',
+                    uniqueString: 'b'
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        sideEffects: {
+          mergedAt: {
+            datetime: {
+              year: {
+                low: 2020,
+                high: 0
+              },
+              month: {
+                low: 11,
+                high: 0
+              },
+              day: {
+                low: 13,
+                high: 0
+              }
+            }
+          }
+        }
+      },
+      first: -1,
+      offset: 0
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Custom @cypher mutation with multiple nested @cypher (experimental api)', t => {
+  const graphQLQuery = `mutation {
+    Custom(
+      id: "a"
+      sideEffects: {
+        create: [
+          { id: "b", nested: { create: [{ id: "d" }, { id: "e" }] } }
+          { id: "c", nested: { create: [{ id: "f" }, { id: "g" }] } }
+        ]
+      }
+      computed: {
+        computed: {
+          multiply: {
+            value: 5
+          }
+        }
+      }
+    ) {
+      id
+      computed
+      nested {
+        id
+        nested {
+          id
+        }
+      }
+    }
+  }  
+  `,
+    expectedCypherQuery = `CALL apoc.cypher.doIt("MERGE (custom: Custom {
+  id: $id
+})
+RETURN custom", {id:$id, sideEffects:$sideEffects, computed:$computed, first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
+    WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`custom\`
+CALL {
+  WITH *
+  UNWIND $sideEffects.create AS CustomData
+  MERGE (custom)-[:RELATED]->(subCustom: Custom {   id: CustomData.id }) 
+WITH CustomData AS _CustomData,  subCustom AS custom
+CALL {
+  WITH *
+  UNWIND _CustomData.nested.create AS CustomData
+  MERGE (custom)-[:RELATED]->(subCustom: Custom {
+  id: CustomData.id
+})
+WITH subCustom AS custom
+  RETURN COUNT(*) AS _nested_create_
+}
+  RETURN COUNT(*) AS _sideEffects_create_
+}
+
+CALL {
+  WITH *
+  UNWIND $computed.computed.multiply AS CustomComputedInput
+  SET custom.computed = CustomComputedInput.value * 10
+  RETURN COUNT(*) AS _computed_multiply_
+}
+    RETURN \`custom\` { .id , .computed ,nested: [(\`custom\`)-[:\`RELATED\`]->(\`custom_nested\`:\`Custom\`) | \`custom_nested\` { .id ,nested: [(\`custom_nested\`)-[:\`RELATED\`]->(\`custom_nested_nested\`:\`Custom\`) | \`custom_nested_nested\` { .id }] }] } AS \`custom\``,
+    expectedParams = {
+      id: 'a',
+      sideEffects: {
+        create: [
+          {
+            id: 'b',
+            nested: {
+              create: [
+                {
+                  id: 'd'
+                },
+                {
+                  id: 'e'
+                }
+              ]
+            }
+          },
+          {
+            id: 'c',
+            nested: {
+              create: [
+                {
+                  id: 'f'
+                },
+                {
+                  id: 'g'
+                }
+              ]
+            }
+          }
+        ]
+      },
+      computed: {
+        computed: {
+          multiply: {
+            value: {
+              low: 5,
+              high: 0
+            }
+          }
+        }
+      },
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});

--- a/test/unit/experimental/augmentSchemaTest.test.js
+++ b/test/unit/experimental/augmentSchemaTest.test.js
@@ -700,7 +700,9 @@ test.cb('Test augmented schema', t => {
       OUT
     }
 
-    directive @cypher(statement: String) on FIELD_DEFINITION
+    directive @cypher(
+      statement: String
+    ) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
     directive @relation(
       name: String

--- a/test/unit/experimental/custom/cypherTest.test.js
+++ b/test/unit/experimental/custom/cypherTest.test.js
@@ -1,0 +1,1628 @@
+import test from 'ava';
+import {
+  cypherTestRunner,
+  augmentedSchemaCypherTestRunner
+} from '../../../helpers/experimental/custom/customSchemaTest';
+
+const CYPHER_PARAMS = {
+  userId: 'user-id'
+};
+
+test('Create node mutation with nested @cypher input 2 levels deep (experimental api)', t => {
+  const graphQLQuery = `mutation {
+    CreateUser(
+      data: {
+        idField: "a"
+        name: "Ada"
+        uniqueString: "b"
+        birthday: {
+          year: 2020
+          month: 11
+          day: 10
+        }
+        names: ["A", "B"]
+        liked: {
+          create: [
+            {
+              id: "movie-1"
+              title: "title-1"
+              likedBy: {
+                create: [
+                  { name: "Alan", uniqueString: "x" }
+                  { name: "Ada", uniqueString: "y" }
+                ]
+              }
+            }
+            {
+              id: "movie-2"
+              title: "title-2"
+              likedBy: {
+                create: [
+                  { name: "Alan", uniqueString: "a" }
+                  { name: "Ada", uniqueString: "b" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ) {
+      idField
+      uniqueString
+      liked {
+        id
+        title
+        likedBy {
+          name
+          uniqueString
+        }
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `
+    CREATE (\`user\`:\`User\` {idField:$data.idField,name:$data.name,names:$data.names,birthday: datetime($data.birthday),uniqueString:$data.uniqueString})
+  WITH *
+  
+CALL {
+  WITH *
+  UNWIND $data.liked.create AS MovieCreate
+  CREATE (user)-[:RATING]->(movie: Movie {   id: MovieCreate.id,   title: MovieCreate.title }) 
+WITH MovieCreate AS _MovieCreate,  movie
+CALL {
+  WITH *
+  UNWIND _MovieCreate.likedBy.create AS UserCreate
+  CREATE (movie)<-[:RATING]-(user:User {
+  name: UserCreate.name,
+  uniqueString: UserCreate.uniqueString
+})
+  RETURN COUNT(*) AS _likedBy_create_
+}
+  RETURN COUNT(*) AS _liked_create_
+}
+    RETURN \`user\` { .idField , .uniqueString ,liked: [(\`user\`)-[:\`RATING\`]->(\`user_liked\`:\`Movie\`) | \`user_liked\` { .id , .title ,likedBy: [(\`user_liked\`)<-[:\`RATING\`]-(\`user_liked_likedBy\`:\`User\`) | \`user_liked_likedBy\` { .name , .uniqueString }] }] } AS \`user\`
+  `,
+    expectedParams = {
+      first: -1,
+      offset: 0,
+      data: {
+        idField: 'a',
+        name: 'Ada',
+        names: ['A', 'B'],
+        birthday: {
+          year: {
+            low: 2020,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 10,
+            high: 0
+          }
+        },
+        uniqueString: 'b',
+        liked: {
+          create: [
+            {
+              id: 'movie-1',
+              title: 'title-1',
+              likedBy: {
+                create: [
+                  {
+                    name: 'Alan',
+                    uniqueString: 'x'
+                  },
+                  {
+                    name: 'Ada',
+                    uniqueString: 'y'
+                  }
+                ]
+              }
+            },
+            {
+              id: 'movie-2',
+              title: 'title-2',
+              likedBy: {
+                create: [
+                  {
+                    name: 'Alan',
+                    uniqueString: 'a'
+                  },
+                  {
+                    name: 'Ada',
+                    uniqueString: 'b'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Create node with nested @cypher input 2 levels down through same input type (experimental api)', t => {
+  const graphQLQuery = `mutation {
+    CreateUser(
+      data: {
+        idField: "a"
+        name: "Ada"
+        uniqueString: "b"
+        birthday: { year: 2020, month: 11, day: 10 }
+        names: ["A", "B"]
+        onUserCreate: {
+          int: 5
+          nested: { createdAt: { datetime: { year: 2020, month: 11, day: 14 } } }
+        }
+      }
+    ) {
+      idField
+      name
+      uniqueString
+      birthday {
+        formatted
+      }
+      names
+      int
+      createdAt {
+        formatted
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `
+    CREATE (\`user\`:\`User\` {idField:$data.idField,name:$data.name,names:$data.names,birthday: datetime($data.birthday),uniqueString:$data.uniqueString})
+  WITH *
+  
+CALL {
+  WITH *
+  UNWIND $data.onUserCreate.nested.createdAt AS CreatedAt
+  SET user.int = $data.onUserCreate.int
+SET user.createdAt = datetime(CreatedAt.datetime)
+  RETURN COUNT(*) AS _nested_createdAt_
+}
+    RETURN \`user\` { .idField , .name , .uniqueString ,birthday: { formatted: toString(\`user\`.birthday) }, .names , .int ,createdAt: { formatted: toString(\`user\`.createdAt) }} AS \`user\`
+  `,
+    expectedParams = {
+      first: -1,
+      offset: 0,
+      data: {
+        idField: 'a',
+        name: 'Ada',
+        names: ['A', 'B'],
+        birthday: {
+          year: {
+            low: 2020,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 10,
+            high: 0
+          }
+        },
+        uniqueString: 'b',
+        onUserCreate: {
+          nested: {
+            createdAt: {
+              datetime: {
+                year: {
+                  low: 2020,
+                  high: 0
+                },
+                month: {
+                  low: 11,
+                  high: 0
+                },
+                day: {
+                  low: 14,
+                  high: 0
+                }
+              }
+            }
+          },
+          int: {
+            low: 5,
+            high: 0
+          }
+        }
+      }
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Merge node with @cypher nested 2 levels deep, skipping 1 non-@mutation input object (experimental api)', t => {
+  const graphQLQuery = `mutation {
+    MergeUser(
+      where: {
+        idField: "a"
+      }
+      data: {
+        name: "Ada"
+        uniqueString: "b"
+        birthday: {
+          year: 2020
+          month: 11
+          day: 10
+        }
+        names: ["A", "B"]
+        liked: {
+          merge: [
+            {
+              where: {
+                id: "movie-1"
+              }
+              data: {
+                title: "title-1"
+                likedBy: {
+                  create: [
+                    { name: "Alan", uniqueString: "x" }
+                    { name: "Ada", uniqueString: "y" }
+                  ]
+                }
+              }
+            }
+            {
+              where: {
+                id: "movie-2"
+              }
+              data: {
+                title: "title-2"
+                likedBy: {
+                  create: [
+                    { name: "Alan", uniqueString: "a" }
+                    { name: "Ada", uniqueString: "b" }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    ) {
+      idField
+      uniqueString
+      liked {
+        id
+        title
+        likedBy {
+          name
+          uniqueString
+        }
+      }
+    }
+  }  
+  `,
+    expectedCypherQuery = `MERGE (\`user\`:\`User\`{idField:$where.idField})
+ON CREATE
+  SET \`user\` += {name:$data.name,names:$data.names,birthday: datetime($data.birthday),uniqueString:$data.uniqueString}
+ON MATCH
+  SET \`user\` += {name:$data.name,names:$data.names,birthday: datetime($data.birthday),uniqueString:$data.uniqueString} 
+  WITH *
+  
+CALL {
+  WITH *
+  UNWIND $data.liked.merge AS MovieMerge
+  MERGE (movie: Movie {   id: MovieMerge.where.id }) ON CREATE   SET movie.title = MovieMerge.data.title MERGE (user)-[:RATING]->(movie) 
+WITH MovieMerge AS _MovieMerge,  movie
+CALL {
+  WITH *
+  UNWIND _MovieMerge.data.likedBy.create AS UserCreate
+  CREATE (movie)<-[:RATING]-(user:User {
+  name: UserCreate.name,
+  uniqueString: UserCreate.uniqueString
+})
+  RETURN COUNT(*) AS _likedBy_create_
+}
+  RETURN COUNT(*) AS _liked_merge_
+}RETURN \`user\` { .idField , .uniqueString ,liked: [(\`user\`)-[:\`RATING\`]->(\`user_liked\`:\`Movie\`) | \`user_liked\` { .id , .title ,likedBy: [(\`user_liked\`)<-[:\`RATING\`]-(\`user_liked_likedBy\`:\`User\`) | \`user_liked_likedBy\` { .name , .uniqueString }] }] } AS \`user\``,
+    expectedParams = {
+      where: {
+        idField: 'a'
+      },
+      data: {
+        name: 'Ada',
+        names: ['A', 'B'],
+        birthday: {
+          year: {
+            low: 2020,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 10,
+            high: 0
+          }
+        },
+        uniqueString: 'b',
+        liked: {
+          merge: [
+            {
+              where: {
+                id: 'movie-1'
+              },
+              data: {
+                title: 'title-1',
+                likedBy: {
+                  create: [
+                    {
+                      name: 'Alan',
+                      uniqueString: 'x'
+                    },
+                    {
+                      name: 'Ada',
+                      uniqueString: 'y'
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              where: {
+                id: 'movie-2'
+              },
+              data: {
+                title: 'title-2',
+                likedBy: {
+                  create: [
+                    {
+                      name: 'Alan',
+                      uniqueString: 'a'
+                    },
+                    {
+                      name: 'Ada',
+                      uniqueString: 'b'
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Merge node mutation with complex @cypher nested 2 levels deep, skipping 1 non-@mutation input object (experimental api)', t => {
+  const graphQLQuery = `mutation {
+    MergeUser(
+      where: {
+        idField: "a"
+      }
+      data: {
+        name: "Ada"
+        uniqueString: "b"
+        birthday: {
+          year: 2020
+          month: 11
+          day: 10
+        }
+        names: ["A", "B"]
+        liked: {
+          merge: [
+            {
+              where: {
+                id: "movie-1"
+              }
+              data: {
+                title: "title-1"
+                likedBy: {
+                  merge: [
+                    { 
+                      where: {
+                        idField: "b"
+                      }
+                      data: {
+                        name: "Alan"
+                        uniqueString: "x"
+                      }
+                    }
+                    { 
+                      where: {
+                        idField: "c"
+                      }
+                      data: {
+                        name: "Ada"
+                        uniqueString: "y"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+            {
+              where: {
+                id: "movie-2"
+              }
+              data: {
+                title: "title-2"
+                likedBy: {
+                  merge: [
+                    { 
+                      where: {
+                        idField: "b"
+                      }
+                      data: {
+                        name: "Alan"
+                        uniqueString: "x"
+                      }
+                    }
+                    { 
+                      where: {
+                        idField: "c"
+                      }
+                      data: {
+                        name: "Ada"
+                        uniqueString: "y"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    ) {
+      idField
+      uniqueString
+      liked {
+        id
+        title
+        likedBy {
+          name
+          uniqueString
+        }
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `MERGE (\`user\`:\`User\`{idField:$where.idField})
+ON CREATE
+  SET \`user\` += {name:$data.name,names:$data.names,birthday: datetime($data.birthday),uniqueString:$data.uniqueString}
+ON MATCH
+  SET \`user\` += {name:$data.name,names:$data.names,birthday: datetime($data.birthday),uniqueString:$data.uniqueString} 
+  WITH *
+  
+CALL {
+  WITH *
+  UNWIND $data.liked.merge AS MovieMerge
+  MERGE (movie: Movie {   id: MovieMerge.where.id }) ON CREATE   SET movie.title = MovieMerge.data.title MERGE (user)-[:RATING]->(movie) 
+WITH MovieMerge AS _MovieMerge,  movie
+CALL {
+  WITH *
+  UNWIND _MovieMerge.data.likedBy.merge AS UserMerge
+  MERGE (user: User {
+  idField: UserMerge.where.idField
+})
+ON CREATE 
+  SET user.name = UserMerge.data.name, 
+      user.uniqueString = UserMerge.data.uniqueString
+MERGE (movie)<-[:RATING]-(user)
+  RETURN COUNT(*) AS _likedBy_merge_
+}
+  RETURN COUNT(*) AS _liked_merge_
+}RETURN \`user\` { .idField , .uniqueString ,liked: [(\`user\`)-[:\`RATING\`]->(\`user_liked\`:\`Movie\`) | \`user_liked\` { .id , .title ,likedBy: [(\`user_liked\`)<-[:\`RATING\`]-(\`user_liked_likedBy\`:\`User\`) | \`user_liked_likedBy\` { .name , .uniqueString }] }] } AS \`user\``,
+    expectedParams = {
+      where: {
+        idField: 'a'
+      },
+      data: {
+        name: 'Ada',
+        names: ['A', 'B'],
+        birthday: {
+          year: {
+            low: 2020,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 10,
+            high: 0
+          }
+        },
+        uniqueString: 'b',
+        liked: {
+          merge: [
+            {
+              where: {
+                id: 'movie-1'
+              },
+              data: {
+                title: 'title-1',
+                likedBy: {
+                  merge: [
+                    {
+                      where: {
+                        idField: 'b'
+                      },
+                      data: {
+                        name: 'Alan',
+                        uniqueString: 'x'
+                      }
+                    },
+                    {
+                      where: {
+                        idField: 'c'
+                      },
+                      data: {
+                        name: 'Ada',
+                        uniqueString: 'y'
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              where: {
+                id: 'movie-2'
+              },
+              data: {
+                title: 'title-2',
+                likedBy: {
+                  merge: [
+                    {
+                      where: {
+                        idField: 'b'
+                      },
+                      data: {
+                        name: 'Alan',
+                        uniqueString: 'x'
+                      }
+                    },
+                    {
+                      where: {
+                        idField: 'c'
+                      },
+                      data: {
+                        name: 'Ada',
+                        uniqueString: 'y'
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Merge node mutation with @cypher nested 3 levels deep, skipping 2 non-@mutation input objects (experimental api)', t => {
+  const graphQLQuery = `mutation {
+    CreateUser(
+      data: {
+        idField: "a"
+        name: "Ada"
+        uniqueString: "b"
+        birthday: { year: 2020, month: 11, day: 10 }
+        names: ["A", "B"]
+        liked: {
+          nestedCreate: [
+            {
+              customLayer: {
+                custom: "custom-1"
+                data: {
+                  id: "movie-1"
+                  title: "title-1"
+                  likedBy: {
+                    create: [
+                      { name: "Alan", uniqueString: "x" }
+                      { name: "Ada", uniqueString: "y" }
+                    ]
+                  }
+                }
+              }
+            }
+            {
+              customLayer: {
+                custom: "custom-2"
+                data: {
+                  id: "movie-2"
+                  title: "title-2"
+                  likedBy: {
+                    create: [
+                      { name: "Alan", uniqueString: "a" }
+                      { name: "Ada", uniqueString: "b" }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    ) {
+      idField
+      uniqueString
+      liked {
+        id
+        title
+        custom
+        likedBy {
+          name
+          uniqueString
+        }
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `
+    CREATE (\`user\`:\`User\` {idField:$data.idField,name:$data.name,names:$data.names,birthday: datetime($data.birthday),uniqueString:$data.uniqueString})
+  WITH *
+  
+CALL {
+  WITH *
+  UNWIND $data.liked.nestedCreate AS MovieCreate
+  CREATE (user)-[:RATING]->(movie: Movie {   id: MovieCreate.customLayer.data.id,   title: MovieCreate.customLayer.data.title,   custom: MovieCreate.customLayer.custom }) 
+WITH MovieCreate AS _MovieCreate,  movie
+CALL {
+  WITH *
+  UNWIND _MovieCreate.customLayer.data.likedBy.create AS UserCreate
+  CREATE (movie)<-[:RATING]-(user:User {
+  name: UserCreate.name,
+  uniqueString: UserCreate.uniqueString
+})
+  RETURN COUNT(*) AS _likedBy_create_
+}
+  RETURN COUNT(*) AS _liked_nestedCreate_
+}
+    RETURN \`user\` { .idField , .uniqueString ,liked: [(\`user\`)-[:\`RATING\`]->(\`user_liked\`:\`Movie\`) | \`user_liked\` { .id , .title , .custom ,likedBy: [(\`user_liked\`)<-[:\`RATING\`]-(\`user_liked_likedBy\`:\`User\`) | \`user_liked_likedBy\` { .name , .uniqueString }] }] } AS \`user\`
+  `,
+    expectedParams = {
+      first: -1,
+      offset: 0,
+      data: {
+        idField: 'a',
+        name: 'Ada',
+        names: ['A', 'B'],
+        birthday: {
+          year: {
+            low: 2020,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 10,
+            high: 0
+          }
+        },
+        uniqueString: 'b',
+        liked: {
+          nestedCreate: [
+            {
+              customLayer: {
+                custom: 'custom-1',
+                data: {
+                  id: 'movie-1',
+                  title: 'title-1',
+                  likedBy: {
+                    create: [
+                      {
+                        name: 'Alan',
+                        uniqueString: 'x'
+                      },
+                      {
+                        name: 'Ada',
+                        uniqueString: 'y'
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              customLayer: {
+                custom: 'custom-2',
+                data: {
+                  id: 'movie-2',
+                  title: 'title-2',
+                  likedBy: {
+                    create: [
+                      {
+                        name: 'Alan',
+                        uniqueString: 'a'
+                      },
+                      {
+                        name: 'Ada',
+                        uniqueString: 'b'
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Delete node mutation with @cypher deleting related node (experimental api)', t => {
+  const graphQLQuery = `mutation {
+    DeleteUser(
+      where: {
+        idField: "a",
+      }
+      liked: {
+        delete: {
+          id: "movie-1"
+        }
+      }
+    ) {
+      idField
+    }
+  }
+  `,
+    expectedCypherQuery = `MATCH (\`user\`:\`User\`) WHERE (\`user\`.idField = $where.idField) 
+
+CALL {
+  WITH *
+  UNWIND $liked.delete AS MovieWhere
+  MATCH (user)-[:RATING]->(movie: Movie { id: MovieWhere.id })
+DETACH DELETE movie
+  RETURN COUNT(*) AS _liked_delete_
+}
+WITH \`user\` AS \`user_toDelete\`, \`user\` { .idField } AS \`user\`
+DETACH DELETE \`user_toDelete\`
+RETURN \`user\``,
+    expectedParams = {
+      where: {
+        idField: 'a'
+      },
+      liked: {
+        delete: [
+          {
+            id: 'movie-1'
+          }
+        ]
+      },
+      first: -1,
+      offset: 0
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Sequence of custom nested @cypher (experimental api)', t => {
+  const graphQLQuery = `mutation {
+    MergeUser(
+      where: {
+        idField: "a"
+      }
+      data: {
+        name: "Ada"
+        uniqueString: "b"
+        birthday: {
+          year: 2020
+          month: 11
+          day: 10
+        }
+        names: ["A", "B"]
+        liked: {
+          merge: [
+            {
+              where: {
+                id: "movie-1"
+              }
+              data: {
+                title: "title-1"
+                likedBy: {
+                  merge: [
+                    { 
+                      where: {
+                        idField: "b"
+                      }
+                      data: {
+                        name: "Alan"
+                        uniqueString: "x"
+                      }
+                    }
+                    { 
+                      where: {
+                        idField: "c"
+                      }
+                      data: {
+                        name: "Ada"
+                        uniqueString: "y"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+            {
+              where: {
+                id: "movie-2"
+              }
+              data: {
+                title: "title-2"
+                likedBy: {
+                  merge: [
+                    { 
+                      where: {
+                        idField: "b"
+                      }
+                      data: {
+                        name: "Alan"
+                        uniqueString: "x"
+                      }
+                    }
+                    { 
+                      where: {
+                        idField: "c"
+                      }
+                      data: {
+                        name: "Ada"
+                        uniqueString: "y"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+          create: [
+            {
+              id: "movie-1"
+              title: "title-1"
+              likedBy: {
+                create: [
+                  { name: "Alan", uniqueString: "x" }
+                  { name: "Ada", uniqueString: "y" }
+                ]
+              }
+            }
+            {
+              id: "movie-2"
+              title: "title-2"
+              likedBy: {
+                create: [
+                  { name: "Alan", uniqueString: "a" }
+                  { name: "Ada", uniqueString: "b" }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ) {
+      idField
+      uniqueString
+      liked {
+        id
+        title
+        likedBy {
+          name
+          uniqueString
+        }
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `MERGE (\`user\`:\`User\`{idField:$where.idField})
+ON CREATE
+  SET \`user\` += {name:$data.name,names:$data.names,birthday: datetime($data.birthday),uniqueString:$data.uniqueString}
+ON MATCH
+  SET \`user\` += {name:$data.name,names:$data.names,birthday: datetime($data.birthday),uniqueString:$data.uniqueString} 
+  WITH *
+  
+CALL {
+  WITH *
+  UNWIND $data.liked.create AS MovieCreate
+  CREATE (user)-[:RATING]->(movie: Movie {   id: MovieCreate.id,   title: MovieCreate.title }) 
+WITH MovieCreate AS _MovieCreate,  movie
+CALL {
+  WITH *
+  UNWIND _MovieCreate.likedBy.create AS UserCreate
+  CREATE (movie)<-[:RATING]-(user:User {
+  name: UserCreate.name,
+  uniqueString: UserCreate.uniqueString
+})
+  RETURN COUNT(*) AS _likedBy_create_
+}
+  RETURN COUNT(*) AS _liked_create_
+}
+
+CALL {
+  WITH *
+  UNWIND $data.liked.merge AS MovieMerge
+  MERGE (movie: Movie {   id: MovieMerge.where.id }) ON CREATE   SET movie.title = MovieMerge.data.title MERGE (user)-[:RATING]->(movie) 
+WITH MovieMerge AS _MovieMerge,  movie
+CALL {
+  WITH *
+  UNWIND _MovieMerge.data.likedBy.merge AS UserMerge
+  MERGE (user: User {
+  idField: UserMerge.where.idField
+})
+ON CREATE 
+  SET user.name = UserMerge.data.name, 
+      user.uniqueString = UserMerge.data.uniqueString
+MERGE (movie)<-[:RATING]-(user)
+  RETURN COUNT(*) AS _likedBy_merge_
+}
+  RETURN COUNT(*) AS _liked_merge_
+}RETURN \`user\` { .idField , .uniqueString ,liked: [(\`user\`)-[:\`RATING\`]->(\`user_liked\`:\`Movie\`) | \`user_liked\` { .id , .title ,likedBy: [(\`user_liked\`)<-[:\`RATING\`]-(\`user_liked_likedBy\`:\`User\`) | \`user_liked_likedBy\` { .name , .uniqueString }] }] } AS \`user\``,
+    expectedParams = {
+      where: {
+        idField: 'a'
+      },
+      data: {
+        name: 'Ada',
+        names: ['A', 'B'],
+        birthday: {
+          year: {
+            low: 2020,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 10,
+            high: 0
+          }
+        },
+        uniqueString: 'b',
+        liked: {
+          create: [
+            {
+              id: 'movie-1',
+              title: 'title-1',
+              likedBy: {
+                create: [
+                  {
+                    name: 'Alan',
+                    uniqueString: 'x'
+                  },
+                  {
+                    name: 'Ada',
+                    uniqueString: 'y'
+                  }
+                ]
+              }
+            },
+            {
+              id: 'movie-2',
+              title: 'title-2',
+              likedBy: {
+                create: [
+                  {
+                    name: 'Alan',
+                    uniqueString: 'a'
+                  },
+                  {
+                    name: 'Ada',
+                    uniqueString: 'b'
+                  }
+                ]
+              }
+            }
+          ],
+          merge: [
+            {
+              where: {
+                id: 'movie-1'
+              },
+              data: {
+                title: 'title-1',
+                likedBy: {
+                  merge: [
+                    {
+                      where: {
+                        idField: 'b'
+                      },
+                      data: {
+                        name: 'Alan',
+                        uniqueString: 'x'
+                      }
+                    },
+                    {
+                      where: {
+                        idField: 'c'
+                      },
+                      data: {
+                        name: 'Ada',
+                        uniqueString: 'y'
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              where: {
+                id: 'movie-2'
+              },
+              data: {
+                title: 'title-2',
+                likedBy: {
+                  merge: [
+                    {
+                      where: {
+                        idField: 'b'
+                      },
+                      data: {
+                        name: 'Alan',
+                        uniqueString: 'x'
+                      }
+                    },
+                    {
+                      where: {
+                        idField: 'c'
+                      },
+                      data: {
+                        name: 'Ada',
+                        uniqueString: 'y'
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Create node with multiple nested @cypher (experimental api)', t => {
+  const graphQLQuery = `mutation {
+    CreateUser(
+      data: {
+        idField: "a"
+        name: "Ada"
+        uniqueString: "b"
+        birthday: { year: 2020, month: 11, day: 10 }
+        names: ["A", "B"]
+        liked: {
+          create: [
+            {
+              id: "movie-1"
+              title: "title-1"
+              likedBy: {
+                create: [
+                  { name: "Alan", uniqueString: "x" }
+                  { name: "Ada", uniqueString: "y" }
+                ]
+              }
+            }
+            {
+              id: "movie-2"
+              title: "title-2"
+              likedBy: {
+                create: [
+                  { name: "Alan", uniqueString: "a" }
+                  { name: "Ada", uniqueString: "b" }
+                ]
+              }
+            }
+          ]
+        }
+        onUserCreate: {
+          createdAt: { datetime: { year: 2020, month: 11, day: 13 } }
+        }
+      }
+    ) {
+      idField
+      uniqueString
+      liked {
+        id
+        title
+        likedBy {
+          name
+          uniqueString
+        }
+      }
+      createdAt {
+        formatted
+      }
+    }
+  }  
+  `,
+    expectedCypherQuery = `
+    CREATE (\`user\`:\`User\` {idField:$data.idField,name:$data.name,names:$data.names,birthday: datetime($data.birthday),uniqueString:$data.uniqueString})
+  WITH *
+  
+CALL {
+  WITH *
+  UNWIND $data.liked.create AS MovieCreate
+  CREATE (user)-[:RATING]->(movie: Movie {   id: MovieCreate.id,   title: MovieCreate.title }) 
+WITH MovieCreate AS _MovieCreate,  movie
+CALL {
+  WITH *
+  UNWIND _MovieCreate.likedBy.create AS UserCreate
+  CREATE (movie)<-[:RATING]-(user:User {
+  name: UserCreate.name,
+  uniqueString: UserCreate.uniqueString
+})
+  RETURN COUNT(*) AS _likedBy_create_
+}
+  RETURN COUNT(*) AS _liked_create_
+}
+
+CALL {
+  WITH *
+  UNWIND $data.onUserCreate.createdAt AS CreatedAt
+  SET user.int = $data.onUserCreate.int
+SET user.createdAt = datetime(CreatedAt.datetime)
+  RETURN COUNT(*) AS _onUserCreate_createdAt_
+}
+    RETURN \`user\` { .idField , .uniqueString ,liked: [(\`user\`)-[:\`RATING\`]->(\`user_liked\`:\`Movie\`) | \`user_liked\` { .id , .title ,likedBy: [(\`user_liked\`)<-[:\`RATING\`]-(\`user_liked_likedBy\`:\`User\`) | \`user_liked_likedBy\` { .name , .uniqueString }] }] ,createdAt: { formatted: toString(\`user\`.createdAt) }} AS \`user\`
+  `,
+    expectedParams = {
+      first: -1,
+      offset: 0,
+      data: {
+        idField: 'a',
+        name: 'Ada',
+        names: ['A', 'B'],
+        birthday: {
+          year: {
+            low: 2020,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 10,
+            high: 0
+          }
+        },
+        uniqueString: 'b',
+        liked: {
+          create: [
+            {
+              id: 'movie-1',
+              title: 'title-1',
+              likedBy: {
+                create: [
+                  {
+                    name: 'Alan',
+                    uniqueString: 'x'
+                  },
+                  {
+                    name: 'Ada',
+                    uniqueString: 'y'
+                  }
+                ]
+              }
+            },
+            {
+              id: 'movie-2',
+              title: 'title-2',
+              likedBy: {
+                create: [
+                  {
+                    name: 'Alan',
+                    uniqueString: 'a'
+                  },
+                  {
+                    name: 'Ada',
+                    uniqueString: 'b'
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        onUserCreate: {
+          createdAt: {
+            datetime: {
+              year: {
+                low: 2020,
+                high: 0
+              },
+              month: {
+                low: 11,
+                high: 0
+              },
+              day: {
+                low: 13,
+                high: 0
+              }
+            }
+          }
+        }
+      }
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Merge node with multiple nested @cypher (experimental api)', t => {
+  const graphQLQuery = `mutation {
+    MergeUser(
+      where: {
+        idField: "a"
+      }
+      data: {
+        name: "Ada"
+        uniqueString: "b"
+        birthday: { year: 2020, month: 11, day: 10 }
+        names: ["A", "B"]
+        liked: {
+          create: [
+            {
+              id: "movie-1"
+              title: "title-1"
+              likedBy: {
+                create: [
+                  { name: "Alan", uniqueString: "x" }
+                  { name: "Ada", uniqueString: "y" }
+                ]
+              }
+            }
+            {
+              id: "movie-2"
+              title: "title-2"
+              likedBy: {
+                create: [
+                  { name: "Alan", uniqueString: "a" }
+                  { name: "Ada", uniqueString: "b" }
+                ]
+              }
+            }
+          ]
+        }
+        onUserMerge: {
+          mergedAt: { datetime: { year: 2020, month: 11, day: 13 } }
+        }
+      }
+    ) {
+      idField
+      uniqueString
+      liked {
+        id
+        title
+        likedBy {
+          name
+          uniqueString
+        }
+      }
+      createdAt {
+        formatted
+      }
+    }
+  }
+  `,
+    expectedCypherQuery = `MERGE (\`user\`:\`User\`{idField:$where.idField})
+ON CREATE
+  SET \`user\` += {name:$data.name,names:$data.names,birthday: datetime($data.birthday),uniqueString:$data.uniqueString}
+ON MATCH
+  SET \`user\` += {name:$data.name,names:$data.names,birthday: datetime($data.birthday),uniqueString:$data.uniqueString} 
+  WITH *
+  
+CALL {
+  WITH *
+  UNWIND $data.liked.create AS MovieCreate
+  CREATE (user)-[:RATING]->(movie: Movie {   id: MovieCreate.id,   title: MovieCreate.title }) 
+WITH MovieCreate AS _MovieCreate,  movie
+CALL {
+  WITH *
+  UNWIND _MovieCreate.likedBy.create AS UserCreate
+  CREATE (movie)<-[:RATING]-(user:User {
+  name: UserCreate.name,
+  uniqueString: UserCreate.uniqueString
+})
+  RETURN COUNT(*) AS _likedBy_create_
+}
+  RETURN COUNT(*) AS _liked_create_
+}
+
+CALL {
+  WITH *
+  UNWIND $data.onUserMerge.mergedAt AS CreatedAt
+  SET user.modifiedAt = datetime(CreatedAt.datetime)
+  RETURN COUNT(*) AS _onUserMerge_mergedAt_
+}RETURN \`user\` { .idField , .uniqueString ,liked: [(\`user\`)-[:\`RATING\`]->(\`user_liked\`:\`Movie\`) | \`user_liked\` { .id , .title ,likedBy: [(\`user_liked\`)<-[:\`RATING\`]-(\`user_liked_likedBy\`:\`User\`) | \`user_liked_likedBy\` { .name , .uniqueString }] }] ,createdAt: { formatted: toString(\`user\`.createdAt) }} AS \`user\``,
+    expectedParams = {
+      where: {
+        idField: 'a'
+      },
+      data: {
+        name: 'Ada',
+        names: ['A', 'B'],
+        birthday: {
+          year: {
+            low: 2020,
+            high: 0
+          },
+          month: {
+            low: 11,
+            high: 0
+          },
+          day: {
+            low: 10,
+            high: 0
+          }
+        },
+        uniqueString: 'b',
+        liked: {
+          create: [
+            {
+              id: 'movie-1',
+              title: 'title-1',
+              likedBy: {
+                create: [
+                  {
+                    name: 'Alan',
+                    uniqueString: 'x'
+                  },
+                  {
+                    name: 'Ada',
+                    uniqueString: 'y'
+                  }
+                ]
+              }
+            },
+            {
+              id: 'movie-2',
+              title: 'title-2',
+              likedBy: {
+                create: [
+                  {
+                    name: 'Alan',
+                    uniqueString: 'a'
+                  },
+                  {
+                    name: 'Ada',
+                    uniqueString: 'b'
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        onUserMerge: {
+          mergedAt: {
+            datetime: {
+              year: {
+                low: 2020,
+                high: 0
+              },
+              month: {
+                low: 11,
+                high: 0
+              },
+              day: {
+                low: 13,
+                high: 0
+              }
+            }
+          }
+        }
+      }
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});
+
+test('Custom @cypher mutation with multiple nested @cypher (experimental api)', t => {
+  const graphQLQuery = `mutation {
+    Custom(
+      id: "a"
+      sideEffects: {
+        create: [
+          { id: "b", nested: { create: [{ id: "d" }, { id: "e" }] } }
+          { id: "c", nested: { create: [{ id: "f" }, { id: "g" }] } }
+        ]
+      }
+      computed: {
+        computed: {
+          multiply: {
+            value: 5
+          }
+        }
+      }
+    ) {
+      id
+      computed
+      nested {
+        id
+        nested {
+          id
+        }
+      }
+    }
+  }  
+  `,
+    expectedCypherQuery = `CALL apoc.cypher.doIt("MERGE (custom: Custom {
+  id: $id
+})
+RETURN custom", {id:$id, sideEffects:$sideEffects, computed:$computed, first:$first, offset:$offset, cypherParams: $cypherParams}) YIELD value
+    WITH apoc.map.values(value, [keys(value)[0]])[0] AS \`custom\`
+CALL {
+  WITH *
+  UNWIND $sideEffects.create AS CustomData
+  MERGE (custom)-[:RELATED]->(subCustom: Custom {   id: CustomData.id }) 
+WITH CustomData AS _CustomData,  subCustom AS custom
+CALL {
+  WITH *
+  UNWIND _CustomData.nested.create AS CustomData
+  MERGE (custom)-[:RELATED]->(subCustom: Custom {
+  id: CustomData.id
+})
+WITH subCustom AS custom
+  RETURN COUNT(*) AS _nested_create_
+}
+  RETURN COUNT(*) AS _sideEffects_create_
+}
+
+CALL {
+  WITH *
+  UNWIND $computed.computed.multiply AS CustomComputedInput
+  SET custom.computed = CustomComputedInput.value * 10
+  RETURN COUNT(*) AS _computed_multiply_
+}
+    RETURN \`custom\` { .id , .computed ,nested: [(\`custom\`)-[:\`RELATED\`]->(\`custom_nested\`:\`Custom\`) | \`custom_nested\` { .id ,nested: [(\`custom_nested\`)-[:\`RELATED\`]->(\`custom_nested_nested\`:\`Custom\`) | \`custom_nested_nested\` { .id }] }] } AS \`custom\``,
+    expectedParams = {
+      id: 'a',
+      sideEffects: {
+        create: [
+          {
+            id: 'b',
+            nested: {
+              create: [
+                {
+                  id: 'd'
+                },
+                {
+                  id: 'e'
+                }
+              ]
+            }
+          },
+          {
+            id: 'c',
+            nested: {
+              create: [
+                {
+                  id: 'f'
+                },
+                {
+                  id: 'g'
+                }
+              ]
+            }
+          }
+        ]
+      },
+      computed: {
+        computed: {
+          multiply: {
+            value: {
+              low: 5,
+              high: 0
+            }
+          }
+        }
+      },
+      first: -1,
+      offset: 0,
+      cypherParams: CYPHER_PARAMS
+    };
+  t.plan(4);
+  return Promise.all([
+    cypherTestRunner(t, graphQLQuery, {}, expectedCypherQuery, expectedParams),
+    augmentedSchemaCypherTestRunner(
+      t,
+      graphQLQuery,
+      {},
+      expectedCypherQuery,
+      expectedParams
+    )
+  ]);
+});


### PR DESCRIPTION
This PR adds support for using the `@cypher` directive on INPUT_FIELD_DEFINITION, allowing for custom nested mutations that are translated using Cypher [correlated subqueries](https://neo4j.com/docs/cypher-manual/current/clauses/call-subquery/), available in Neo4j version 4.1.

Initial documentation: https://deploy-preview-60--distracted-golick-08ed24.netlify.app/docs/guide-graphql-schema-design#custom-nested-mutations

#### Node Mutation API Tests
Schema: https://github.com/michaeldgraham/neo4j-graphql-js/blob/master/test/helpers/custom/testSchema.js

Tests: https://github.com/michaeldgraham/neo4j-graphql-js/blob/master/test/unit/custom/cypherTest.test.js

##### Experimental API
As of PR #531, when `config.experimental = true`, the arguments for generated node mutations have an input object format. Nested `@cypher` input fields also work for this more recent schema design option: 

Schema: https://github.com/michaeldgraham/neo4j-graphql-js/blob/master/test/helpers/experimental/custom/testSchema.js

Tests: https://github.com/michaeldgraham/neo4j-graphql-js/blob/master/test/unit/experimental/custom/cypherTest.test.js

This PR seems relevant to #89, #331, #532, and #539.

The #532 feature request will be updated to include designs for follow-up enhancements to the augmentation process based on this PR.
