### PR TITLE
Fix Syntax error in generated query when using interfaces

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -956,12 +956,12 @@ export const removeIgnoredFields = (schemaType, selections) => {
 };
 
 export const getInterfaceDerivedTypeNames = (schema, interfaceName) => {
-  const implementingTypeMap = schema._implementations
-    ? schema._implementations[interfaceName]
+  const implementingTypeMap = schema._implementationsMap
+    ? schema._implementationsMap[interfaceName]
     : {};
   let implementingTypes = [];
-  if (implementingTypeMap) {
-    implementingTypes = Object.values(implementingTypeMap).map(
+  if (implementingTypeMap && implementingTypeMap.objects) {
+    implementingTypes = Object.values(implementingTypeMap.objects).map(
       type => type.name
     );
   }


### PR DESCRIPTION
Fixes `getInterfaceDerivedTypeNames` function, this solves the syntax error in the cypher query when selecting interfaces or interface fragments.

Let me know if you need more information, I would be happy if this could be resolved quickly because we need this feature in production

closes #527 