### PR TITLE
Make session in assertSchema configurable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -318,11 +318,12 @@ export const assertSchema = ({
   driver,
   schema,
   dropExisting = true,
-  debug = false
+  debug = false,
+  sessionParams = {}
 }) => {
   const statement = schemaAssert({ schema, dropExisting });
   const executeQuery = driver => {
-    const session = driver.session();
+    const session = driver.session(sessionParams);
     return session
       .writeTransaction(tx =>
         tx.run(statement).then(result => {


### PR DESCRIPTION
Similar to https://github.com/neo4j-graphql/neo4j-graphql-js/pull/577, this change is needed so that one can target a specific database in projects with multiple active Neo4j databases. 

With the change, a user could call the function like this:
```js
assertSchema(driver, schema, sessionParams: { database: 'foo' })
```